### PR TITLE
Implements #134 - add a --confirm flag

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -22,7 +22,8 @@ var cli = meow([
   "  --canary, -c         Publish packages after every successful merge using the sha as part of the tag",
   "  --skip-git           Skip commiting, tagging, and pushing git changes (only affects publish)",
   "  --npm-tag [tagname]  Publish packages with the specified npm dist-tag",
-  "  --force-publish      Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)"
+  "  --force-publish      Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)",
+  "  --confirm            Skip all confirmation prompts"
 ], {
   alias: {
     independent: "i",

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -214,9 +214,14 @@ export default class PublishCommand extends Command {
     }).join("\n"));
     this.logger.newLine();
 
-    PromptUtilities.confirm("Are you sure you want to publish the above changes?", confirm => {
-      callback(null, confirm);
-    });
+    if (!this.flags.confirm) {
+      PromptUtilities.confirm("Are you sure you want to publish the above changes?", confirm => {
+        callback(null, confirm);
+      });
+    } else {
+      this.logger.info("Assuming confirmation.");
+      callback(null, true);
+    }
   }
 
   updateVersionInLernaJson() {


### PR DESCRIPTION
This adds a `--confirm` flag for usage in CI that automatically answers the publish confirmation prompt.

```
lerna publish --canary --confirm

Lerna v2.0.0-beta.9
Independent Versioning Mode
Publishing canary build
Checking for updated packages...

Changes:
- component-a: 0.0.3 => 0.0.3-canary.2c247805
- component-b: 0.0.2 => 0.0.2-canary.2c247805
- component-c: 0.0.2 => 0.0.2-canary.2c247805

Assuming confirmation.

Publishing packages to npm...
Reseting git state
Successfully published:
 - component-a@0.0.3-canary.2c247805
 - component-b@0.0.2-canary.2c247805
 - component-c@0.0.2-canary.2c247805
```