### PR TITLE
Use alpha version instead of canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ $ lerna publish --canary
 
 The `canary` flag will publish packages after every successful merge using the sha as part of the tag.
 
-It will take the current `version` and append the sha as the new `version`. ex: `1.0.0-canary.81e3b443`.
+It will take the current `version` and append the sha as the new `version`. ex: `1.0.0-alpha.81e3b443`.
 
 More specifically, `canary` flag will append the current git sha to the current `version` and publish it.
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -178,7 +178,7 @@ export default class PublishCommand extends Command {
   }
 
   getCanaryVersionSuffix() {
-    return "-canary." + GitUtilities.getCurrentSHA().slice(0, 8);
+    return "-alpha." + GitUtilities.getCurrentSHA().slice(0, 8);
   }
 
   promptVersion(packageName, currentVersion, callback) {

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -234,21 +234,21 @@ describe("PublishCommand", () => {
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git checkout -- packages/*/package.json"] },
 
-          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0-canary.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
-          { args: ["npm dist-tag add package-1@1.0.0-canary.81e3b443 canary"] },
+          { args: ["npm dist-tag add package-1@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.0-canary.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@1.0.0-canary.81e3b443 canary"] },
+          { args: ["npm dist-tag add package-2@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.0-canary.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
-          { args: ["npm dist-tag add package-3@1.0.0-canary.81e3b443 canary"] },
+          { args: ["npm dist-tag add package-3@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.0-canary.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
-          { args: ["npm dist-tag add package-4@1.0.0-canary.81e3b443 canary"] },
+          { args: ["npm dist-tag add package-4@1.0.0-alpha.81e3b443 canary"] },
 
           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
           { args: ["git push origin master"] },
@@ -267,13 +267,13 @@ describe("PublishCommand", () => {
           // because `git checkout --` would have removed the file changes.
           // However, this is what would've been published to npm so it's
           // useful to test.
-          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0-canary.81e3b443");
-          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.0-canary.81e3b443");
-          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.0-canary.81e3b443");
-          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.0-canary.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.0-alpha.81e3b443");
 
-          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0-canary.81e3b443");
-          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.0-canary.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.0-alpha.81e3b443");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
           done();
@@ -323,21 +323,21 @@ describe("PublishCommand", () => {
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git checkout -- packages/*/package.json"] },
 
-          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0-canary.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0-alpha.81e3b443\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
-          { args: ["npm dist-tag add package-1@1.0.0-canary.81e3b443 canary"] },
+          { args: ["npm dist-tag add package-1@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 2.0.0-canary.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 2.0.0-alpha.81e3b443\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@2.0.0-canary.81e3b443 canary"] },
+          { args: ["npm dist-tag add package-2@2.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 3.0.0-canary.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 3.0.0-alpha.81e3b443\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
-          { args: ["npm dist-tag add package-3@3.0.0-canary.81e3b443 canary"] },
+          { args: ["npm dist-tag add package-3@3.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 4.0.0-canary.81e3b443\nstable: 1.0.0" },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 4.0.0-alpha.81e3b443\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
-          { args: ["npm dist-tag add package-4@4.0.0-canary.81e3b443 canary"] },
+          { args: ["npm dist-tag add package-4@4.0.0-alpha.81e3b443 canary"] },
 
           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
           { args: ["git push origin master"] },
@@ -355,13 +355,13 @@ describe("PublishCommand", () => {
           // because `git checkout --` would have removed the file changes.
           // However, this is what would've been published to npm so it's
           // useful to test.
-          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0-canary.81e3b443");
-          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "2.0.0-canary.81e3b443");
-          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "3.0.0-canary.81e3b443");
-          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "4.0.0-canary.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "2.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "3.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "4.0.0-alpha.81e3b443");
 
-          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0-canary.81e3b443");
-          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^2.0.0-canary.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^2.0.0-alpha.81e3b443");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
           done();


### PR DESCRIPTION
Fixes #166 

Could potentially be an option in lernaConfig with a default of alpha? I think its fine to do just this atm though.

This is breaking change if people have been using it before though?