### PR TITLE
feat: --restrict-to={glob} for "run" command

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -22,6 +22,7 @@ var cli = meow([
   "  --canary, -c         Publish packages after every successful merge using the sha as part of the tag",
   "  --skip-git           Skip commiting, tagging, and pushing git changes (only affects publish)",
   "  --npm-tag [tagname]  Publish packages with the specified npm dist-tag",
+  "  --restrict-to [package glob] Restricts a command to run only packages matching the given glob (Works only in combination with the 'run' command).",
   "  --force-publish      Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)"
 ], {
   alias: {

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -15,15 +15,15 @@ export default class RunCommand extends Command {
 
     let packagesToRunCommandIn = this.packages;
 
-    if (this.flags.restrictTo) {
+    if (typeof this.flags.restrictTo !== "undefined") {
       this.logger.info(`Restricting to packages that match '${this.flags.restrictTo}'`);
       packagesToRunCommandIn = packagesToRunCommandIn
         .filter(pkg => minimatch(pkg.name, this.flags.restrictTo));
-    }
 
-    if (!packagesToRunCommandIn.length) {
-      callback(new Error(`No packages found that match '${this.flags.restrictTo}'`));
-      return;
+      if (!packagesToRunCommandIn.length) {
+        callback(new Error(`No packages found that match '${this.flags.restrictTo}'`));
+        return;
+      }
     }
 
     this.packagesWithScript = packagesToRunCommandIn

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -16,9 +16,9 @@ export default class RunCommand extends Command {
     let packagesToRunCommandIn = this.packages;
 
     if (this.flags.restrictTo) {
-        this.logger.info(`Restricting to packages that match '${this.flags.restrictTo}'`);
-        packagesToRunCommandIn = packagesToRunCommandIn
-            .filter(pkg => minimatch(pkg.name, this.flags.restrictTo));
+      this.logger.info(`Restricting to packages that match '${this.flags.restrictTo}'`);
+      packagesToRunCommandIn = packagesToRunCommandIn
+        .filter(pkg => minimatch(pkg.name, this.flags.restrictTo));
     }
 
     if (!packagesToRunCommandIn.length) {

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -15,7 +15,7 @@ export default class RunCommand extends Command {
 
     let packagesToRunCommandIn = this.packages;
 
-    if (this.flags.restrictTo && `${this.flags.restrictTo}`.length > 0) {
+    if (this.flags.restrictTo) {
         this.logger.info(`Restricting to packages that match '${this.flags.restrictTo}'`);
         packagesToRunCommandIn = packagesToRunCommandIn
             .filter(pkg => minimatch(pkg.name, this.flags.restrictTo));

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -1,6 +1,7 @@
 import NpmUtilities from "../NpmUtilities";
 import Command from "../Command";
 import async from "async";
+import minimatch from "minimatch";
 
 export default class RunCommand extends Command {
   initialize(callback) {
@@ -12,7 +13,20 @@ export default class RunCommand extends Command {
       return;
     }
 
-    this.packagesWithScript = this.packages
+    let packagesToRunCommandIn = this.packages;
+
+    if (this.flags.restrictTo && `${this.flags.restrictTo}`.length > 0) {
+        this.logger.info(`Restricting to packages that match '${this.flags.restrictTo}'`);
+        packagesToRunCommandIn = packagesToRunCommandIn
+            .filter(pkg => minimatch(pkg.name, this.flags.restrictTo));
+    }
+
+    if (!packagesToRunCommandIn.length) {
+      callback(new Error(`No packages found that match '${this.flags.restrictTo}'`));
+      return;
+    }
+
+    this.packagesWithScript = packagesToRunCommandIn
       .filter(pkg => pkg.scripts && pkg.scripts[this.script]);
 
     if (!this.packagesWithScript.length) {

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -73,7 +73,7 @@ describe("RunCommand", () => {
     }));
   });
 
-  it("should run for all packages when --restrict-to is empty", done => {
+  it("should run for no packages when --restrict-to is given but empty", done => {
     const runCommand = new RunCommand(["my-script"], {restrictTo: ""});
 
     runCommand.runValidations();
@@ -86,10 +86,7 @@ describe("RunCommand", () => {
     });
 
     runCommand.runCommand(exitWithCode(0, () => {
-      assert.deepEqual(ranInPackages, [
-        "package-1",
-        "package-3"
-      ]);
+      assert.deepEqual(ranInPackages, []);
       done();
     }));
   });

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -72,4 +72,25 @@ describe("RunCommand", () => {
         done();
     }));
   });
+
+  it("should run for all packages when --restrict-to is empty", done => {
+    const runCommand = new RunCommand(["my-script"], {restrictTo: ""});
+
+    runCommand.runValidations();
+    runCommand.runPreparations();
+
+    const ranInPackages = [];
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+        callback();
+    });
+
+    runCommand.runCommand(exitWithCode(0, () => {
+        assert.deepEqual(ranInPackages, [
+            "package-1",
+            "package-3"
+        ]);
+        done();
+    }));
+  });
 });

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -60,16 +60,16 @@ describe("RunCommand", () => {
 
     const ranInPackages = [];
     stub(ChildProcessUtilities, "exec", (command, options, callback) => {
-        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
-        callback();
+      ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+      callback();
     });
 
     runCommand.runCommand(exitWithCode(0, () => {
-        assert.deepEqual(ranInPackages, [
-            "package-1",
-            "package-3"
-        ]);
-        done();
+      assert.deepEqual(ranInPackages, [
+        "package-1",
+        "package-3"
+      ]);
+      done();
     }));
   });
 
@@ -81,16 +81,16 @@ describe("RunCommand", () => {
 
     const ranInPackages = [];
     stub(ChildProcessUtilities, "exec", (command, options, callback) => {
-        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
-        callback();
+      ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+      callback();
     });
 
     runCommand.runCommand(exitWithCode(0, () => {
-        assert.deepEqual(ranInPackages, [
-            "package-1",
-            "package-3"
-        ]);
-        done();
+      assert.deepEqual(ranInPackages, [
+        "package-1",
+        "package-3"
+      ]);
+      done();
     }));
   });
 });

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -42,13 +42,13 @@ describe("RunCommand", () => {
 
     const ranInPackages = [];
     stub(ChildProcessUtilities, "exec", (command, options, callback) => {
-        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
-        callback();
+      ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+      callback();
     });
 
     runCommand.runCommand(exitWithCode(0, () => {
-        assert.deepEqual(ranInPackages, ["package-1"]);
-        done();
+      assert.deepEqual(ranInPackages, ["package-1"]);
+      done();
     }));
   });
 

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -33,4 +33,43 @@ describe("RunCommand", () => {
 
     runCommand.runCommand(exitWithCode(0, done));
   });
+
+  it("should run a command for a single package when specified via --restrict-to", done => {
+    const runCommand = new RunCommand(["my-script"], {restrictTo: "package-1"});
+
+    runCommand.runValidations();
+    runCommand.runPreparations();
+
+    const ranInPackages = [];
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+        callback();
+    });
+
+    runCommand.runCommand(exitWithCode(0, () => {
+        assert.deepEqual(ranInPackages, ["package-1"]);
+        done();
+    }));
+  });
+
+  it("should run a command for packages matched by a glob when using --restrict-to", done => {
+    const runCommand = new RunCommand(["my-script"], {restrictTo: "package-*"});
+
+    runCommand.runValidations();
+    runCommand.runPreparations();
+
+    const ranInPackages = [];
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+        callback();
+    });
+
+    runCommand.runCommand(exitWithCode(0, () => {
+        assert.deepEqual(ranInPackages, [
+            "package-1",
+            "package-3"
+        ]);
+        done();
+    }));
+  });
 });


### PR DESCRIPTION
This adds a flag `--restrict-to` that takes a glob to restrict a command to be run to the packages matched by the glob.

implements #143