### PR TITLE
Add `linkedFiles.prefix` option to add @flow annotations to the linked files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,9 @@ Running `lerna` without arguments will show all commands/options.
       "ignored-file",
       "*.md"
     ]
+  },
+  "linkedFiles": {
+    "prefix": "/**\n * @flow\n */"
   }
 }
 ```
@@ -408,6 +411,7 @@ Running `lerna` without arguments will show all commands/options.
 - `lerna`: the current version of Lerna being used.
 - `version`: the current version of the repository.
 - `publishConfig.ignore`: an array of globs that won't be included in `lerna updated/publish`. Use this to prevent publishing a new version unnecessarily for changes, such as fixing a `README.md` typo.
+- `linkedFiles.prefix`: a prefix added to linked dependency files.
 
 ### Flags
 

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -39,6 +39,10 @@ export default class Repository {
     return this.lernaJson && this.lernaJson.publishConfig || {};
   }
 
+  get linkedFiles() {
+    return this.lernaJson && this.lernaJson.linkedFiles || {};
+  }
+
   isIndependent() {
     return this.version === "independent";
   }

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -79,7 +79,8 @@ export default class BootstrapCommand extends Command {
       version: require(srcPackageJsonLocation).version
     }, null, "  ");
 
-    const indexJsFileContents = "module.exports = require(" + JSON.stringify(src) + ");";
+    const prefix = this.repository.linkedFiles.prefix || "";
+    const indexJsFileContents = prefix + "module.exports = require(" + JSON.stringify(src) + ");";
 
     FileSystemUtilities.writeFile(destPackageJsonLocation, packageJsonFileContents, err => {
       if (err) {

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -54,10 +54,10 @@ describe("BootstrapCommand", () => {
           // Should not exist because mis-matched version
           assert.ok(!pathExists.sync(path.join(testDir, "packages/package-4/node_modules/package-1")));
 
-          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-1") + "\");\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"" + path.join(testDir, "packages/package-1") + "\");\n");
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\"\n}\n");
 
-          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "module.exports = require(\"" + path.join(testDir, "packages/package-2") + "\");\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"" + path.join(testDir, "packages/package-2") + "\");\n");
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\"\n}\n");
 
           done();

--- a/test/fixtures/BootstrapCommand/basic/lerna.json
+++ b/test/fixtures/BootstrapCommand/basic/lerna.json
@@ -1,4 +1,7 @@
 {
   "lerna": "__TEST_VERSION__",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "linkedFiles": {
+    "prefix": "/**\n * @prefix\n */\n"
+  }
 }


### PR DESCRIPTION
We'd like to add flow annotations to Jest (tomorrow at our internal hackathon :) ).

Flow only looks at files with an `@flow` annotation. If a file doesn't have it, it skips it entirely and doesn't infer types for that file. When using lerna, even if the specific package is flow typed, because the proxy file in between in `node_modules` doesn't have `@flow`, the package won't be typed across boundaries.

This diff adds a `linkedFiles.prefix` option to add such annotations (or anything else, really) to such linked files.

I also added it to the README and updated a test for it. I didn't want to duplicate too much test code and add more fixtures, so I added it to an existing bootstrap test which should be good enough. Let me know if you'd like a separate test, however.