### PR TITLE
Re-introduce node 0.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   - node_modules
 
 node_js:
+ - "0.10"
  - "0.12"
  - "4"
  - stable

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "progress": "^1.1.8",
     "rimraf": "^2.4.4",
     "semver": "^5.1.0",
-    "signal-exit": "^2.1.2"
+    "signal-exit": "^2.1.2",
+    "sync-exec": "^0.6.2"
   },
   "bin": {
     "lerna": "./bin/lerna.js"

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -21,15 +21,14 @@ export default class ChildProcessUtilities {
     });
   }
 
-  static execSync(command) {
+  static execSync(command, opts) {
+    const mergedOpts = objectAssign({
+      encoding: "utf8"
+    }, opts);
     if (child.execSync) {
-      return child.execSync(command, {
-        encoding: "utf8"
-      }).trim();
+      return child.execSync(command, mergedOpts).trim();
     } else {
-      return syncExec(command, {
-        encoding: "utf8"
-      }).stdout.trim();
+      return syncExec(command, mergedOpts).stdout.trim();
     }
   }
 

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -1,5 +1,6 @@
 import child from "child_process";
 import objectAssign from "object-assign";
+import syncExec from "sync-exec";
 
 export default class ChildProcessUtilities {
   static exec(command, opts, callback) {
@@ -21,9 +22,15 @@ export default class ChildProcessUtilities {
   }
 
   static execSync(command) {
-    return child.execSync(command, {
-      encoding: "utf8"
-    }).trim();
+    if (child.execSync) {
+      return child.execSync(command, {
+        encoding: "utf8"
+      }).trim();
+    } else {
+      return syncExec(command, {
+        encoding: "utf8"
+      }).stdout.trim();
+    }
   }
 
   static spawn(command, args, opts, callback) {

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -1,10 +1,10 @@
-import child from "child_process";
 import pathExists from "path-exists";
 import assert from "assert";
 import path from "path";
 import fs from "fs";
 
 import PromptUtilities from "../src/PromptUtilities";
+import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import ImportCommand from "../src/commands/ImportCommand";
 import exitWithCode from "./_exitWithCode";
 import initFixture from "./_initFixture";
@@ -40,7 +40,7 @@ describe("ImportCommand", () => {
         if (err) return done(err);
 
         try {
-          const lastCommit = child.execSync("git log --format=\"%s\"", {encoding:"utf8"}).split("\n")[0];
+          const lastCommit = ChildProcessUtilities.execSync("git log --format=\"%s\"", {encoding:"utf8"}).split("\n")[0];
           const packageJson = path.join(testDir, "packages", path.basename(externalDir), "package.json");
           assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
           assert.ok(pathExists.sync(packageJson));

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -2,12 +2,15 @@ import assert from "assert";
 import child from "child_process";
 import path from "path";
 import fs from "fs";
+import syncExec from "sync-exec";
 
 import UpdatedCommand from "../src/commands/UpdatedCommand";
 import exitWithCode from "./_exitWithCode";
 import initFixture from "./_initFixture";
 import logger from "../src/logger";
 import stub from "./_stub";
+
+const execSync = (child.execSync || syncExec);
 
 describe("UpdatedCommand", () => {
 
@@ -23,10 +26,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes", done => {
-      child.execSync("git tag v1.0.0");
-      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
-      child.execSync("git add -A");
-      child.execSync("git commit -m 'Commit'");
+      execSync("git tag v1.0.0");
+      execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      execSync("git add -A");
+      execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {});
 
@@ -46,10 +49,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes with --force-publish *", done => {
-      child.execSync("git tag v1.0.0");
-      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
-      child.execSync("git add -A");
-      child.execSync("git commit -m 'Commit'");
+      execSync("git tag v1.0.0");
+      execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      execSync("git add -A");
+      execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "*"
@@ -71,10 +74,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes with --force-publish [package,package]", done => {
-      child.execSync("git tag v1.0.0");
-      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-      child.execSync("git add -A");
-      child.execSync("git commit -m 'Commit'");
+      execSync("git tag v1.0.0");
+      execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      execSync("git add -A");
+      execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "package-2,package-4"
@@ -103,11 +106,11 @@ describe("UpdatedCommand", () => {
       };
       fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
 
-      child.execSync("git tag v1.0.0");
-      child.execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
-      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-      child.execSync("git add -A");
-      child.execSync("git commit -m 'Commit'");
+      execSync("git tag v1.0.0");
+      execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
+      execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      execSync("git add -A");
+      execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {});
 
@@ -139,10 +142,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes", done => {
-      child.execSync("git tag v1.0.0");
-      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-      child.execSync("git add -A");
-      child.execSync("git commit -m 'Commit'");
+      execSync("git tag v1.0.0");
+      execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      execSync("git add -A");
+      execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {});
 
@@ -162,10 +165,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes with --force-publish *", done => {
-      child.execSync("git tag v1.0.0");
-      child.execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
-      child.execSync("git add -A");
-      child.execSync("git commit -m 'Commit'");
+      execSync("git tag v1.0.0");
+      execSync("touch " + path.join(testDir, "packages/package-2/random-file"));
+      execSync("git add -A");
+      execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "*"
@@ -187,10 +190,10 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list changes with --force-publish [package,package]", done => {
-      child.execSync("git tag v1.0.0");
-      child.execSync("touch " + path.join(testDir, "packages/package-4/random-file"));
-      child.execSync("git add -A");
-      child.execSync("git commit -m 'Commit'");
+      execSync("git tag v1.0.0");
+      execSync("touch " + path.join(testDir, "packages/package-4/random-file"));
+      execSync("git add -A");
+      execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "package-2"
@@ -219,11 +222,11 @@ describe("UpdatedCommand", () => {
       };
       fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
 
-      child.execSync("git tag v1.0.0");
-      child.execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
-      child.execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
-      child.execSync("git add -A");
-      child.execSync("git commit -m 'Commit'");
+      execSync("git tag v1.0.0");
+      execSync("touch " + path.join(testDir, "packages/package-2/ignored-file"));
+      execSync("touch " + path.join(testDir, "packages/package-3/random-file"));
+      execSync("git add -A");
+      execSync("git commit -m 'Commit'");
 
       const updatedCommand = new UpdatedCommand([], {});
 

--- a/test/_initExternalFixture.js
+++ b/test/_initExternalFixture.js
@@ -1,5 +1,6 @@
 import rimraf from "rimraf";
 import child from "child_process";
+import syncExec from "sync-exec";
 import path from "path";
 import cpr from "cpr";
 
@@ -23,7 +24,7 @@ export default function initExternalFixture(fixturePath, callback) {
     confirm: true
   }, err => {
     if (err) return callback(err);
-    child.execSync("git init . && git add -A && git commit -m 'Init external commit'", {
+    (child.execSync || syncExec)("git init . && git add -A && git commit -m 'Init external commit'", {
       cwd: testDir
     });
     callback();

--- a/test/_initFixture.js
+++ b/test/_initFixture.js
@@ -2,6 +2,7 @@ import rimraf from "rimraf";
 import child from "child_process";
 import path from "path";
 import cpr from "cpr";
+import syncExec from "sync-exec";
 
 const tmpDir = path.resolve(__dirname, "../tmp");
 const originalCwd = process.cwd();
@@ -29,7 +30,7 @@ export default function initFixture(fixturePath, callback) {
   }, err => {
     if (err) return callback(err);
     process.chdir(testDir);
-    child.execSync("git init . && git add -A && git commit -m 'Init commit'");
+    (child.execSync || syncExec)("git init . && git add -A && git commit -m 'Init commit'");
     callback();
   });
 


### PR DESCRIPTION
Node's [0.10 maintenance window](https://github.com/nodejs/LTS/blob/ce364a94b0e0619eba570cd57be396573e1ef889/schedule.png) expires in October.  Lerna should probably support it until then.

Also babel still supports it, so... 😆 

![Maintenance Windows](https://raw.githubusercontent.com/nodejs/LTS/ce364a94b0e0619eba570cd57be396573e1ef889/schedule.png)