### PR TITLE
[Feature] Support relative dependencies within the repo

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -136,6 +136,8 @@ export default class BootstrapCommand extends Command {
   }
 
   isCompatableVersion(actual, expected) {
-    return semver.satisfies(actual, expected);
+    // If it's a relative dependency, then it is satisfied from within the
+    // repository, regardless of what the actual version of the module is.
+    return expected.startsWith("../") || semver.satisfies(actual, expected);
   }
 }

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -138,6 +138,6 @@ export default class BootstrapCommand extends Command {
   isCompatableVersion(actual, expected) {
     // If it's a relative dependency, then it is satisfied from within the
     // repository, regardless of what the actual version of the module is.
-    return expected.startsWith("../") || semver.satisfies(actual, expected);
+    return expected.match(/^..\//) || semver.satisfies(actual, expected);
   }
 }

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -63,4 +63,20 @@ describe("BootstrapCommand", () => {
       }
     }));
   });
+
+  describe("version compatibility", () => {
+
+    const checkPair = (actual, expected) => {
+      return new BootstrapCommand([], {}).isCompatableVersion(actual, expected);
+    };
+
+    it("should consider relative dependencies compatible", () => {
+      assert.ok(checkPair("1.0.1", "../peer-package"));
+    });
+
+    it("should otherwise adhere to semver compatibility", () => {
+      assert.ok( checkPair("1.0.1", "^1.0.0"));
+      assert.ok(!checkPair("1.0.1", "^1.0.2"));
+    });
+  });
 });


### PR DESCRIPTION
We use [relative dependencies in private packages](https://github.com/redfin/react-server/blob/master/packages/react-server-test-pages/package.json#L21-L23) as a crude workaround for #11.

This generates warnings during bootstrap, and prevents us from receiving the full benefit of #199.

This patch causes bootstrap to treat relative dependencies as satisfactory.
