### PR TITLE
Add --skip-npm flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,21 @@ When run with this flag, `publish` will publish to npm without running any of th
 
 > Only publish to npm; skip committing, tagging, and pushing git changes (this only affects publish).
 
+#### --skip-npm
+
+```sh
+$ lerna publish --skip-npm
+```
+
+When run with this flag, `publish` will update all `package.json` package
+versions and dependency versions, but it will not actually publish the
+packages to npm.
+
+This flag can be combined with `--skip-git` to _just_ update versions and
+dependencies, without comitting, tagging, pushing or publishing.
+
+> Only update versions and dependencies; don't actually publish (this only affects publish).
+
 #### --force-publish [packages]
 
 ```sh

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -22,6 +22,7 @@ var cli = meow([
   "  --independent, -i    Version packages independently",
   "  --canary, -c         Publish packages after every successful merge using the sha as part of the tag",
   "  --skip-git           Skip commiting, tagging, and pushing git changes (only affects publish)",
+  "  --skip-npm           Stop before actually publishing change to npm (only affects publish)",
   "  --npm-tag [tagname]  Publish packages with the specified npm dist-tag",
   "  --scope [glob]       Restricts the scope to package names matching the given glob (Works only in combination with the 'run' and the 'exec' command).",
   "  --force-publish      Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)",

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -87,6 +87,15 @@ export default class PublishCommand extends Command {
       return;
     }
 
+    if (this.flags.skipNpm) {
+      callback(null, true);
+    } else {
+      this.publishPackagesToNpm(callback);
+    }
+  }
+
+  publishPackagesToNpm(callback) {
+
     this.logger.newLine();
     this.logger.info("Publishing packages to npm...");
 


### PR DESCRIPTION
Have Lerna update all versions and dependencies where required in `package.json` files without actually publishing the changes to NPM.

This is useful for publishing manually, which is necessary to do periodically to get README updates to show up on npmjs.com (until https://github.com/npm/newww/issues/389 is resolved).

This is a workaround for #64.

This was proposed in #127.