### PR TITLE
[Feature] Update bootstrap to link external dependencies when present in the root node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+!test/**/node_modules
 *.log
 lib
 tmp

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -8,6 +8,7 @@ export default class Repository {
 
     this.lernaJsonLocation = path.join(this.rootPath, "lerna.json");
     this.packageJsonLocation = path.join(this.rootPath, "package.json");
+    this.nodeModulesLocation = path.join(this.rootPath, "node_modules");
     this.packagesLocation = path.join(this.rootPath, "packages");
 
     // Legacy

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -25,7 +25,8 @@ describe("BootstrapCommand", () => {
 
     assertStubbedCalls([
       [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-        { args: ["npm install package-1@^0.0.0", { cwd: path.join(testDir, "packages/package-4") }] }
+        { args: ["npm install external-package-1@^2.0.0", { cwd: path.join(testDir, "packages/package-2") }] },
+        { args: ["npm install package-1@^0.0.0 external-package-2@^1.0.0", { cwd: path.join(testDir, "packages/package-4") }] },
       ]]
     ]);
 
@@ -35,27 +36,52 @@ describe("BootstrapCommand", () => {
       try {
         assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
 
+        // node_modules should have been created for every package
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-1/node_modules")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-4/node_modules")));
 
+        // package-2 should have installed package-1
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")));
 
+        // package-2 should not have installed external-package-1 because of a version mismatch
+        assert.ok(!pathExists.sync(path.join(testDir, "packages/package-2/node_modules/external-package-1")));
+
+        // package-3 should have installed package-2 and external-package-1
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")));
         assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")));
+        assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/external-package-1")));
+        assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/external-package-1/index.js")));
+        assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/external-package-1/package.json")));
 
-        // Should not exist because mis-matched version
+        // package-4 should have installed external-package-1
+        assert.ok(pathExists.sync(path.join(testDir, "packages/package-4/node_modules/external-package-1")));
+        assert.ok(pathExists.sync(path.join(testDir, "packages/package-4/node_modules/external-package-1/index.js")));
+        assert.ok(pathExists.sync(path.join(testDir, "packages/package-4/node_modules/external-package-1/package.json")));
+
+        // package-4 should not have installed package-1 because of a version mismatch, and should not have installed external-package-2 because it is not present in the root node_modules directory
         assert.ok(!pathExists.sync(path.join(testDir, "packages/package-4/node_modules/package-1")));
+        assert.ok(!pathExists.sync(path.join(testDir, "packages/package-4/node_modules/external-package-2")));
 
+        // package-2 -> package-1
         assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-1") + "\");\n");
         assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\"\n}\n");
 
+        // package-3 -> package-2
         assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-2") + "\");\n");
         assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\"\n}\n");
+
+        // package-3 -> external-package-1
+        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/external-package-1/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "node_modules/external-package-1") + "\");\n");
+        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/external-package-1/package.json")).toString(), "{\n  \"name\": \"external-package-1\",\n  \"version\": \"1.0.0\"\n}\n");
+
+        // package-4 -> external-package-1
+        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-4/node_modules/external-package-1/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "node_modules/external-package-1") + "\");\n");
+        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-4/node_modules/external-package-1/package.json")).toString(), "{\n  \"name\": \"external-package-1\",\n  \"version\": \"1.0.0\"\n}\n");
 
         done();
       } catch (err) {

--- a/test/fixtures/BootstrapCommand/basic/node_modules/external-package-1/package.json
+++ b/test/fixtures/BootstrapCommand/basic/node_modules/external-package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "external-package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/basic/package.json
+++ b/test/fixtures/BootstrapCommand/basic/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "independent"
+  "name": "independent",
+  "dependencies": {
+    "external-package-1": "^1.0.0"
+  }
 }

--- a/test/fixtures/BootstrapCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-2/package.json
@@ -2,6 +2,7 @@
   "name": "package-2",
   "version": "1.0.0",
   "dependencies": {
-    "package-1": "^1.0.0"
+    "package-1": "^1.0.0",
+    "external-package-1": "^2.0.0"
   }
 }

--- a/test/fixtures/BootstrapCommand/basic/packages/package-3/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-3/package.json
@@ -2,6 +2,7 @@
   "name": "package-3",
   "version": "1.0.0",
   "devDependencies": {
-    "package-2": "^1.0.0"
+    "package-2": "^1.0.0",
+    "external-package-1": "^1.0.0"
   }
 }

--- a/test/fixtures/BootstrapCommand/basic/packages/package-4/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-4/package.json
@@ -2,6 +2,8 @@
   "name": "package-4",
   "version": "1.0.0",
   "dependencies": {
-    "package-1": "^0.0.0"
+    "package-1": "^0.0.0",
+    "external-package-1": "^1.0.0",
+    "external-package-2": "^1.0.0"
   }
 }


### PR DESCRIPTION
Resolves https://github.com/lerna/lerna/issues/176

Before installing external dependencies for packages, this makes bootstrap check to see if there is a package in the root node_modules directory that will satisfy the dependency.  If there is, it is linked in the same way that the local packages are cross linked.  If there is not, the package is installed through npm normally.
