### PR TITLE
Use relative paths in file proxy

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -83,7 +83,8 @@ export default class BootstrapCommand extends Command {
     }, null, "  ");
 
     const prefix = this.repository.linkedFiles.prefix || "";
-    const indexJsFileContents = prefix + "module.exports = require(" + JSON.stringify(src) + ");";
+    const relativeSrc = path.join("..", "..", src.replace(this.repository.packagesLocation, ""));
+    const indexJsFileContents = prefix + "module.exports = require(" + JSON.stringify(relativeSrc) + ");";
 
     FileSystemUtilities.writeFile(destPackageJsonLocation, packageJsonFileContents, err => {
       if (err) {

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -54,10 +54,10 @@ describe("BootstrapCommand", () => {
           // Should not exist because mis-matched version
           assert.ok(!pathExists.sync(path.join(testDir, "packages/package-4/node_modules/package-1")));
 
-          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"" + path.join(testDir, "packages/package-1") + "\");\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"../../package-1\");\n");
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\"\n}\n");
 
-          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"" + path.join(testDir, "packages/package-2") + "\");\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"../../package-2\");\n");
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\"\n}\n");
 
           done();


### PR DESCRIPTION
**Problem**: Absolute paths does not allow for renaming project folder, or moving the folder around. 
My specific issue is that I would like to host/run the dev-setup with `lerna bootstrap` and friends on an Heroku instance, but Heroku does move the project after a successful build.

**Solution**: Write relative paths. Currently very naiv with replacing `repository.packagesLocation` absolute path and prepending `../..`

**Alternative** if this is not ok: Maybe have an options for this? :)