### PR TITLE
Docs update exec run

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,9 @@ Running `lerna` without arguments will show all commands/options.
 - `version`: the current version of the repository.
 - `publishConfig.ignore`: an array of globs that won't be included in `lerna updated/publish`. Use this to prevent publishing a new version unnecessarily for changes, such as fixing a `README.md` typo.
 
-### --concurrency
+### Flags
+
+#### --concurrency
 
 How many threads to use when Lerna parallelizes the tasks (defaults to `4`)
 
@@ -387,7 +389,7 @@ How many threads to use when Lerna parallelizes the tasks (defaults to `4`)
 $ lerna publish --concurrency 1
 ```
 
-### --scope [glob]
+#### --scope [glob]
 
 Allows to scope an command only affect a subset of packages.
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ List all of the public packages in the current Lerna repo.
 ### run
 
 ```sh
-$ lerna run [script] // runs npm run my-script in all packages that have it
+$ lerna run [script] # runs npm run my-script in all packages that have it
 $ lerna run test
 $ lerna run build
 ```
@@ -329,7 +329,7 @@ $ lerna run --scope my-component test
 ### exec
 
 ```sh
-$ lerna exec -- [command] // runs the command in all packages
+$ lerna exec -- [command] # runs the command in all packages
 $ lerna exec -- rm -rf ./node_modules
 $ lerna exec -- protractor conf.js
 ```

--- a/README.md
+++ b/README.md
@@ -318,6 +318,40 @@ $ lerna run build
 
 Run an [npm script](https://docs.npmjs.com/misc/scripts) in each package that contains that script.
 
+`lerna run` respects the `--concurrency` flag (see below).
+
+`lerna run` respects the `--scope` flag (see below).
+
+```sh
+$ lerna run --scope my-component test
+```
+
+### exec
+
+```sh
+$ lerna exec -- [command] // runs the command in all packages
+$ lerna exec -- rm -rf ./node_modules
+$ lerna exec -- protractor conf.js
+```
+
+Run an arbitrary command in each package.
+
+`lerna exec` respects the `--concurrency` flag (see below).
+
+`lerna exec` respects the `--scope` flag (see below).
+
+```sh
+$ lerna exec --scope my-component -- ls -la
+```
+
+> Hint: The commands are spawned in parallel, using the concurrency given.
+> The output is piped through, so not deterministic.
+> If you want to run the command in one package after another, use it like this:
+
+```sh
+$ lerna exec --concurrency 1 -- ls -la
+```
+
 ## Misc
 
 Lerna will log to a `lerna-debug.log` file (same as `npm-debug.log`) when it encounters an error running a command.
@@ -345,11 +379,25 @@ Running `lerna` without arguments will show all commands/options.
 - `version`: the current version of the repository.
 - `publishConfig.ignore`: an array of globs that won't be included in `lerna updated/publish`. Use this to prevent publishing a new version unnecessarily for changes, such as fixing a `README.md` typo.
 
-#### --concurrency
+### --concurrency
 
+How many threads to use when Lerna parallelizes the tasks (defaults to `4`)
 
 ```sh
 $ lerna publish --concurrency 1
 ```
 
-How many threads to use when Lerna parallelizes the tasks (defaults to `4`)
+### --scope [glob]
+
+Allows to scope an command only affect a subset of packages.
+
+```sh
+$ lerna exec --scope my-component -- ls -la
+```
+
+```sh
+$ lerna run --scope toolbar-* -- ls -la
+```
+
+> Hint: The glob is matched against the package name defined in `package.json`,
+> not the directory name the package lives in.

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -29,7 +29,7 @@ export default class ExecCommand extends Command {
   execute(callback) {
     async.parallelLimit(this.packages.map(pkg => cb => {
       this.runCommandInPackage(pkg, cb);
-    }), 4, callback);
+    }), this.concurrency, callback);
   }
 
   runCommandInPackage(pkg, callback) {


### PR DESCRIPTION
Adds information about `lerna exec` the `--scope` flag and fixes `lerna exec` to respect `--concurrency`.

@hzoo PTAL

refs #152 