### PR TITLE
Add 'lerna exec' command

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -15,7 +15,7 @@ var cli = meow([
   "  diff       Diff all packages or a single package since the last release",
   "  init       Initialize a lerna repo",
   "  run        Run npm script in each package",
-  "  exec       Run npm command in each package",
+  "  exec       Run a command in each package",
   "  ls         List all public packages",
   "",
   "Options:",

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -15,6 +15,7 @@ var cli = meow([
   "  diff       Diff all packages or a single package since the last release",
   "  init       Initialize a lerna repo",
   "  run        Run npm script in each package",
+  "  exec       Run npm command in each package",
   "  ls         List all public packages",
   "",
   "Options:",

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -28,9 +28,14 @@ export default class NpmUtilities {
     return ChildProcessUtilities.execSync(`npm dist-tag ls ${packageName}`).indexOf(tag) >= 0;
   }
 
+  @logger.logifySync
+  static execInDir(command, args, directory, callback) {
+    ChildProcessUtilities.exec(`npm ${command} ${args.join(" ")}`, { cwd: directory }, callback);
+  }
+
   @logger.logifyAsync
   static runScriptInDir(script, args, directory, callback) {
-    ChildProcessUtilities.exec(`npm run ${script} ${args.join(" ")}`, { cwd: directory }, callback);
+    NpmUtilities.execInDir(`run ${script}`, args, directory, callback);
   }
 
   @logger.logifyAsync

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -1,4 +1,4 @@
-import NpmUtilities from "../NpmUtilities";
+import ChildProcessUtilities from "../ChildProcessUtilities";
 import Command from "../Command";
 import async from "async";
 
@@ -8,7 +8,7 @@ export default class ExecCommand extends Command {
     this.args = this.input.slice(1);
 
     if (!this.command) {
-      callback(new Error("You must specify which npm command to run."));
+      callback(new Error("You must specify which command to run."));
       return;
     }
 
@@ -22,9 +22,9 @@ export default class ExecCommand extends Command {
   }
 
   runCommandInPackage(pkg, callback) {
-    NpmUtilities.execInDir(this.command, this.args, pkg.location, (err, stdout) => {
+    ChildProcessUtilities.exec(this.command, { cwd: pkg.location }, (err, stdout) => {
       if (err) {
-        this.logger.error(`Errored while running npm command '${this.command}' in '${pkg.name}'`, err);
+        this.logger.error(`Errored while running command '${this.command}' in '${pkg.name}'`, err);
       } else {
         this.logger.info(stdout);
       }

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -1,0 +1,34 @@
+import NpmUtilities from "../NpmUtilities";
+import Command from "../Command";
+import async from "async";
+
+export default class ExecCommand extends Command {
+  initialize(callback) {
+    this.command = this.input[0];
+    this.args = this.input.slice(1);
+
+    if (!this.command) {
+      callback(new Error("You must specify which npm command to run."));
+      return;
+    }
+
+    callback(null, true);
+  }
+
+  execute(callback) {
+    async.parallelLimit(this.packages.map(pkg => cb => {
+      this.runCommandInPackage(pkg, cb);
+    }), 4, callback);
+  }
+
+  runCommandInPackage(pkg, callback) {
+    NpmUtilities.execInDir(this.command, this.args, pkg.location, (err, stdout) => {
+      if (err) {
+        this.logger.error(`Errored while running npm command '${this.command}' in '${pkg.name}'`, err);
+      } else {
+        this.logger.info(stdout);
+      }
+      callback(err);
+    });
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import UpdatedCommand from "./commands/UpdatedCommand";
 import DiffCommand from "./commands/DiffCommand";
 import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
+import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
 
 export const __commands__ = {
@@ -13,6 +14,7 @@ export const __commands__ = {
   diff: DiffCommand,
   init: InitCommand,
   run: RunCommand,
+  exec: ExecCommand,
   ls: LsCommand
 };
 

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -1,0 +1,35 @@
+import assert from "assert";
+import path from "path";
+
+import ChildProcessUtilities from "../src/ChildProcessUtilities";
+import exitWithCode from "./_exitWithCode";
+import initFixture from "./_initFixture";
+import ExecCommand from '../src/commands/ExecCommand';
+import stub from "./_stub";
+
+describe('ExecCommand', () => {
+  let testDir;
+  beforeEach(done => {
+    testDir = initFixture("ExecCommand/basic", done);
+  });
+
+  it("should run a command", done => {
+    const execCommand = new ExecCommand(["ls"], {});
+
+    execCommand.runValidations();
+    execCommand.runPreparations();
+
+    let calls = 0;
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+      assert.equal(command, "ls");
+
+      if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") });
+      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-3") });
+
+      calls++;
+      callback();
+    });
+
+    execCommand.runCommand(exitWithCode(0, done));
+  })
+});

--- a/test/fixtures/ExecCommand/basic/lerna.json
+++ b/test/fixtures/ExecCommand/basic/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ExecCommand/basic/package.json
+++ b/test/fixtures/ExecCommand/basic/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/ExecCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/ExecCommand/basic/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ExecCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/ExecCommand/basic/packages/package-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-2",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
As opposed to 'lerna run', which runs
scripts defined in package.json, exec will
let you execute an inbuilt npm command directly
in each package, e.g.

- `lerna exec rebuild`
- `lerna exec publish`
- `lerna exec upgrade`


This is response to #127 and implements one of the solutions @thejameskyle suggests. What do you think?