### PR TITLE
Add `lerna changelog`

### DIFF
--- a/lib/commands/changelog.js
+++ b/lib/commands/changelog.js
@@ -1,0 +1,197 @@
+var child       = require("child_process");
+var progressBar = require("../progress-bar");
+
+var org  = process.env.GITHUB_ORG;
+var repo = process.env.GITHUB_REPO;
+
+var tags = [
+  "tag: breaking change",
+  "tag: spec compliancy",
+  "tag: new feature",
+  "tag: bug fix",
+  "tag: documentation",
+  "tag: internal",
+  "tag: polish"
+];
+
+exports.description = "Creates a basic changelog categorized by designated github labels";
+
+function getLastTag() {
+  return execSync("git describe --abbrev=0 --tags");
+}
+
+exports.githubAPIrequest = function (url) {
+  return execSync("curl -H 'Authorization: token " + process.env.GITHUB_AUTH + "' --silent " + url);
+}
+
+exports.getIssueData = function(issue) {
+  var url  = "https://api.github.com/repos/" + org + "/" + repo + "/issues/" + issue;
+
+  return exports.githubAPIrequest(url);
+}
+
+exports.getListOfCommits = function (config) {
+  var lastTag = getLastTag(config);
+  // console.log("Last tag: ", lastTag);
+
+  var commits = execSync("git log --first-parent --oneline " + lastTag + "..").split("\n");
+  return commits;
+}
+
+exports.getCommitInfo = function(commits) {
+  var tick = progressBar(commits.length);
+
+  var logs = commits.map(function(commit) {
+
+    var sha = commit.slice(0,7);
+    var message = commit.slice(8);
+    var response;
+    tick(sha);
+
+    if (message.indexOf("Merge pull request ") === 0) {
+      var start = message.indexOf("#") + 1;
+      var end = message.slice(start).indexOf(" ");
+      var issueNumber = message.slice(start, start + end);
+
+      response = JSON.parse(exports.getIssueData(issueNumber));
+      response.commitSHA = sha;
+      response.mergeMessage = message;
+      return response;
+    }
+
+    return {
+      commitSHA: sha,
+      message: message,
+      labels: []
+    };
+  });
+
+  return logs;
+}
+
+exports.getCommitsByCategory = function(logs) {
+  var categories = tags.map(function(tag) {
+    var commits = [];
+
+    logs.forEach(function(log) {
+      var labels = log.labels.map(function(label) {
+        return label.name;
+      });
+
+      if (labels.indexOf(tag.toLowerCase()) >= 0) {
+        commits.push(log);
+      }
+    });
+
+    return {
+      tag: tag,
+      commits: commits
+    };
+  });
+
+  return categories;
+};
+
+function toTitleCase(str) {
+    return str.replace(/\w\S*/g, function(text){
+      return text.charAt(0).toUpperCase() + text.substr(1).toLowerCase();
+    });
+}
+
+function normalizeTag(tag) {
+  return toTitleCase(tag.slice(5));
+}
+
+exports.createMarkdown = function(commitsByCategory) {
+  var date = new Date().toISOString();
+  date = date.slice(0, date.indexOf("T"));
+
+  var markdown = "\n";
+
+  markdown += "## Unreleased (" + date + ")";
+
+  var tick = progressBar(commitsByCategory.length);
+
+  commitsByCategory.filter(function(category) {
+    return category.commits.length > 0;
+  }).forEach(function(category) {
+    tick(category.tag);
+
+    markdown += "\n";
+    markdown += "\n";
+    markdown += "* **" + normalizeTag(category.tag) + "**";
+
+    category.commits.forEach(function(commit) {
+      markdown += "\n";
+
+      var changedPackages =
+      execSync("git log -m --name-only --pretty='format:' " + commit.commitSHA)
+      // not sure why it's including extra files
+      .split("\n\n")[0]
+      // turn into an array
+      .split("\n")
+      // remove files that aren't in packages/
+      .filter(function(files) {
+        return files.indexOf("packages/") >= 0;
+      })
+      // extract base package name
+      .map(function(files) {
+        files = files.slice(9);
+        return files.slice(0, files.indexOf("/"));
+      })
+      // unique packages
+      .filter(function(value, index, self) {
+        return self.indexOf(value) === index;
+      });
+
+      var spaces = 2;
+
+      if (changedPackages.length > 0) {
+        markdown += repeat(" ", spaces) + "* ";
+
+        changedPackages.forEach(function(package, i) {
+          markdown += (i === 0 ? "" : ",") + "`" + package + "`";
+        });
+
+        markdown += "\n";
+
+        // indent more?
+        // spaces = 4;
+      }
+
+      if (commit.number) {
+        var prUrl = "https://github.com/" + org + "/" + repo + "/pull/" + commit.number;
+        markdown += repeat(" ", spaces) + "* ";
+        markdown += "[#" + commit.number + "](" + prUrl + ")";
+      }
+
+      markdown += " " + commit.title + "." + " ([@" + commit.user.login + "](" + commit.user.html_url + "))";
+    });
+  });
+
+  return markdown;
+}
+
+function repeat(str, times) {
+  return Array(times + 1).join(str);
+}
+
+exports.execute = function (config) {
+  var commits = exports.getListOfCommits(config);
+  // console.log(commits);
+
+  var commitInfo = exports.getCommitInfo(commits);
+  // console.log(commitInfo);
+
+  var commitsByCategory = exports.getCommitsByCategory(commitInfo);
+  // console.log(commitsByCategory);
+
+  var changelog = exports.createMarkdown(commitsByCategory);
+  console.log(changelog);
+};
+
+function execSync(cmd) {
+  return child.execSync(cmd, {
+    encoding: "utf8"
+  }).trim();
+}

--- a/lib/commands/changelog.js
+++ b/lib/commands/changelog.js
@@ -1,6 +1,12 @@
-var progressBar = require("../../utils/progressBar");
-var execSync    = require("../../utils/execSync");
+var progressBar = require("../progress-bar");
 var chalk       = require("chalk");
+var child       = require("child_process");
+
+function execSync(cmd) {
+  return child.execSync(cmd, {
+    encoding: "utf8"
+  }).trim();
+}
 
 var org  = process.env.GITHUB_ORG;
 var repo = process.env.GITHUB_REPO;
@@ -56,11 +62,19 @@ function getCommitInfo(commits) {
     var response;
     tick(sha);
 
+    var mergeCommit = message.match(/\(#\d{4}\)$/);
+
     if (message.indexOf("Merge pull request ") === 0) {
       var start = message.indexOf("#") + 1;
       var end = message.slice(start).indexOf(" ");
       var issueNumber = message.slice(start, start + end);
 
+      response = JSON.parse(getIssueData(issueNumber));
+      response.commitSHA = sha;
+      response.mergeMessage = message;
+      return response;
+    } else if (mergeCommit) {
+      var issueNumber = mergeCommit[0].slice(2, 6);
       response = JSON.parse(getIssueData(issueNumber));
       response.commitSHA = sha;
       response.mergeMessage = message;
@@ -134,6 +148,8 @@ function createMarkdown(commitsByCategory) {
     category.commits.forEach(function(commit) {
       markdown += "\n";
 
+      console.log(commit);
+
       var changedPackages =
       execSync("git log -m --name-only --pretty='format:' " + commit.commitSHA)
       // not sure why it's including extra files
@@ -155,6 +171,8 @@ function createMarkdown(commitsByCategory) {
       });
 
       var spaces = 0;
+
+      console.log(changedPackages);
 
       if (changedPackages.length > 0) {
         markdown += repeat(" ", spaces) + "* ";
@@ -191,7 +209,10 @@ function repeat(str, times) {
   return Array(times + 1).join(str);
 }
 
-module.exports = function changelog(config) {
+exports.description = "Create a changelog";
+
+
+exports.execute = function (config) {
   if (!process.env.GITHUB_AUTH) {
     console.log(chalk.red("Must provide GITHUB_AUTH"));
     process.exit(1);
@@ -199,6 +220,9 @@ module.exports = function changelog(config) {
 
   var commits = getListOfCommits(config);
   var commitInfo = getCommitInfo(commits);
+
+  console.log(commitInfo);
+
   var committers = getCommiters(commitInfo);
   var commitsByCategory = getCommitsByCategory(commitInfo);
   var changelog = createMarkdown(commitsByCategory);

--- a/lib/commands/changelog/index.js
+++ b/lib/commands/changelog/index.js
@@ -1,5 +1,5 @@
-var child       = require("child_process");
-var progressBar = require("../progress-bar");
+var progressBar = require("../../utils/progressBar");
+var execSync    = require("../../utils/execSync");
 
 var org  = process.env.GITHUB_ORG;
 var repo = process.env.GITHUB_REPO;
@@ -14,23 +14,21 @@ var tags = [
   "tag: polish"
 ];
 
-exports.description = "Creates a basic changelog categorized by designated github labels";
-
 function getLastTag() {
   return execSync("git describe --abbrev=0 --tags");
 }
 
-exports.githubAPIrequest = function (url) {
+function githubAPIrequest(url) {
   return execSync("curl -H 'Authorization: token " + process.env.GITHUB_AUTH + "' --silent " + url);
 }
 
-exports.getIssueData = function(issue) {
+function getIssueData(issue) {
   var url  = "https://api.github.com/repos/" + org + "/" + repo + "/issues/" + issue;
 
-  return exports.githubAPIrequest(url);
+  return githubAPIrequest(url);
 }
 
-exports.getListOfCommits = function (config) {
+function getListOfCommits(config) {
   var lastTag = getLastTag(config);
   // console.log("Last tag: ", lastTag);
 
@@ -38,7 +36,7 @@ exports.getListOfCommits = function (config) {
   return commits;
 }
 
-exports.getCommitInfo = function(commits) {
+function getCommitInfo(commits) {
   var tick = progressBar(commits.length);
 
   var logs = commits.map(function(commit) {
@@ -53,7 +51,7 @@ exports.getCommitInfo = function(commits) {
       var end = message.slice(start).indexOf(" ");
       var issueNumber = message.slice(start, start + end);
 
-      response = JSON.parse(exports.getIssueData(issueNumber));
+      response = JSON.parse(getIssueData(issueNumber));
       response.commitSHA = sha;
       response.mergeMessage = message;
       return response;
@@ -69,7 +67,7 @@ exports.getCommitInfo = function(commits) {
   return logs;
 }
 
-exports.getCommitsByCategory = function(logs) {
+function getCommitsByCategory(logs) {
   var categories = tags.map(function(tag) {
     var commits = [];
 
@@ -90,7 +88,7 @@ exports.getCommitsByCategory = function(logs) {
   });
 
   return categories;
-};
+}
 
 function toTitleCase(str) {
     return str.replace(/\w\S*/g, function(text){
@@ -102,7 +100,7 @@ function normalizeTag(tag) {
   return toTitleCase(tag.slice(5));
 }
 
-exports.createMarkdown = function(commitsByCategory) {
+function createMarkdown(commitsByCategory) {
   var date = new Date().toISOString();
   date = date.slice(0, date.indexOf("T"));
 
@@ -176,22 +174,16 @@ function repeat(str, times) {
   return Array(times + 1).join(str);
 }
 
-exports.execute = function (config) {
-  var commits = exports.getListOfCommits(config);
+module.exports = function execute(config) {
+  var commits = getListOfCommits(config);
   // console.log(commits);
 
-  var commitInfo = exports.getCommitInfo(commits);
+  var commitInfo = getCommitInfo(commits);
   // console.log(commitInfo);
 
-  var commitsByCategory = exports.getCommitsByCategory(commitInfo);
+  var commitsByCategory = getCommitsByCategory(commitInfo);
   // console.log(commitsByCategory);
 
-  var changelog = exports.createMarkdown(commitsByCategory);
+  var changelog = createMarkdown(commitsByCategory);
   console.log(changelog);
 };
-
-function execSync(cmd) {
-  return child.execSync(cmd, {
-    encoding: "utf8"
-  }).trim();
-}

--- a/lib/commands/changelog/index.js
+++ b/lib/commands/changelog/index.js
@@ -1,5 +1,6 @@
 var progressBar = require("../../utils/progressBar");
 var execSync    = require("../../utils/execSync");
+var chalk       = require("chalk");
 
 var org  = process.env.GITHUB_ORG;
 var repo = process.env.GITHUB_REPO;
@@ -24,14 +25,11 @@ function githubAPIrequest(url) {
 
 function getIssueData(issue) {
   var url  = "https://api.github.com/repos/" + org + "/" + repo + "/issues/" + issue;
-
   return githubAPIrequest(url);
 }
 
 function getListOfCommits(config) {
   var lastTag = getLastTag(config);
-  // console.log("Last tag: ", lastTag);
-
   var commits = execSync("git log --first-parent --oneline " + lastTag + "..").split("\n");
   return commits;
 }
@@ -154,7 +152,7 @@ function createMarkdown(commitsByCategory) {
         markdown += "\n";
 
         // indent more?
-        // spaces = 4;
+        spaces = 4;
       }
 
       if (commit.number) {
@@ -174,16 +172,17 @@ function repeat(str, times) {
   return Array(times + 1).join(str);
 }
 
-module.exports = function execute(config) {
+module.exports = function changelog(config) {
+  if (!process.env.GITHUB_AUTH) {
+    console.log(chalk.red("Must provide GITHUB_AUTH"));
+    process.exit(1);
+  }
+
   var commits = getListOfCommits(config);
-  // console.log(commits);
-
   var commitInfo = getCommitInfo(commits);
-  // console.log(commitInfo);
-
   var commitsByCategory = getCommitsByCategory(commitInfo);
-  // console.log(commitsByCategory);
-
   var changelog = createMarkdown(commitsByCategory);
+
   console.log(changelog);
+  process.exit();
 };

--- a/lib/commands/changelog/index.js
+++ b/lib/commands/changelog/index.js
@@ -15,6 +15,8 @@ var tags = [
   "tag: polish"
 ];
 
+var baseIssueUrl = "https://phabricator.babeljs.io/";
+
 function getLastTag() {
   return execSync("git describe --abbrev=0 --tags");
 }
@@ -34,12 +36,22 @@ function getListOfCommits(config) {
   return commits;
 }
 
+function getCommiters(commits) {
+  var committers = commits.map(function(commit) {
+    return commit.user && commit.user.login;
+  });
+
+  return committers.filter(function(item, pos) {
+    return item && committers.indexOf(item) === pos;
+  });
+}
+
 function getCommitInfo(commits) {
   var tick = progressBar(commits.length);
 
   var logs = commits.map(function(commit) {
 
-    var sha = commit.slice(0,7);
+    var sha = commit.slice(0, 7);
     var message = commit.slice(8);
     var response;
     tick(sha);
@@ -102,6 +114,8 @@ function createMarkdown(commitsByCategory) {
   var date = new Date().toISOString();
   date = date.slice(0, date.indexOf("T"));
 
+  var fixesRegex = /Fix(es)? ([T#]\d+)/i;
+
   var markdown = "\n";
 
   markdown += "## Unreleased (" + date + ")";
@@ -115,7 +129,7 @@ function createMarkdown(commitsByCategory) {
 
     markdown += "\n";
     markdown += "\n";
-    markdown += "* **" + normalizeTag(category.tag) + "**";
+    markdown += "#### " + normalizeTag(category.tag);
 
     category.commits.forEach(function(commit) {
       markdown += "\n";
@@ -140,25 +154,30 @@ function createMarkdown(commitsByCategory) {
         return self.indexOf(value) === index;
       });
 
-      var spaces = 2;
+      var spaces = 0;
 
       if (changedPackages.length > 0) {
         markdown += repeat(" ", spaces) + "* ";
 
         changedPackages.forEach(function(package, i) {
-          markdown += (i === 0 ? "" : ",") + "`" + package + "`";
+          markdown += (i === 0 ? "" : ", ") + "`" + package + "`";
         });
 
         markdown += "\n";
 
         // indent more?
-        spaces = 4;
+        spaces = 2;
       }
 
       if (commit.number) {
         var prUrl = "https://github.com/" + org + "/" + repo + "/pull/" + commit.number;
         markdown += repeat(" ", spaces) + "* ";
         markdown += "[#" + commit.number + "](" + prUrl + ")";
+      }
+
+
+      if (commit.title.match(fixesRegex)) {
+        commit.title = commit.title.replace(fixesRegex, "Fixes [$2](" + baseIssueUrl + "$2)");
       }
 
       markdown += " " + commit.title + "." + " ([@" + commit.user.login + "](" + commit.user.html_url + "))";
@@ -180,9 +199,18 @@ module.exports = function changelog(config) {
 
   var commits = getListOfCommits(config);
   var commitInfo = getCommitInfo(commits);
+  var committers = getCommiters(commitInfo);
   var commitsByCategory = getCommitsByCategory(commitInfo);
   var changelog = createMarkdown(commitsByCategory);
 
   console.log(changelog);
+
+  console.log("");
+  console.log("#### Commiters: " + committers.length);
+  console.log(committers.sort().map(function(commiter) {
+    return "- " + commiter;
+  }).join("\n"));
+  console.log("");
+
   process.exit();
 };

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,3 +1,4 @@
 exports.bootstrap = require("./bootstrap");
+exports.changelog = require("./changelog");
 exports.publish   = require("./publish");
 exports.updated   = require("./updated");

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -185,7 +185,6 @@ exports.execute = function (config) {
             if (process.env.NPM_DIST_TAG) {
               execSync("npm dist-tag add " + name + "@" + NEW_VERSION + " " + process.env.NPM_DIST_TAG);
             } else {
-              execSync("npm dist-tag add " + name + "@" + NEW_VERSION + " stable");
               execSync("npm dist-tag add " + name + "@" + NEW_VERSION + " latest");
             }
             tick(name);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lerna",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Tool for managing JavaScript projects with multiple packages",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
From other PR (#23) - Didn't get to updating the readme but I would do that as well

To run it, currently I'm checking out the branch,

`GITHUB_AUTH=public_repo_auth_key_here GITHUB_ORG=babel GITHUB_REPO=babel ./node_modules/.bin/lerna changelog`

---

Example changelog: https://github.com/babel/babel/releases/tag/v6.7.0

Then we go in and manually add code if useful, and summary/explanations

---

I've been using this for the babel changelog