### PR TITLE
Feature/lerna exec

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -15,7 +15,7 @@ var cli = meow([
   "  diff       Diff all packages or a single package since the last release",
   "  init       Initialize a lerna repo",
   "  run        Run npm script in each package",
-  "  exec       Run npm command in each package",
+  "  exec       Run a command in each package",
   "  ls         List all public packages",
   "",
   "Options:",

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -15,6 +15,7 @@ var cli = meow([
   "  diff       Diff all packages or a single package since the last release",
   "  init       Initialize a lerna repo",
   "  run        Run npm script in each package",
+  "  exec       Run npm command in each package",
   "  ls         List all public packages",
   "",
   "Options:",

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -1,4 +1,5 @@
 import child from "child_process";
+import objectAssign from "object-assign";
 
 export default class ChildProcessUtilities {
   static exec(command, opts, callback) {
@@ -17,9 +18,9 @@ export default class ChildProcessUtilities {
     }).trim();
   }
 
-  static spawn(command, args, callback) {
-    child.spawn(command, args, {
+  static spawn(command, args, opts, callback) {
+    child.spawn(command, args, objectAssign({
       stdio: "inherit"
-    }).on("close", callback);
+    }, opts)).on("close", callback);
   }
 }

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -28,9 +28,14 @@ export default class NpmUtilities {
     return ChildProcessUtilities.execSync(`npm dist-tag ls ${packageName}`).indexOf(tag) >= 0;
   }
 
+  @logger.logifySync
+  static execInDir(command, args, directory, callback) {
+    ChildProcessUtilities.exec(`npm ${command} ${args.join(" ")}`, { cwd: directory }, callback);
+  }
+
   @logger.logifyAsync
   static runScriptInDir(script, args, directory, callback) {
-    ChildProcessUtilities.exec(`npm run ${script} ${args.join(" ")}`, { cwd: directory }, callback);
+    NpmUtilities.execInDir(`run ${script}`, args, directory, callback);
   }
 
   @logger.logifyAsync

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -35,7 +35,7 @@ export default class DiffCommand extends Command {
   }
 
   execute(callback) {
-    ChildProcessUtilities.spawn("git", ["diff", this.lastCommit, "--color=auto", this.filePath], code => {
+    ChildProcessUtilities.spawn("git", ["diff", this.lastCommit, "--color=auto", this.filePath], {}, code => {
       if (code !== 0) {
         callback(new Error("Errored while spawning `git diff`."));
       } else {

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -1,4 +1,4 @@
-import NpmUtilities from "../NpmUtilities";
+import ChildProcessUtilities from "../ChildProcessUtilities";
 import Command from "../Command";
 import async from "async";
 
@@ -8,7 +8,7 @@ export default class ExecCommand extends Command {
     this.args = this.input.slice(1);
 
     if (!this.command) {
-      callback(new Error("You must specify which npm command to run."));
+      callback(new Error("You must specify which command to run."));
       return;
     }
 
@@ -22,9 +22,9 @@ export default class ExecCommand extends Command {
   }
 
   runCommandInPackage(pkg, callback) {
-    NpmUtilities.execInDir(this.command, this.args, pkg.location, (err, stdout) => {
+    ChildProcessUtilities.exec(this.command, { cwd: pkg.location }, (err, stdout) => {
       if (err) {
-        this.logger.error(`Errored while running npm command '${this.command}' in '${pkg.name}'`, err);
+        this.logger.error(`Errored while running command '${this.command}' in '${pkg.name}'`, err);
       } else {
         this.logger.info(stdout);
       }

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -1,0 +1,34 @@
+import NpmUtilities from "../NpmUtilities";
+import Command from "../Command";
+import async from "async";
+
+export default class ExecCommand extends Command {
+  initialize(callback) {
+    this.command = this.input[0];
+    this.args = this.input.slice(1);
+
+    if (!this.command) {
+      callback(new Error("You must specify which npm command to run."));
+      return;
+    }
+
+    callback(null, true);
+  }
+
+  execute(callback) {
+    async.parallelLimit(this.packages.map(pkg => cb => {
+      this.runCommandInPackage(pkg, cb);
+    }), 4, callback);
+  }
+
+  runCommandInPackage(pkg, callback) {
+    NpmUtilities.execInDir(this.command, this.args, pkg.location, (err, stdout) => {
+      if (err) {
+        this.logger.error(`Errored while running npm command '${this.command}' in '${pkg.name}'`, err);
+      } else {
+        this.logger.info(stdout);
+      }
+      callback(err);
+    });
+  }
+}

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -22,9 +22,10 @@ export default class ExecCommand extends Command {
   }
 
   runCommandInPackage(pkg, callback) {
-    ChildProcessUtilities.exec(this.command, { cwd: pkg.location }, (err, stdout) => {
+    ChildProcessUtilities.spawn(this.command, this.args, { cwd: pkg.location }, (err, stdout) => {
       if (err) {
-        this.logger.error(`Errored while running command '${this.command}' in '${pkg.name}'`, err);
+        this.logger.error(`Errored while running command '${this.command}' ` +
+                          `with arguments ${this.args.join(" ")} in '${pkg.name}'`, err);
       } else {
         this.logger.info(stdout);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import UpdatedCommand from "./commands/UpdatedCommand";
 import DiffCommand from "./commands/DiffCommand";
 import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
+import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
 
 export const __commands__ = {
@@ -13,6 +14,7 @@ export const __commands__ = {
   diff: DiffCommand,
   init: InitCommand,
   run: RunCommand,
+  exec: ExecCommand,
   ls: LsCommand
 };
 

--- a/test/ChildProcessUtilities.js
+++ b/test/ChildProcessUtilities.js
@@ -20,7 +20,7 @@ describe("ChildProcessUtilities", () => {
 
   describe(".spawn()", () => {
     it("should spawn a command in a child process", done => {
-      ChildProcessUtilities.spawn("echo", ["foo"], done);
+      ChildProcessUtilities.spawn("echo", ["foo"], {}, done);
     });
   });
 });

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -20,7 +20,7 @@ describe("DiffCommand", () => {
     diffCommand.runValidations();
     diffCommand.runPreparations();
 
-    stub(ChildProcessUtilities, "spawn", (command, args, callback) => {
+    stub(ChildProcessUtilities, "spawn", (command, args, opts, callback) => {
       assert.equal(command, "git");
       assert.equal(args[0], "diff");
       assert.equal(args[1].length, 40); // commit
@@ -38,7 +38,7 @@ describe("DiffCommand", () => {
     diffCommand.runValidations();
     diffCommand.runPreparations();
 
-    stub(ChildProcessUtilities, "spawn", (command, args, callback) => {
+    stub(ChildProcessUtilities, "spawn", (command, args, opts, callback) => {
       assert.equal(command, "git");
       assert.equal(args[0], "diff");
       assert.equal(args[1].length, 40); // commit

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -4,13 +4,25 @@ import path from "path";
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import exitWithCode from "./_exitWithCode";
 import initFixture from "./_initFixture";
-import ExecCommand from '../src/commands/ExecCommand';
+import ExecCommand from "../src/commands/ExecCommand";
 import stub from "./_stub";
 
-describe('ExecCommand', () => {
+describe("ExecCommand", () => {
   let testDir;
   beforeEach(done => {
     testDir = initFixture("ExecCommand/basic", done);
+  });
+
+  it("should complain if invoked without command", done => {
+    const execCommand = new ExecCommand([], {});
+
+    execCommand.runValidations();
+    execCommand.runPreparations();
+
+    execCommand.runCommand(exitWithCode(1, (err) => {
+      assert.ok(err instanceof Error);
+      done();
+    }));
   });
 
   it("should run a command", done => {
@@ -20,16 +32,48 @@ describe('ExecCommand', () => {
     execCommand.runPreparations();
 
     let calls = 0;
-    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+    stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
       assert.equal(command, "ls");
 
       if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") });
-      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-3") });
+      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2") });
 
       calls++;
       callback();
     });
 
-    execCommand.runCommand(exitWithCode(0, done));
-  })
+    execCommand.runCommand(exitWithCode(0, () => {
+      assert.equal(calls, 2);
+      done();
+    }));
+  });
+
+  it("should run a command with parameters", done => {
+    const execCommand = new ExecCommand(["ls", "-la"], {});
+
+    execCommand.runValidations();
+    execCommand.runPreparations();
+
+    let calls = 0;
+    stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
+      assert.equal(command, "ls");
+
+      if (calls === 0) {
+        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") });
+        assert.deepEqual(args, ["-la"]);
+      }
+      if (calls === 1) {
+        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2") });
+        assert.deepEqual(args, ["-la"]);
+      }
+
+      calls++;
+      callback();
+    });
+
+    execCommand.runCommand(exitWithCode(0, () => {
+      assert.equal(calls, 2);
+      done();
+    }));
+  });
 });

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -1,0 +1,35 @@
+import assert from "assert";
+import path from "path";
+
+import ChildProcessUtilities from "../src/ChildProcessUtilities";
+import exitWithCode from "./_exitWithCode";
+import initFixture from "./_initFixture";
+import ExecCommand from '../src/commands/ExecCommand';
+import stub from "./_stub";
+
+describe('ExecCommand', () => {
+  let testDir;
+  beforeEach(done => {
+    testDir = initFixture("ExecCommand/basic", done);
+  });
+
+  it("should run a command", done => {
+    const execCommand = new ExecCommand(["ls"], {});
+
+    execCommand.runValidations();
+    execCommand.runPreparations();
+
+    let calls = 0;
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+      assert.equal(command, "ls");
+
+      if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") });
+      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-3") });
+
+      calls++;
+      callback();
+    });
+
+    execCommand.runCommand(exitWithCode(0, done));
+  })
+});

--- a/test/fixtures/ExecCommand/basic/lerna.json
+++ b/test/fixtures/ExecCommand/basic/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ExecCommand/basic/package.json
+++ b/test/fixtures/ExecCommand/basic/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/ExecCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/ExecCommand/basic/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ExecCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/ExecCommand/basic/packages/package-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-2",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
This implements a proper `lerna exec` command that allows you to both pass flags to the lerna runtime and run commands in each package with multiple parameters, e.g.:
`lerna exec --debug -- ls -la node_modules`

closes #130 

cc @thejameskyle 
Also, after this is merged I'd like to enhance #145 to also change the target packages of `lerna exec`.