### PR TITLE
Add `lerna clean` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ Check which `packages` have changed since the last release (the last git tag).
 
 Lerna determines the last git tag created and runs `git diff --name-only v6.8.1` to get all files changed since that tag. It then returns an array of packages that have an updated file.
 
+### clean
+
+```sh
+$ lerna clean
+```
+
+Remove the `node_modules` directory from all packages.
+
 ### diff
 
 ```sh

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -12,6 +12,7 @@ var cli = meow([
   "  bootstrap  Link together local packages and npm install remaining package dependencies",
   "  publish    Publish updated packages to npm",
   "  updated    Check which packages have changed since the last release",
+  "  clean      Remove the node_modules directory from all packages",
   "  diff       Diff all packages or a single package since the last release",
   "  init       Initialize a lerna repo",
   "  run        Run npm script in each package",

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -5,17 +5,21 @@ import progressBar from "../progressBar";
 
 export default class CleanCommand extends Command {
   initialize(callback) {
-    this.logger.info(`About remove the following directories:\n${
-      this.packages.map(pkg => "- " + pkg.nodeModulesLocation).join("\n")
-    }`);
-    PromptUtilities.confirm("Proceed?", confirmed => {
-      if (confirmed) {
-        callback(null, true);
-      } else {
-        this.logger.info("Okay bye!");
-        callback(null, false);
-      }
-    });
+    if (this.flags.yes) {
+      callback(null, true);
+    } else {
+      this.logger.info(`About remove the following directories:\n${
+        this.packages.map(pkg => "- " + pkg.nodeModulesLocation).join("\n")
+      }`);
+      PromptUtilities.confirm("Proceed?", confirmed => {
+        if (confirmed) {
+          callback(null, true);
+        } else {
+          this.logger.info("Okay bye!");
+          callback(null, false);
+        }
+      });
+    }
   }
 
   execute(callback) {

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -1,0 +1,32 @@
+import Command from "../Command";
+import ChildProcessUtilities from "../ChildProcessUtilities";
+import PromptUtilities from "../PromptUtilities";
+import progressBar from "../progressBar";
+
+export default class CleanCommand extends Command {
+  initialize(callback) {
+    this.logger.info(`About remove the following directories:\n${
+      this.packages.map(pkg => "- " + pkg.nodeModulesLocation).join("\n")
+    }`);
+    PromptUtilities.confirm("Proceed?", confirmed => {
+      if (confirmed) {
+        callback(null, true);
+      } else {
+        this.logger.info("Okay bye!");
+        callback(null, false);
+      }
+    });
+  }
+
+  execute(callback) {
+    progressBar.init(this.packages.length);
+    this.packages.forEach(pkg => {
+      progressBar.tick(pkg.name);
+
+      ChildProcessUtilities.execSync("rm -rf " + pkg.nodeModulesLocation);
+    });
+    progressBar.terminate();
+    this.logger.info("All clean!");
+    callback(null, true);
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import BootstrapCommand from "./commands/BootstrapCommand";
 import PublishCommand from "./commands/PublishCommand";
 import UpdatedCommand from "./commands/UpdatedCommand";
+import CleanCommand from "./commands/CleanCommand";
 import DiffCommand from "./commands/DiffCommand";
 import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
@@ -10,6 +11,7 @@ export const __commands__ = {
   bootstrap: BootstrapCommand,
   publish: PublishCommand,
   updated: UpdatedCommand,
+  clean: CleanCommand,
   diff: DiffCommand,
   init: InitCommand,
   run: RunCommand,

--- a/test/CleanCommand.js
+++ b/test/CleanCommand.js
@@ -40,4 +40,16 @@ describe("CleanCommand", () => {
 
     cleanCommand.runCommand(exitWithCode(0, done));
   });
+
+  it("should be possible to skip asking for confirmation", done => {
+    const cleanCommand = new CleanCommand([], {
+      yes: true
+    });
+
+    cleanCommand.runValidations();
+    cleanCommand.runPreparations();
+
+    cleanCommand.initialize(done);
+  });
+
 });

--- a/test/CleanCommand.js
+++ b/test/CleanCommand.js
@@ -1,0 +1,43 @@
+import assert from "assert";
+import path from "path";
+
+import ChildProcessUtilities from "../src/ChildProcessUtilities";
+import exitWithCode from "./_exitWithCode";
+import initFixture from "./_initFixture";
+import CleanCommand from "../src/commands/CleanCommand";
+import PromptUtilities from "../src/PromptUtilities";
+import stub from "./_stub";
+import assertStubbedCalls from "./_assertStubbedCalls";
+
+describe("CleanCommand", () => {
+  let testDir;
+
+  beforeEach(done => {
+    testDir = initFixture("CleanCommand/basic", done);
+  });
+
+  it("should rm -rf the node_modules", done => {
+    const cleanCommand = new CleanCommand([], {});
+
+    assertStubbedCalls([
+      [PromptUtilities, "confirm", { valueCallback: true }, [
+        { args: ["Proceed?"], returns: true }
+      ]],
+    ]);
+
+    cleanCommand.runValidations();
+    cleanCommand.runPreparations();
+
+    let curPkg = 1;
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+      const rmDir = path.join(testDir, "packages/package-" + curPkg, "node_modules");
+
+      assert.equal(command, "rm -rf " + rmDir)
+
+      curPkg++;
+      callback();
+    });
+
+    cleanCommand.runCommand(exitWithCode(0, done));
+  });
+});

--- a/test/CleanCommand.js
+++ b/test/CleanCommand.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 import path from "path";
 
-import ChildProcessUtilities from "../src/ChildProcessUtilities";
+import FileSystemUtilities from "../src/FileSystemUtilities";
 import exitWithCode from "./_exitWithCode";
 import initFixture from "./_initFixture";
 import CleanCommand from "../src/commands/CleanCommand";
@@ -29,10 +29,12 @@ describe("CleanCommand", () => {
     cleanCommand.runPreparations();
 
     let curPkg = 1;
-    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
-      const rmDir = path.join(testDir, "packages/package-" + curPkg, "node_modules");
+    stub(FileSystemUtilities, "rimraf", (actualDir, callback) => {
+      const expectedDir = path.join(
+        testDir, "packages/package-" + curPkg, "node_modules"
+      );
 
-      assert.equal(command, "rm -rf " + rmDir)
+      assert.equal(actualDir, expectedDir)
 
       curPkg++;
       callback();

--- a/test/fixtures/CleanCommand/basic/lerna.json
+++ b/test/fixtures/CleanCommand/basic/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/CleanCommand/basic/package.json
+++ b/test/fixtures/CleanCommand/basic/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/CleanCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/CleanCommand/basic/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/CleanCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/CleanCommand/basic/packages/package-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-2",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Removes the `node_modules` directory from all packages.

Closes #195.

Or would [`lerna nuke`](https://github.com/lerna/lerna/issues/195#issuecomment-224743936) be better? 👹 