### PR TITLE
chore: enforce proper indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,8 @@
     "camelcase": 0,
     "no-console": 0,
     "no-constant-condition": 0,
-    "no-inner-declarations": 0
+    "no-inner-declarations": 0,
+    "indent": ["error", 2]
   },
   "env": {
     "node": true


### PR DESCRIPTION
This adds an eslint rule to make sure we use proper indentation.

cc @thejameskyle 