### PR TITLE
WIP: Make tests pass on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
-    "cpr": "^1.1.1",
     "eslint": "^2.3.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "fs-extra": "^0.30.0"
   }
 }

--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -43,7 +43,7 @@ export default class FileSystemUtilities {
 
   @logger.logifySync
   static readFileSync(filePath) {
-    return fs.readFileSync(filePath).toString().trim();
+    return fs.readFileSync(filePath, "utf-8").toString().trim();
   }
 
   @logger.logifyAsync

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -83,7 +83,7 @@ export default class BootstrapCommand extends Command {
     }, null, "  ");
 
     const prefix = this.repository.linkedFiles.prefix || "";
-    const indexJsFileContents = prefix + "module.exports = require(" + JSON.stringify(src) + ");";
+    const indexJsFileContents = prefix + "module.exports = require(" +  path.join(JSON.stringify(src)) + ");";
 
     FileSystemUtilities.writeFile(destPackageJsonLocation, packageJsonFileContents, err => {
       if (err) {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -7,6 +7,7 @@ import Command from "../Command";
 import semver from "semver";
 import async from "async";
 import path from "path";
+import { EOL } from "os";
 
 export default class PublishCommand extends Command {
   initialize(callback) {
@@ -126,7 +127,7 @@ export default class PublishCommand extends Command {
         let message = "Successfully published:";
 
         this.updates.forEach(update => {
-          message += `\n - ${update.package.name}@${update.package.version}`;
+          message += `${EOL} - ${update.package.name}@${update.package.version}`;
         });
 
         this.logger.success(message);
@@ -226,7 +227,7 @@ export default class PublishCommand extends Command {
     this.logger.info("Changes:");
     this.logger.info(this.updates.map((update) => {
       return `- ${update.package.name}: ${update.package.version} => ${this.updatesVersions[update.package.name]}`;
-    }).join("\n"));
+    }).join(EOL));
     this.logger.newLine();
 
     if (!this.flags.yes) {
@@ -302,11 +303,11 @@ export default class PublishCommand extends Command {
   }
 
   gitCommitAndTagVersionForUpdates() {
-    let message = "Publish\n";
+    let message = "Publish" + EOL;
 
     const tags = this.updates.map(update => {
       const tag = `${update.package.name}@${this.updatesVersions[update.package.name]}`;
-      message += `\n - ${tag}`;
+      message += `${EOL} - ${tag}`;
       return tag;
     });
 

--- a/test/ChildProcessUtilities.js
+++ b/test/ChildProcessUtilities.js
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { EOL } from "os";
 
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
 
@@ -12,7 +13,7 @@ describe("ChildProcessUtilities", () => {
   describe(".exec()", () => {
     it("should execute a command in a child process and call the callback with the result", done => {
       ChildProcessUtilities.exec("echo foo", null, (stderr, stdout) => {
-        assert.equal(stdout, "foo\n");
+        assert.equal(stdout, "foo" + EOL);
         done(stderr);
       });
     });

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -9,7 +9,7 @@ describe("PackageUtilities", () => {
     it("should append the packages path to the repo path given", () => {
       assert.equal(
         PackageUtilities.getPackagesPath("/path/to/repo"),
-        "/path/to/repo/packages"
+        path.join("/path/to/repo/packages")
       );
     });
   });
@@ -18,7 +18,7 @@ describe("PackageUtilities", () => {
     it("should append the package path to the packages path given", () => {
       assert.equal(
         PackageUtilities.getPackagePath("/path/to/repo/packages", "my-package"),
-        "/path/to/repo/packages/my-package"
+        path.join("/path/to/repo/packages/my-package")
       );
     });
   });
@@ -27,7 +27,7 @@ describe("PackageUtilities", () => {
     it("should append the package config path to the packages path given", () => {
       assert.equal(
         PackageUtilities.getPackageConfigPath("/path/to/repo/packages", "my-package"),
-        "/path/to/repo/packages/my-package/package.json"
+        path.join("/path/to/repo/packages/my-package/package.json")
       );
     });
   });

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -2,6 +2,7 @@ import pathExists from "path-exists";
 import assert from "assert";
 import path from "path";
 import fs from "fs";
+import { EOL } from "os";
 
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import PromptUtilities from "../src/PromptUtilities";
@@ -56,19 +57,19 @@ describe("PublishCommand", () => {
           { args: ["cd " + path.join(testDir, "packages/package-4") + " && npm publish --tag lerna-temp"] }
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 latest"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp"] },
           { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
-          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
           { args: ["npm dist-tag add package-3@1.0.1 latest"] },
 
-          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.1 latest"] },
 
@@ -83,7 +84,7 @@ describe("PublishCommand", () => {
 
         try {
           assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8"), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
           assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
@@ -139,7 +140,7 @@ describe("PublishCommand", () => {
           { args: ["git add " + path.join(testDir, "packages/package-2/package.json")] },
           { args: ["git add " + path.join(testDir, "packages/package-3/package.json")] },
           { args: ["git add " + path.join(testDir, "packages/package-4/package.json")] },
-          { args: ["git commit -m \"$(echo \"Publish\n\n - package-1@1.0.1\n - package-2@1.1.0\n - package-3@2.0.0\n - package-4@1.1.0\")\""] },
+          { args: ["git commit -m \"$(echo \"Publish" + EOL + EOL + " - package-1@1.0.1" + EOL + " - package-2@1.1.0" + EOL + " - package-3@2.0.0" + EOL + " - package-4@1.1.0\")\""] },
           { args: ["git tag package-1@1.0.1"] },
           { args: ["git tag package-2@1.1.0"] },
           { args: ["git tag package-3@2.0.0"] },
@@ -152,19 +153,19 @@ describe("PublishCommand", () => {
           { args: ["cd " + path.join(testDir, "packages/package-4") + " && npm publish --tag lerna-temp"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 latest"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp"] },
           { args: ["npm dist-tag add package-2@1.1.0 latest"] },
 
-          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 2.0.0\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 2.0.0" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
           { args: ["npm dist-tag add package-3@2.0.0 latest"] },
 
-          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.1.0 latest"] },
 
@@ -234,19 +235,19 @@ describe("PublishCommand", () => {
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git checkout -- packages/*/package.json"] },
 
-          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0-canary.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.0-canary.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp"] },
           { args: ["npm dist-tag add package-2@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.0-canary.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
           { args: ["npm dist-tag add package-3@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.0-canary.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.0-alpha.81e3b443 canary"] },
 
@@ -261,7 +262,7 @@ describe("PublishCommand", () => {
 
         try {
           assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.0\"\n}\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8"), "{" + EOL + "  \"lerna\": \"__TEST_VERSION__\"," + EOL + "  \"version\": \"1.0.0\"" + EOL + "}" + EOL + "");
 
           // The following wouldn't be the actual results of a canary release
           // because `git checkout --` would have removed the file changes.
@@ -323,19 +324,19 @@ describe("PublishCommand", () => {
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git checkout -- packages/*/package.json"] },
 
-          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0-canary.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 2.0.0-alpha.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 2.0.0-canary.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp"] },
           { args: ["npm dist-tag add package-2@2.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 3.0.0-alpha.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 3.0.0-canary.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
           { args: ["npm dist-tag add package-3@3.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 4.0.0-alpha.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 4.0.0-canary.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@4.0.0-alpha.81e3b443 canary"] },
 
@@ -408,19 +409,19 @@ describe("PublishCommand", () => {
           { args: ["cd " + path.join(testDir, "packages/package-4") + " && npm publish --tag lerna-temp"] }
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 latest"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp"] },
           { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
-          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
           { args: ["npm dist-tag add package-3@1.0.1 latest"] },
 
-          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.1 latest"] }
         ]],
@@ -431,7 +432,7 @@ describe("PublishCommand", () => {
 
         try {
           assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8"), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
           assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
@@ -581,7 +582,7 @@ describe("PublishCommand", () => {
       testDir = initFixture("PublishCommand/normal", done);
     });
 
-    it("should publish the changed packages", done => {
+    it("should publish the changed packages with npm tag", done => {
       const publishCommand = new PublishCommand([], {
         npmTag: "prerelease"
       });
@@ -615,19 +616,19 @@ describe("PublishCommand", () => {
           { args: ["cd " + path.join(testDir, "packages/package-4") + " && npm publish --tag lerna-temp"] }
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 prerelease"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp"] },
           { args: ["npm dist-tag add package-2@1.0.1 prerelease"] },
 
-          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
           { args: ["npm dist-tag add package-3@1.0.1 prerelease"] },
 
-          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.1 prerelease"] },
 
@@ -642,7 +643,7 @@ describe("PublishCommand", () => {
 
         try {
           assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8"), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
           assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");

--- a/test/_initExternalFixture.js
+++ b/test/_initExternalFixture.js
@@ -1,7 +1,7 @@
 import rimraf from "rimraf";
 import child from "child_process";
 import path from "path";
-import cpr from "cpr";
+import fse from "fs-extra";
 
 const tmpDir = path.resolve(__dirname, "../tmp");
 
@@ -19,11 +19,9 @@ export default function initExternalFixture(fixturePath, callback) {
 
   createdDirectories.push(testDir);
 
-  cpr(fixtureDir, testDir, {
-    confirm: true
-  }, err => {
+fse.copy(fixtureDir, testDir, err => {
     if (err) return callback(err);
-    child.execSync("git init . && git add -A && git commit -m 'Init external commit'", {
+    child.execSync("git init . && git add -A && git commit -m \"Init external commit\"", {
       cwd: testDir
     });
     callback();

--- a/test/_initExternalFixture.js
+++ b/test/_initExternalFixture.js
@@ -19,7 +19,7 @@ export default function initExternalFixture(fixturePath, callback) {
 
   createdDirectories.push(testDir);
 
-fse.copy(fixtureDir, testDir, err => {
+  fse.copy(fixtureDir, testDir, err => {
     if (err) return callback(err);
     child.execSync("git init . && git add -A && git commit -m \"Init external commit\"", {
       cwd: testDir

--- a/test/_initFixture.js
+++ b/test/_initFixture.js
@@ -29,7 +29,7 @@ export default function initFixture(fixturePath, callback) {
   }, err => {
     if (err) return callback(err);
     process.chdir(testDir);
-    child.execSync("git init . && git add -A && git commit -m 'Init commit'");
+    child.execSync("git init . && git add -A && git commit -m \"Init commit\"");
     callback();
   });
 

--- a/test/_initFixture.js
+++ b/test/_initFixture.js
@@ -1,7 +1,7 @@
 import rimraf from "rimraf";
 import child from "child_process";
 import path from "path";
-import cpr from "cpr";
+import fse from "fs-extra";
 
 const tmpDir = path.resolve(__dirname, "../tmp");
 const originalCwd = process.cwd();
@@ -24,9 +24,7 @@ export default function initFixture(fixturePath, callback) {
 
   createdDirectories.push(testDir);
 
-  cpr(fixtureDir, testDir, {
-    confirm: true
-  }, err => {
+  fse.copy(fixtureDir, testDir,  err => {
     if (err) return callback(err);
     process.chdir(testDir);
     child.execSync("git init . && git add -A && git commit -m \"Init commit\"");


### PR DESCRIPTION
Still not finished with this, but wanted to get the PR out there for people to look at and make sure I'm not making any *nix issues by fixing on Windows.

Originally had 16 failing tests with a raw pull down of lerna, I've got it down to 3 failing tests now on Windows, but these are proving a bit trickier to solve than your basic slash/end-of-line bugs.

These are the remaining 3 failing tests:
![windows-errors](https://cloud.githubusercontent.com/assets/6899011/15659253/8a09dc9e-268d-11e6-8768-8a3654d8efd6.JPG)

Thing is, the exact tests that it fails on is random. Each time I run it I will get a different test that errors out with `Unexpected end of JSON input` and a different test that errors out with `done() invoked with non-Error: Error: ENOENT: no such file or directory...`

I *think* this has something to do with `cpr` module, but I need to dig more.