### PR TITLE
[Bug] WIP: Multiple cache folders to fix windows EPERM error

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -3,8 +3,8 @@ import logger from "./logger";
 
 export default class NpmUtilities {
   @logger.logifyAsync
-  static installInDir(directory, dependencies, callback) {
-    let command = "npm install";
+  static installInDir(directory, dependencies, callback, cacheFolder) {
+    let command = "npm install --cache=/" + cacheFolder;
 
     if (dependencies) {
       command += " " + dependencies.join(" ");

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -106,7 +106,7 @@ export default class BootstrapCommand extends Command {
       });
 
     if (externalPackages.length) {
-      NpmUtilities.installInDir(pkg.location, externalPackages, callback);
+      NpmUtilities.installInDir(pkg.location, externalPackages, callback, externalPackages.length);
     } else {
       callback();
     }


### PR DESCRIPTION
On windows, I kept getting `EPERM: operation not permitted` errors, which would randomly make `lerna bootstrap` fail. After a bit of research I think the issue has to do with parallel instances of `npm install` running at the same time and butting heads in the `npm-cache` folder.

An idea I had to combat this was to have a different cache folder for each npm install. This pull request appends the `--cache=/folder` command to the `npm install`. 

As a quick prototype I just sent in the length of the external dependencies as an argument to get unique folder names for each `npm install`. Obviously will need to do something better than that.

Would like comments/feedback on how to evolve this approach for windows users. Does lerna depend on the npm cache? Does changing the paths like this mess with lerna in some way?
