### PR TITLE
Add option to ignore packages when bootstrapping (fixes #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ When run, this command will:
 Currently, what Lerna does to link internal dependencies is replace the
 `node_modules/package-x` with a link to the actual file in the repo.
 
+`lerna bootstrap` respects the `--ignore` flag (see below).
+
 #### How `bootstrap` works
 
 Let's use `babel` as an example.
@@ -425,7 +427,7 @@ $ lerna publish --concurrency 1
 
 #### --scope [glob]
 
-Allows to scope an command only affect a subset of packages.
+Scopes a command to a subset of packages.
 
 ```sh
 $ lerna exec --scope my-component -- ls -la
@@ -433,6 +435,28 @@ $ lerna exec --scope my-component -- ls -la
 
 ```sh
 $ lerna run --scope toolbar-* -- ls -la
+```
+
+#### --ignore [glob]
+
+Excludes a subset of packages when running a command.
+
+```sh
+$ lerna bootstrap --ignore component-*
+```
+
+The `ignore` flag, when used with the `bootstrap` command, can also be set in `lerna.json` under the `bootstrapConfig` key. The command-line flag will take precendence over this option.
+
+**Example**
+
+```javascript
+{
+  "lerna": "2.0.0-beta.16",
+  "version": "0.0.0",
+  "bootstrapConfig": {
+    "ignore": "component-*"
+  }
+}
 ```
 
 > Hint: The glob is matched against the package name defined in `package.json`,

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -26,6 +26,7 @@ var cli = meow([
   "  --skip-npm           Stop before actually publishing change to npm (only affects publish)",
   "  --npm-tag [tagname]  Publish packages with the specified npm dist-tag",
   "  --scope [glob]       Restricts the scope to package names matching the given glob (Works only in combination with the 'run' and the 'exec' command).",
+  "  --ignore [glob]      Ignores packages with names matching the given glob (Works only in combination with the 'bootstrap' command).",
   "  --force-publish      Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)",
   "  --yes                Skip all confirmation prompts",
   "  --repo-version       Specify repo version to publish",

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -66,7 +66,13 @@ export default class PackageUtilities {
   */
   static filterPackages(packages, glob, negate = false) {
     if (typeof glob !== "undefined") {
-      packages = packages.filter(pkg => negate ^ minimatch(pkg.name, glob));
+      packages = packages.filter(pkg => {
+        if (negate) {
+          return !minimatch(pkg.name, glob)
+        } else {
+          return minimatch(pkg.name, glob);
+        }
+      });
 
       if (!packages.length) {
         throw new Error(`No packages found that match '${glob}'`);

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -60,12 +60,13 @@ export default class PackageUtilities {
   *
   * @param {!Array.<Package>} packages The packages to filter
   * @param {String} glob The glob to match the package name against
+  * @param {Boolean} negate Negate glob pattern matches
   * @return {Array.<Package>} The packages with a name matching the glob
   * @throws in case a given glob would produce an empty list of packages
   */
-  static filterPackages(packages, glob) {
+  static filterPackages(packages, glob, negate = false) {
     if (typeof glob !== "undefined") {
-      packages = packages.filter(pkg => minimatch(pkg.name, glob));
+      packages = packages.filter(pkg => negate ^ minimatch(pkg.name, glob));
 
       if (!packages.length) {
         throw new Error(`No packages found that match '${glob}'`);

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -43,6 +43,10 @@ export default class Repository {
     return this.lernaJson && this.lernaJson.linkedFiles || {};
   }
 
+  get bootstrapConfig() {
+    return this.lernaJson && this.lernaJson.bootstrapConfig || {};
+  }
+
   isIndependent() {
     return this.version === "independent";
   }

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -1,5 +1,6 @@
 import FileSystemUtilities from "../FileSystemUtilities";
 import NpmUtilities from "../NpmUtilities";
+import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 import semver from "semver";
 import async from "async";
@@ -27,7 +28,9 @@ export default class BootstrapCommand extends Command {
     this.progressBar.init(this.packages.length);
     this.logger.info("Linking all dependencies");
 
-    async.parallelLimit(this.packages.map(pkg => done => {
+    const ignore = this.flags.ignore || this.repository.bootstrapConfig.ignore;
+
+    async.parallelLimit(PackageUtilities.filterPackages(this.packages, ignore, true).map(pkg => done => {
       async.series([
         cb => FileSystemUtilities.mkdirp(pkg.nodeModulesLocation, cb),
         cb => this.installExternalPackages(pkg, cb),

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -76,8 +76,8 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runPreparations();
 
       assertStubbedCalls([
-        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-          { args: ["npm install package-1@^0.0.0", { cwd: path.join(testDir, "packages/package-4") }] }
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "package-1@^0.0.0"], { cwd: path.join(testDir, "packages/package-4"), stdio: "ignore" }] }
         ]]
       ]);
 

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -66,6 +66,54 @@ describe("BootstrapCommand", () => {
         }
       }));
     });
+
+    it("should not bootstrap an ignored package", done => {
+      const bootstrapCommand = new BootstrapCommand([], {
+        ignore: "package-2"
+      });
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      assertStubbedCalls([
+        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+          { args: ["npm install package-1@^0.0.0", { cwd: path.join(testDir, "packages/package-4") }] }
+        ]]
+      ]);
+
+      bootstrapCommand.runCommand(exitWithCode(0, err => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.ok(!pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1")));
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
+
+    it("should not bootstrap ignored packages", done => {
+      const bootstrapCommand = new BootstrapCommand([], {
+        ignore: "package-@(3|4)"
+      });
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      bootstrapCommand.runCommand(exitWithCode(0, err => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.ok(!pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2")));
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
   });
 
   describe("external dependencies that haven't been installed", () => {

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -88,6 +88,17 @@ describe("PackageUtilities", () => {
         ["package-a-1", "package-a-2"]
       );
     });
+
+    it("should properly filter packages by negating the glob", () => {
+      assert.deepEqual(
+        PackageUtilities.filterPackages(packages, "package-3", true).map(pkg => pkg.name),
+        ["package-4", "package-a-1", "package-a-2"]
+      );
+      assert.deepEqual(
+        PackageUtilities.filterPackages(packages, "package-a-?", true).map(pkg => pkg.name),
+        ["package-3", "package-4"]
+      );
+    });
   });
 
 });


### PR DESCRIPTION
* Added `ignore` flag to CLI
* Check `bootstrapConfig.ignore` key in `lerna.json`

The CLI flag will override the `bootstrapConfig` option in `lerna.json`. Both the flag and the option accept a glob pattern of package names to ignore.

this is the new PR from my company's github org