### PR TITLE
Expicitly ignore output from `npm install`

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -4,13 +4,18 @@ import logger from "./logger";
 export default class NpmUtilities {
   @logger.logifyAsync
   static installInDir(directory, dependencies, callback) {
-    let command = "npm install";
+    let args = ["install"];
 
     if (dependencies) {
-      command += " " + dependencies.join(" ");
+      args = args.concat(dependencies);
     }
 
-    ChildProcessUtilities.exec(command, { cwd: directory }, callback);
+    const opts = {
+      cwd: directory,
+      stdio: "ignore"
+    }
+
+    ChildProcessUtilities.spawn("npm", args, opts, callback);
   }
 
   @logger.logifySync

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -27,8 +27,8 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runPreparations();
 
       assertStubbedCalls([
-        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-          { args: ["npm install package-1@^0.0.0", { cwd: path.join(testDir, "packages/package-4") }] }
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "package-1@^0.0.0"], { cwd: path.join(testDir, "packages/package-4"), stdio: "ignore" }] }
         ]]
       ]);
 
@@ -82,9 +82,9 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runPreparations();
 
       let installed = false;
-      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
-        assert.equal(command, "npm install external@^1.0.0")
-        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") })
+      stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
+        assert.deepEqual(args, ["install", "external@^1.0.0"])
+        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), stdio: "ignore" })
         installed = true;
         callback();
       });
@@ -118,7 +118,7 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runPreparations();
 
       let installed = false;
-      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+      stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
         installed = true;
         callback();
       });


### PR DESCRIPTION
This output was getting discarded, anyway.  This avoids buffering it
(and potentially failing due to exceeding `maxBuffer`).

This fixes #213.