### PR TITLE
Add cache for checking updated dependencies

### DIFF
--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -79,19 +79,40 @@ export default class UpdatedPackagesCollector {
   }
 
   isPackageDependentOf(packageName, dependency) {
-    var dependencies = this.packageGraph.get(packageName).dependencies;
+    if (!this.cache[packageName]) {
+      this.cache[packageName] = {};
+    }
+
+    if (this.cache[packageName][dependency] === "dependent") {
+      return true;
+    } else if (this.cache[packageName][dependency] === "visited") {
+      return false;
+    }
+
+    let dependencies = this.packageGraph.get(packageName).dependencies;
 
     if (dependencies.indexOf(dependency) > -1) {
+      this.cache[packageName][dependency] = "dependent";
       return true;
     }
 
-    return !!find(dependencies, dep => {
-      return this.isPackageDependentOf(dep, dependency);
+    this.cache[packageName][dependency] = "visited";
+
+    let hasSubDependents = false;
+
+    dependencies.forEach(dep => {
+      if (this.isPackageDependentOf(dep, dependency)) {
+        this.cache[packageName][dependency] = "dependent";
+        hasSubDependents = true;
+      }
     });
+
+    return hasSubDependents;
   }
 
   collectDependents() {
     const dependents = {};
+    this.cache = {};
 
     this.packages.forEach(pkg => {
       Object.keys(this.updatedPackages).forEach(dependency => {

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -8,7 +8,7 @@ import path from "path";
 
 class Update {
   constructor(pkg) {
-    this.package = pkg;
+    this.package  = pkg;
   }
 }
 

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -8,7 +8,7 @@ import path from "path";
 
 class Update {
   constructor(pkg) {
-    this.package  = pkg;
+    this.package = pkg;
   }
 }
 

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -10,113 +10,236 @@ import logger from "../src/logger";
 import stub from "./_stub";
 
 describe("UpdatedCommand", () => {
-  let testDir;
 
-  beforeEach(done => {
-    testDir = initFixture("UpdatedCommand/basic", done);
+  /** =========================================================================
+   * Basic
+   * ======================================================================= */
+
+  describe("Basic", () => {
+    let testDir;
+
+    beforeEach(done => {
+      testDir = initFixture("UpdatedCommand/basic", done);
+    });
+
+    it("should list changes", done => {
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
+
+      const updatedCommand = new UpdatedCommand([], {});
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-2\n- package-3");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
+    });
+
+    it("should list changes with --force-version *", done => {
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
+
+      const updatedCommand = new UpdatedCommand([], {
+        forceVersion: "*"
+      });
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-1\n- package-2\n- package-3\n- package-4");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
+    });
+
+    it("should list changes with --force-version [package,package]", done => {
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
+
+      const updatedCommand = new UpdatedCommand([], {
+        forceVersion: "package-2,package-4"
+      });
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-2\n- package-3\n- package-4");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
+    });
+
+    it("should list changes without ignored files", done => {
+      const lernaJsonLocation = path.join(testDir, "lerna.json");
+      const lernaJson = JSON.parse(fs.readFileSync(lernaJsonLocation));
+      lernaJson.publishConfig = {
+        ignore: ["ignored-file"]
+      };
+      fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
+
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
+      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
+
+      const updatedCommand = new UpdatedCommand([], {});
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-3");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
+    });
   });
 
-  it("should list changes", done => {
-    child.execSync("git tag v1.0.0");
-    child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
-    child.execSync("git add -A");
-    child.execSync("git commit -m 'Commit'");
+  /** =========================================================================
+   * Circular
+   * ======================================================================= */
 
-    const updatedCommand = new UpdatedCommand([], {});
+  describe("Circular Dependencies", () => {
+    let testDir;
 
-    updatedCommand.runValidations();
-    updatedCommand.runPreparations();
-
-    let calls = 0;
-    stub(logger, "info", message => {
-      if (calls === 0) assert.equal(message, "Checking for updated packages...");
-      if (calls === 1) assert.equal(message, "");
-      if (calls === 2) assert.equal(message, "- package-2\n- package-3");
-      if (calls === 3) assert.equal(message, "");
-      calls++;
+    beforeEach(done => {
+      testDir = initFixture("UpdatedCommand/circular", done);
     });
 
-    updatedCommand.runCommand(exitWithCode(0, done));
-  });
+    it("should list changes", done => {
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
-  it("should list changes with --force-version *", done => {
-    child.execSync("git tag v1.0.0");
-    child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
-    child.execSync("git add -A");
-    child.execSync("git commit -m 'Commit'");
+      const updatedCommand = new UpdatedCommand([], {});
 
-    const updatedCommand = new UpdatedCommand([], {
-      forceVersion: "*"
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-3\n- package-4");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
     });
 
-    updatedCommand.runValidations();
-    updatedCommand.runPreparations();
+    it("should list changes with --force-version *", done => {
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
-    let calls = 0;
-    stub(logger, "info", message => {
-      if (calls === 0) assert.equal(message, "Checking for updated packages...");
-      if (calls === 1) assert.equal(message, "");
-      if (calls === 2) assert.equal(message, "- package-1\n- package-2\n- package-3\n- package-4");
-      if (calls === 3) assert.equal(message, "");
-      calls++;
+      const updatedCommand = new UpdatedCommand([], {
+        forceVersion: "*"
+      });
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-1\n- package-2\n- package-3\n- package-4");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
     });
 
-    updatedCommand.runCommand(exitWithCode(0, done));
-  });
+    it("should list changes with --force-version [package,package]", done => {
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-4/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
-  it("should list changes with --force-version [package,package]", done => {
-    child.execSync("git tag v1.0.0");
-    child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-    child.execSync("git add -A");
-    child.execSync("git commit -m 'Commit'");
+      const updatedCommand = new UpdatedCommand([], {
+        forceVersion: "package-2"
+      });
 
-    const updatedCommand = new UpdatedCommand([], {
-      forceVersion: "package-2,package-4"
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-2\n- package-3\n- package-4");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
     });
 
-    updatedCommand.runValidations();
-    updatedCommand.runPreparations();
+    it("should list changes without ignored files", done => {
+      const lernaJsonLocation = path.join(testDir, "lerna.json");
+      const lernaJson = JSON.parse(fs.readFileSync(lernaJsonLocation));
+      lernaJson.publishConfig = {
+        ignore: ["ignored-file"]
+      };
+      fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
 
-    let calls = 0;
-    stub(logger, "info", message => {
-      if (calls === 0) assert.equal(message, "Checking for updated packages...");
-      if (calls === 1) assert.equal(message, "");
-      if (calls === 2) assert.equal(message, "- package-2\n- package-3\n- package-4");
-      if (calls === 3) assert.equal(message, "");
-      calls++;
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
+      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
+
+      const updatedCommand = new UpdatedCommand([], {});
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-3\n- package-4");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
     });
-
-    updatedCommand.runCommand(exitWithCode(0, done));
-  });
-
-  it("should list changes without ignored files", done => {
-    const lernaJsonLocation = path.join(testDir, "lerna.json");
-    const lernaJson = JSON.parse(fs.readFileSync(lernaJsonLocation));
-    lernaJson.publishConfig = {
-      ignore: ["ignored-file"]
-    };
-    fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
-
-    child.execSync("git tag v1.0.0");
-    child.execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
-    child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-    child.execSync("git add -A");
-    child.execSync("git commit -m 'Commit'");
-
-    const updatedCommand = new UpdatedCommand([], {});
-
-    updatedCommand.runValidations();
-    updatedCommand.runPreparations();
-
-    let calls = 0;
-    stub(logger, "info", message => {
-      if (calls === 0) assert.equal(message, "Checking for updated packages...");
-      if (calls === 1) assert.equal(message, "");
-      if (calls === 2) assert.equal(message, "- package-3");
-      if (calls === 3) assert.equal(message, "");
-      calls++;
-    });
-
-    updatedCommand.runCommand(exitWithCode(0, done));
   });
 });

--- a/test/fixtures/UpdatedCommand/circular/lerna.json
+++ b/test/fixtures/UpdatedCommand/circular/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/UpdatedCommand/circular/package.json
+++ b/test/fixtures/UpdatedCommand/circular/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/UpdatedCommand/circular/packages/package-1/package.json
+++ b/test/fixtures/UpdatedCommand/circular/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/UpdatedCommand/circular/packages/package-2/package.json
+++ b/test/fixtures/UpdatedCommand/circular/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/UpdatedCommand/circular/packages/package-3/package.json
+++ b/test/fixtures/UpdatedCommand/circular/packages/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-4": "^1.0.0"
+  }
+}

--- a/test/fixtures/UpdatedCommand/circular/packages/package-4/package.json
+++ b/test/fixtures/UpdatedCommand/circular/packages/package-4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-3": "^1.0.0"
+  }
+}


### PR DESCRIPTION
https://github.com/lerna/lerna/issues/128

Probably not the best but it seems to work on Babel (where the max callstack error happened).

Examples:
babel-types -> all packages updated
babel -> babel only (no other dependencies)
stage-3 preset -> stage-0, stage-1, stage-2, stage-3