### PR TITLE
Only install missing external dependencies during bootstrap

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -101,6 +101,9 @@ export default class BootstrapCommand extends Command {
 
         return !(match && this.hasMatchingDependency(pkg, match));
       })
+      .filter(dependency => {
+        return !this.hasDependencyInstalled(pkg, dependency);
+      })
       .map(dependency => {
         return dependency + "@" + allDependencies[dependency];
       });
@@ -133,6 +136,18 @@ export default class BootstrapCommand extends Command {
     }
 
     return false;
+  }
+
+  hasDependencyInstalled(pkg, dependency) {
+    const packageJson = path.join(pkg.nodeModulesLocation, dependency, "package.json");
+    try {
+      return this.isCompatableVersion(
+        require(packageJson).version,
+        pkg.allDependencies[dependency]
+      );
+    } catch (e) {
+      return false;
+    }
   }
 
   isCompatableVersion(actual, expected) {

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -7,60 +7,134 @@ import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import BootstrapCommand from "../src/commands/BootstrapCommand";
 import exitWithCode from "./_exitWithCode";
 import initFixture from "./_initFixture";
+import stub from "./_stub";
 
 import assertStubbedCalls from "./_assertStubbedCalls";
 
 describe("BootstrapCommand", () => {
-  let testDir;
 
-  beforeEach(done => {
-    testDir = initFixture("BootstrapCommand/basic", done);
+  describe("dependencies between packages in the repo", () => {
+    let testDir;
+
+    beforeEach(done => {
+      testDir = initFixture("BootstrapCommand/basic", done);
+    });
+
+    it("should bootstrap files", done => {
+      const bootstrapCommand = new BootstrapCommand([], {});
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      assertStubbedCalls([
+        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+          { args: ["npm install package-1@^0.0.0", { cwd: path.join(testDir, "packages/package-4") }] }
+        ]]
+      ]);
+
+      bootstrapCommand.runCommand(exitWithCode(0, err => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-1/node_modules")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-4/node_modules")));
+
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")));
+
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")));
+
+          // Should not exist because mis-matched version
+          assert.ok(!pathExists.sync(path.join(testDir, "packages/package-4/node_modules/package-1")));
+
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-1") + "\");\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\"\n}\n");
+
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-2") + "\");\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\"\n}\n");
+
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
   });
 
-  it("should bootstrap files", done => {
-    const bootstrapCommand = new BootstrapCommand([], {});
+  describe("external dependencies that haven't been installed", () => {
+    let testDir;
 
-    bootstrapCommand.runValidations();
-    bootstrapCommand.runPreparations();
+    beforeEach(done => {
+      testDir = initFixture("BootstrapCommand/cold", done);
+    });
 
-    assertStubbedCalls([
-      [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-        { args: ["npm install package-1@^0.0.0", { cwd: path.join(testDir, "packages/package-4") }] }
-      ]]
-    ]);
+    it("should get installed", done => {
+      const bootstrapCommand = new BootstrapCommand([], {});
 
-    bootstrapCommand.runCommand(exitWithCode(0, err => {
-      if (err) return done(err);
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
 
-      try {
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+      let installed = false;
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        assert.equal(command, "npm install external@^1.0.0")
+        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") })
+        installed = true;
+        callback();
+      });
 
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-1/node_modules")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-4/node_modules")));
+      bootstrapCommand.runCommand(exitWithCode(0, err => {
+        if (err) return done(err);
 
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")));
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.ok(installed, "The external dependency was installed");
 
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")));
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
+  });
 
-        // Should not exist because mis-matched version
-        assert.ok(!pathExists.sync(path.join(testDir, "packages/package-4/node_modules/package-1")));
+  describe("external dependencies that have already been installed", () => {
+    let testDir;
 
-        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-1") + "\");\n");
-        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\"\n}\n");
+    beforeEach(done => {
+      testDir = initFixture("BootstrapCommand/warm", done);
+    });
 
-        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-2") + "\");\n");
-        assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\"\n}\n");
+    it("should not get re-installed", done => {
+      const bootstrapCommand = new BootstrapCommand([], {});
 
-        done();
-      } catch (err) {
-        done(err);
-      }
-    }));
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      let installed = false;
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        installed = true;
+        callback();
+      });
+
+      bootstrapCommand.runCommand(exitWithCode(0, err => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.ok(!installed, "The external dependency was not installed");
+
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
   });
 });

--- a/test/fixtures/BootstrapCommand/cold/lerna.json
+++ b/test/fixtures/BootstrapCommand/cold/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/cold/package.json
+++ b/test/fixtures/BootstrapCommand/cold/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/cold/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/cold/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "external": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/cold/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/cold/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/warm/lerna.json
+++ b/test/fixtures/BootstrapCommand/warm/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/warm/package.json
+++ b/test/fixtures/BootstrapCommand/warm/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/warm/packages/package-1/node_modules/external/package.json
+++ b/test/fixtures/BootstrapCommand/warm/packages/package-1/node_modules/external/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "external",
+  "version": "1.0.1"
+}

--- a/test/fixtures/BootstrapCommand/warm/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/warm/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "external": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/warm/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/warm/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}


### PR DESCRIPTION
This makes bootstrap in a repo that has been bootstrapped previously much faster.

This addresses #125.