### PR TITLE
Wait for child processes to exit before exiting from parent

### DIFF
--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -46,7 +46,7 @@ export default class ChildProcessUtilities {
     let stderr = "";
 
     const childProcess = ChildProcessUtilities.registerChild(
-      child.spawn(command, args, objectAssign({
+      spawn(command, args, objectAssign({
         stdio: "inherit"
       }, opts))
         .on("error", () => {})

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -4,8 +4,8 @@ import objectAssign from "object-assign";
 import syncExec from "sync-exec";
 import {EventEmitter} from "events";
 
-// This will hold ChildProcess objects until they exit.
-const children = [];
+// Keep track of how many live children we have.
+let children = 0;
 
 // This is used to alert listeners when all children have exited.
 const emitter = new EventEmitter;
@@ -64,10 +64,10 @@ export default class ChildProcessUtilities {
   }
 
   static registerChild(child) {
-    children.push(child);
+    children++;
     child.on("exit", () => {
-      children.splice(children.indexOf(child), 1);
-      if (children.length === 0) {
+      children--;
+      if (children === 0) {
         emitter.emit("empty");
       }
     });
@@ -75,7 +75,7 @@ export default class ChildProcessUtilities {
   }
 
   static getChildProcessCount() {
-    return children.length;
+    return children;
   }
 
   static onAllExited(callback) {

--- a/src/Command.js
+++ b/src/Command.js
@@ -1,3 +1,4 @@
+import ChildProcessUtilities from "./ChildProcessUtilities";
 import FileSystemUtilities from "./FileSystemUtilities";
 import PackageUtilities from "./PackageUtilities";
 import ExitHandler from "./ExitHandler";
@@ -147,12 +148,26 @@ export default class Command {
       exitHandler.writeLogs();
     }
 
-    if (callback) {
-      callback(err, code);
+    const finish = function() {
+      if (callback) {
+        callback(err, code);
+      }
+
+      if (process.env.NODE_ENV !== "test") {
+        process.exit(code);
+      }
     }
 
-    if (process.env.NODE_ENV !== "test") {
-      process.exit(code);
+    const childProcessCount = ChildProcessUtilities.getChildProcessCount();
+    if (childProcessCount > 0) {
+      logger.info(
+        `Waiting for ${childProcessCount} child ` +
+        `process${childProcessCount === 1 ? "" : "es"} to exit. ` +
+        "CTRL-C to exit immediately."
+      );
+      ChildProcessUtilities.onAllExited(finish);
+    } else {
+      finish();
     }
   }
 

--- a/src/Command.js
+++ b/src/Command.js
@@ -156,7 +156,7 @@ export default class Command {
       if (process.env.NODE_ENV !== "test") {
         process.exit(code);
       }
-    }
+    };
 
     const childProcessCount = ChildProcessUtilities.getChildProcessCount();
     if (childProcessCount > 0) {

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -55,7 +55,7 @@ describe("RunCommand", () => {
 
   });
 
-  it("should wait for children to exit", done => {
+  it("should wait for children to exit", (done) => {
     const runCommand = new RunCommand(["my-script"], {});
 
     runCommand.runValidations();
@@ -69,10 +69,10 @@ describe("RunCommand", () => {
     });
 
     let lastInfo;
-    stub(logger, "info", message => lastInfo = message);
+    stub(logger, "info", (message) => lastInfo = message);
 
     let haveExited = false;
-    runCommand.runCommand(exitWithCode(0, err => {
+    runCommand.runCommand(exitWithCode(0, (err) => {
       assert.equal(lastInfo, "Waiting for 2 child processes to exit. CTRL-C to exit immediately.");
       haveExited = true;
       done(err);
@@ -80,6 +80,6 @@ describe("RunCommand", () => {
 
     assert.equal(haveExited, false);
 
-    children.forEach(child => child.emit("exit"));
+    children.forEach((child) => child.emit("exit"));
   });
 });

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -5,7 +5,9 @@ import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import exitWithCode from "./_exitWithCode";
 import initFixture from "./_initFixture";
 import RunCommand from "../src/commands/RunCommand";
+import logger from "../src/logger";
 import stub from "./_stub";
+import FakeChild from "./_fakeChild";
 
 describe("RunCommand", () => {
   let testDir;
@@ -50,5 +52,34 @@ describe("RunCommand", () => {
       assert.deepEqual(ranInPackages, ["package-1"]);
       done();
     }));
+
+  });
+
+  it("should wait for children to exit", done => {
+    const runCommand = new RunCommand(["my-script"], {});
+
+    runCommand.runValidations();
+    runCommand.runPreparations();
+
+    const children = [];
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+      children.unshift(new FakeChild);
+      ChildProcessUtilities.registerChild(children[0]);
+      callback();
+    });
+
+    let lastInfo;
+    stub(logger, "info", message => lastInfo = message);
+
+    let haveExited = false;
+    runCommand.runCommand(exitWithCode(0, err => {
+      assert.equal(lastInfo, "Waiting for 2 child processes to exit. CTRL-C to exit immediately.");
+      haveExited = true;
+      done(err);
+    }));
+
+    assert.equal(haveExited, false);
+
+    children.forEach(child => child.emit("exit"));
   });
 });

--- a/test/_fakeChild.js
+++ b/test/_fakeChild.js
@@ -1,0 +1,4 @@
+import {EventEmitter} from "events";
+
+export default class FakeChild extends EventEmitter {
+}


### PR DESCRIPTION
I ran into this with `lerna run test`.  I have one test that fails quickly and another _expensive_ test that keeps on chugging after lerna exits.

With this patch I get this:
![image](https://cloud.githubusercontent.com/assets/115908/15910665/ccc7153e-2d80-11e6-9154-c3f24546b124.png)

Then I can just `CTRL-C` instead of having to track down orphaned children and kill them.