### PR TITLE
Add option to ignore packages when bootstrapping (fixes #117)

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -18,11 +18,12 @@ var cli = meow([
   "  ls         List all public packages",
   "",
   "Options:",
-  "  --independent, -i    Version packages independently",
-  "  --canary, -c         Publish packages after every successful merge using the sha as part of the tag",
-  "  --skip-git           Skip commiting, tagging, and pushing git changes (only affects publish)",
-  "  --npm-tag [tagname]  Publish packages with the specified npm dist-tag",
-  "  --force-publish      Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)"
+  "  --independent, -i              Version packages independently",
+  "  --canary, -c                   Publish packages after every successful merge using the sha as part of the tag",
+  "  --skip-git                     Skip commiting, tagging, and pushing git changes (only affects publish)",
+  "  --npm-tag [tagname]            Publish packages with the specified npm dist-tag",
+  "  --force-publish                Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)",
+  "  --bootstrap-ignore [package]   Ignore the specified package(s) when bootstrapping"
 ], {
   alias: {
     independent: "i",

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -34,6 +34,10 @@ export default class Repository {
     return this.lernaJson && this.lernaJson.publishConfig || {};
   }
 
+  get bootstrapConfig() {
+    return this.lernaJson && this.lernaJson.bootstrapConfig || {};
+  }
+
   isIndependent() {
     return this.version === "independent";
   }


### PR DESCRIPTION
* Added `bootstrap-ignore` flag to CLI
* Check `bootstrapConfig.ignore` key in `lerna.json`

The CLI flag will override the `bootstrapConfig` option in `lerna.json`. Both the flag and the option allow one or more packages to be specified. The CLI flag accepts comma-separated values while the `bootstrapConfig` option can also accept an array.