### PR TITLE
lerna init should add lerna as a devDependency

### DIFF
--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -36,7 +36,7 @@ export default class InitCommand extends Command {
     // if (!packageJson.private) packageJson.private = true;
     if (!packageJson.dependencies) packageJson.dependencies = {};
 
-    objectAssignSorted(packageJson.dependencies, {
+    objectAssignSorted(packageJson.devDependencies, {
       lerna: this.lernaVersion
     });
 


### PR DESCRIPTION
I think we want this as a devDep right? Also do we want to add `^` in front as well?

Also, this means we don't want users to use it as a global npm package?

cc @thejameskyle  