### PR TITLE
Add outdated command

### DIFF
--- a/src/commands/OutdatedCommand.js
+++ b/src/commands/OutdatedCommand.js
@@ -1,0 +1,45 @@
+import NpmUtilities from "../NpmUtilities";
+import Command from "../Command";
+import async from "async";
+
+export default class OutdatedCommand extends Command {
+  initialize(callback) {
+    this.args = this.input.slice(1);
+
+    if (!this.packages.length) {
+      callback(new Error(`No packages found`));
+      return;
+    }
+
+    callback(null, true);
+  }
+
+  execute(callback) {
+    this.runOutdatedInPackages(err => {
+      if (err) {
+        callback(err);
+      } else {
+        this.logger.success(`Successfully ran npm outdated in all packages`);
+        callback(null, true);
+      }
+    });
+  }
+
+  runOutdatedInPackages(callback) {
+    async.parallelLimit(this.packages.map(pkg => cb => {
+      this.runOutdatedInPackage(pkg, cb);
+    }), this.concurrency, callback);
+  }
+
+  runOutdatedInPackage(pkg, callback) {
+    NpmUtilities.execInDir('outdated', this.args, pkg.location, (err, stdout) => {
+      if (err) {
+        this.logger.error(`Errored while running npm outdated in '${pkg.name}'`, err);
+      } else {
+        this.logger.info(`=== ${pkg.name} ===`);
+        this.logger.info(stdout);
+      }
+      callback(err);
+    });
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
 import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
+import OutdatedCommand from "./commands/OutdatedCommand";
 
 export const __commands__ = {
   bootstrap: BootstrapCommand,
@@ -19,7 +20,8 @@ export const __commands__ = {
   init: InitCommand,
   run: RunCommand,
   exec: ExecCommand,
-  ls: LsCommand
+  ls: LsCommand,
+  outdated: OutdatedCommand
 };
 
 import PackageUtilities from "./PackageUtilities";


### PR DESCRIPTION
Runs [npm outdated](https://docs.npmjs.com/cli/outdated) command to find out-of-date dependencies.

Example output:

```
dougwade code/clefs ‹master*› » lerna outdated
Lerna v2.0.0-beta.22
=== clefs ===
Package  Current  Wanted  Latest  Location
snyk      1.14.3  1.16.0  1.16.0  clefs
xo        0.15.1  0.15.1  0.16.0  clefs

=== clefs-fs ===
Package  Current  Wanted  Latest  Location
snyk      1.14.3  1.16.0  1.16.0  clefs-fs
xo        0.15.1  0.15.1  0.16.0  clefs-fs

=== clefs-localstorage ===
Package  Current  Wanted  Latest  Location
snyk      1.14.3  1.16.0  1.16.0  clefs-localstorage
xo        0.15.1  0.15.1  0.16.0  clefs-localstorage

=== clefs-simpleobject ===
Package  Current  Wanted  Latest  Location
snyk      1.14.3  1.16.0  1.16.0  clefs-simpleobject
xo        0.15.1  0.15.1  0.16.0  clefs-simpleobject

=== integration-tests ===
Package  Current  Wanted  Latest  Location
del        2.2.0   2.2.1   2.2.1  integration-tests

Successfully ran npm outdated in all packages
```