### PR TITLE
Revert "Use sync-exec for node 0.10"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
   - node_modules
 
 node_js:
- - "0.10"
  - "0.12"
  - "4"
  - stable

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "progress": "^1.1.8",
     "rimraf": "^2.4.4",
     "semver": "^5.1.0",
-    "signal-exit": "^2.1.2",
-    "sync-exec": "^0.6.2"
+    "signal-exit": "^2.1.2"
   },
   "bin": {
     "lerna": "./bin/lerna.js"

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -1,6 +1,5 @@
 import child from "child_process";
 import objectAssign from "object-assign";
-import syncExec from "sync-exec";
 
 export default class ChildProcessUtilities {
   static exec(command, opts, callback) {
@@ -22,15 +21,9 @@ export default class ChildProcessUtilities {
   }
 
   static execSync(command) {
-    if (child.execSync) {
-      return child.execSync(command, {
-        encoding: "utf8"
-      }).trim();
-    } else {
-      return syncExec(command, {
-        encoding: "utf8"
-      }).stdout.trim();
-    }
+    return child.execSync(command, {
+      encoding: "utf8"
+    }).trim();
   }
 
   static spawn(command, args, opts, callback) {

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -2,15 +2,12 @@ import assert from "assert";
 import child from "child_process";
 import path from "path";
 import fs from "fs";
-import syncExec from "sync-exec";
 
 import UpdatedCommand from "../src/commands/UpdatedCommand";
 import exitWithCode from "./_exitWithCode";
 import initFixture from "./_initFixture";
 import logger from "../src/logger";
 import stub from "./_stub";
-
-const execSync = (child.execSync || syncExec);
 
 describe("UpdatedCommand", () => {
 
@@ -26,10 +23,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes", done => {
-      execSync("git tag v1.0.0");
-      execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
-      execSync("git add -A");
-      execSync("git commit -m 'Commit'");
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {});
 
@@ -49,10 +46,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes with --force-publish *", done => {
-      execSync("git tag v1.0.0");
-      execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
-      execSync("git add -A");
-      execSync("git commit -m 'Commit'");
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "*"
@@ -74,10 +71,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes with --force-publish [package,package]", done => {
-      execSync("git tag v1.0.0");
-      execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-      execSync("git add -A");
-      execSync("git commit -m 'Commit'");
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "package-2,package-4"
@@ -106,11 +103,11 @@ describe("UpdatedCommand", () => {
       };
       fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
 
-      execSync("git tag v1.0.0");
-      execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
-      execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-      execSync("git add -A");
-      execSync("git commit -m 'Commit'");
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
+      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {});
 
@@ -142,10 +139,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes", done => {
-      execSync("git tag v1.0.0");
-      execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-      execSync("git add -A");
-      execSync("git commit -m 'Commit'");
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {});
 
@@ -165,10 +162,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes with --force-publish *", done => {
-      execSync("git tag v1.0.0");
-      execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
-      execSync("git add -A");
-      execSync("git commit -m 'Commit'");
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "*"
@@ -190,10 +187,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes with --force-publish [package,package]", done => {
-      execSync("git tag v1.0.0");
-      execSync("touch " + path.join(testDir, "packages/package-4/random-file"));
-      execSync("git add -A");
-      execSync("git commit -m 'Commit'");
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-4/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "package-2"
@@ -222,11 +219,11 @@ describe("UpdatedCommand", () => {
       };
       fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
 
-      execSync("git tag v1.0.0");
-      execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
-      execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-      execSync("git add -A");
-      execSync("git commit -m 'Commit'");
+      child.execSync("git tag v1.0.0");
+      child.execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
+      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      child.execSync("git add -A");
+      child.execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {});
 

--- a/test/_initFixture.js
+++ b/test/_initFixture.js
@@ -2,7 +2,6 @@ import rimraf from "rimraf";
 import child from "child_process";
 import path from "path";
 import cpr from "cpr";
-import syncExec from "sync-exec";
 
 const tmpDir = path.resolve(__dirname, "../tmp");
 const originalCwd = process.cwd();
@@ -30,7 +29,7 @@ export default function initFixture(fixturePath, callback) {
   }, err => {
     if (err) return callback(err);
     process.chdir(testDir);
-    (child.execSync || syncExec)("git init . && git add -A && git commit -m 'Init commit'");
+    child.execSync("git init . && git add -A && git commit -m 'Init commit'");
     callback();
   });
 


### PR DESCRIPTION
Reverts lerna/lerna#220

https://github.com/nodejs/LTS - v0.10 maintenance is going to be over soon (same with 0.12) so it seems ok to drop support. We're in beta and a new tool as well