### PR TITLE
Emit partial stderr output from child on maxBuffer exceeded

### DIFF
--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -4,6 +4,14 @@ export default class ChildProcessUtilities {
   static exec(command, opts, callback) {
     return child.exec(command, opts, (err, stdout, stderr) => {
       if (err != null) {
+
+        // If the error from `child.exec` is just that the child process
+        // emitted too much on stderr, then that stderr output is likely to
+        // be useful.
+        if (/^stderr maxBuffer exceeded/.test(err.message)) {
+          err = `Error: ${err.message}.  Partial output follows:\n\n${stderr}`;
+        }
+
         callback(err || stderr);
       } else {
         callback(null, stdout);


### PR DESCRIPTION
If the error from `child.exec` is just that the child process emitted too much
on stderr, then that stderr output is likely to be useful.  Emit as much as
possible, with a warning that it's partial output.