### PR TITLE
Consistent naming in README `import` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ are preserved.  Commits are applied to the current branch.
 This is useful for gathering pre-existing standalone packages into a Lerna
 repo.  Each commit is modified to make changes relative to the package
 directory.  So, for example, the commit that added `package.json` will
-instead add `packages/<package-name>/package.json`.
+instead add `packages/<directory-name>/package.json`.
 
 ## Misc
 


### PR DESCRIPTION
That [last commit](https://github.com/lerna/lerna/pull/173/commits/372de5aa7c433d48da2bb44ca8578f912ef9a6a3) in #173 updated _one_ reference to package name, but missed another. 😅 