### PR TITLE
Fixes the progress bar not working

### DIFF
--- a/lib/progress-bar.js
+++ b/lib/progress-bar.js
@@ -2,14 +2,30 @@ var ProgressBar = require("progress");
 var pad         = require("pad");
 
 module.exports = function (total) {
+
+  var COLUMNS = process.stdout.columns || 100
+  if (! process.stderr.cursorTo) {
+    process.stderr.columns = COLUMNS;
+    process.stderr.isTTY = true;
+    process.stderr.cursorTo = function (column) {
+      process.stderr.write("\u001b[" + COLUMNS + "D");
+      if (column) {
+          process.stderr.write("\u001b[" + column + "C");
+      }
+    };
+    process.stderr.clearLine = function () {
+      this.cursorTo(0)
+      process.stderr.write("\u001b[K");
+    };
+  }
+
   var bar = new ProgressBar(":packagename ╢:bar╟", {
     total: total,
     complete: "█",
     incomplete: "░",
     clear: true,
-
     // terminal columns - package name length - additional characters length
-    width: (process.stdout.columns || 100) - 50 - 3
+    width: COLUMNS - 50 - 3
   });
 
   return function (name) {


### PR DESCRIPTION
Fixes the progress bar not working and erroring when spawning lerna because stdout is not a TTY when called from process.spawn, node-progress was failing when trying to call this.stream.clearLine