### PR TITLE
Add `onlyExplicitUpdates` flag so that only packages that have change…

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,3 +476,16 @@ The `ignore` flag, when used with the `bootstrap` command, can also be set in `l
 
 > Hint: The glob is matched against the package name defined in `package.json`,
 > not the directory name the package lives in.
+
+#### --only-explicit-updates
+
+Only will bump versions for packages that have been updated explicitly rather than cross-dependencies.
+
+> This may not make sense for a major version bump since other packages that depend on the updated packages wouldn't be updated.
+
+```sh
+$ lerna updated --only-explicit-updates
+$ lerna publish --only-explicit-updates
+```
+
+Ex: in Babel, `babel-types` is depended upon by all packages in the monorepo (over 100). However, Babel uses `^` for most of it's dependencies so it isn't necessary to bump the versions of all packages if only `babel-types` is updated. This option allows only the packages that have been explicitly updated to make a new version.

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -127,7 +127,7 @@ export default class UpdatedPackagesCollector {
 
   collectUpdates() {
     return this.packages.filter(pkg => {
-      return this.updatedPackages[pkg.name] || this.dependents[pkg.name] || this.flags.canary;
+      return this.updatedPackages[pkg.name] || (this.flags.onlyExplicitUpdates ? false : this.dependents[pkg.name]) || this.flags.canary;
     }).map(pkg => {
       return new Update(pkg);
     });

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -125,6 +125,31 @@ describe("UpdatedCommand", () => {
 
       updatedCommand.runCommand(exitWithCode(0, done));
     });
+
+    it("should list changes for explicitly changed packages", done => {
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
+
+      const updatedCommand = new UpdatedCommand([], {
+        onlyExplicitUpdates: true
+      });
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", message => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "");
+        if (calls === 2) assert.equal(message, "- package-2");
+        if (calls === 3) assert.equal(message, "");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
+    });
   });
 
   /** =========================================================================


### PR DESCRIPTION
…d have version bumps rather than all packages that depend on the updated packages

Just picked a name

Ref https://github.com/lerna/lerna/issues/240

Doing this for backwards compat with how Babel has been released but maybe we don't want to do this?

cc @thejameskyle @loganfsmyth