### PR TITLE
Allow additional properties in lerna init

### DIFF
--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -70,10 +70,12 @@ export default class InitCommand extends Command {
       this.logger.info("Updating lerna.json.");
     }
 
-    FileSystemUtilities.writeFileSync(lernaJsonLocation, JSON.stringify({
+    objectAssignSorted(lernaJson, {
       lerna: this.lernaVersion,
       version: version
-    }, null, "  "));
+    });
+
+    FileSystemUtilities.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, "  "));
   }
 
   ensureNoVersionFile() {

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -1,6 +1,7 @@
 import FileSystemUtilities from "../FileSystemUtilities";
 import Command from "../Command";
 import objectAssignSorted from "object-assign-sorted";
+import objectAssign from "object-assign";
 
 export default class InitCommand extends Command {
   // don't do any of this.
@@ -70,7 +71,7 @@ export default class InitCommand extends Command {
       this.logger.info("Updating lerna.json.");
     }
 
-    objectAssignSorted(lernaJson, {
+    objectAssign(lernaJson, {
       lerna: this.lernaVersion,
       version: version
     });


### PR DESCRIPTION
`lerna init` is currently overriding `publishConfig` because it isn't included in the init process.

Rather than whitelisting every property I'm just going to accept additional properties.