### PR TITLE
Link to 1.x docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Let's start by installing Lerna globally with [npm](https://www.npmjs.com/).
 ```sh
 $ npm install --global lerna
 # install the latest 2.x version
-$ npm install --global lerna#@2.0.0-beta.13
+$ npm install --global lerna@2.0.0-beta.13
 ```
 
 Next we'll create a new [git](https://git-scm.com/) repository:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Let's start by installing Lerna globally with [npm](https://www.npmjs.com/).
 
 ```sh
 $ npm install --global lerna
+# install the latest 2.x version
+$ npm install --global lerna#@2.0.0-beta.13
 ```
 
 Next we'll create a new [git](https://git-scm.com/) repository:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The two primary commands in Lerna are `lerna bootstrap` and `lerna publish`.
 
 ## Getting Started
 
+> The instructions below are for Lerna 2.x which is currently in beta and actively being worked on.
+> We recommend using it instead of 1.x for a new lerna project. Check the [wiki](https://github.com/lerna/lerna/wiki/1.x-Docs) if you need to see the 1.x README.
+
 Let's start by installing Lerna globally with [npm](https://www.npmjs.com/).
 
 ```sh


### PR DESCRIPTION
I went ahead and added some more stuff and merged the 2.x readme changes. How do we want to keep around the old docs since (some?) people might be using 1.x still.

@thejameskyle 

(Also, when do we want to get out of beta, and should make 2.x the default)

```bash
$ npm view lerna dist-tags
{ latest: '1.1.2', prerelease: '2.0.0-beta.13' }
```