### PR TITLE
Support jsnext:main in packages

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -88,7 +88,7 @@ export default class BootstrapCommand extends Command {
 
     const packageJsonFileContents = JSON.stringify(newPkgJson, null, "  ");
     const indexJsFileContents = "module.exports = require(" + JSON.stringify(src) + ");";
-    const moduleJsFileContents = "import _ from " + JSON.stringify(src) + ";\nexport default _;";
+    const moduleJsFileContents = "export * from " + JSON.stringify(src) + ";";
 
     async.parallel([
       callback => {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -73,21 +73,32 @@ export default class BootstrapCommand extends Command {
     const srcPackageJsonLocation = path.join(src, "package.json");
     const destPackageJsonLocation = path.join(dest, "package.json");
     const destIndexJsLocation = path.join(dest, "index.js");
+    const destModuleJsLocation = path.join(dest, "module.js");
+    const pkg = require(srcPackageJsonLocation);
 
-    const packageJsonFileContents = JSON.stringify({
+    const newPkgJson = {
       name: name,
-      version: require(srcPackageJsonLocation).version
-    }, null, "  ");
+      version: pkg.version,
+      main: "index.js"
+    };
 
+    if (pkg["jsnext:main"]) { // support jsnext:main convention for ES modules
+      newPkgJson["jsnext:main"] = "module.js";
+    }
+
+    const packageJsonFileContents = JSON.stringify(newPkgJson, null, "  ");
     const indexJsFileContents = "module.exports = require(" + JSON.stringify(src) + ");";
+    const moduleJsFileContents = "import _ from " + JSON.stringify(src) + ";\nexport default _;";
 
-    FileSystemUtilities.writeFile(destPackageJsonLocation, packageJsonFileContents, err => {
-      if (err) {
-        return callback(err);
-      }
-
-      FileSystemUtilities.writeFile(destIndexJsLocation, indexJsFileContents, callback);
-    });
+    async.parallel([
+      callback => {
+        FileSystemUtilities.writeFile(destPackageJsonLocation, packageJsonFileContents, callback);
+      }, callback => {
+        FileSystemUtilities.writeFile(destModuleJsLocation, moduleJsFileContents, callback);
+      }, callback => {
+        FileSystemUtilities.writeFile(destIndexJsLocation, indexJsFileContents, callback);
+      }],
+    callback);
   }
 
   installExternalPackages(pkg, callback) {

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -46,16 +46,19 @@ describe("BootstrapCommand", () => {
 
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")));
+        assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/module.js")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")));
 
         // Should not exist because mis-matched version
         assert.ok(!pathExists.sync(path.join(testDir, "packages/package-4/node_modules/package-1")));
 
         assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-1") + "\");\n");
-        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\"\n}\n");
+        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\",\n  \"main\": \"index.js\"\n}\n");
 
+        // package 2 exposes a jsnext:main, package 1 does not
         assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-2") + "\");\n");
-        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\"\n}\n");
+        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/module.js")).toString(), "import _ from \"" + path.join(testDir, "packages/package-2") + "\";\nexport default _;\n");
+        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\",\n  \"main\": \"index.js\",\n  \"jsnext:main\": \"module.js\"\n}\n");
 
         done();
       } catch (err) {

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -57,7 +57,7 @@ describe("BootstrapCommand", () => {
 
         // package 2 exposes a jsnext:main, package 1 does not
         assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-2") + "\");\n");
-        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/module.js")).toString(), "import _ from \"" + path.join(testDir, "packages/package-2") + "\";\nexport default _;\n");
+        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/module.js")).toString(), "export * from \"" + path.join(testDir, "packages/package-2") + "\";\n");
         assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\",\n  \"main\": \"index.js\",\n  \"jsnext:main\": \"module.js\"\n}\n");
 
         done();

--- a/test/fixtures/BootstrapCommand/basic/packages/package-2/myindex.js
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-2/myindex.js
@@ -1,0 +1,1 @@
+module.exports = "hello world";

--- a/test/fixtures/BootstrapCommand/basic/packages/package-2/mymodule.js
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-2/mymodule.js
@@ -1,0 +1,1 @@
+export default "hello world";

--- a/test/fixtures/BootstrapCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-2/package.json
@@ -3,5 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "package-1": "^1.0.0"
-  }
+  },
+  "main": "myindex.js",
+  "jsnext:main": "mymodule.js"
 }


### PR DESCRIPTION
Currently Lerna cannot be used with tools like [Rollup](https://github.com/rollup/rollup), insofar as it depends on the `jsnext:main` field to denote exported ES6 modules, and Lerna writes its own `package.json` for each dependency and omits the `jsnext:main` field.

For my own use case (PouchDB), I would like to build up modules that have both a `main` and a `jsnext:main`. That way, users can choose either CommonJS or ES modules, but internally we'll use `jsnext:main` so that we can get the benefits of Rollup's super-efficient bundler.

This fix adds support for `jsnext:main`. The idea is that, if an existing `package.json` exposes a `jsnext:main` field, then the Lerna-created `package.json` will also have one, with a `module.js` that looks like this:

```js
import _ from 'package';
export default _;
```
Packages that don't have a `jsnext:main` will have the same behavior as before.