### PR TITLE
Run `prepublish` scripts during bootstrap

### DIFF
--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -77,6 +77,9 @@ export default class PackageUtilities {
       if (!packages.length) {
         throw new Error(`No packages found that match '${glob}'`);
       }
+    } else {
+      // Always return a copy.
+      packages = packages.slice();
     }
     return packages;
   }

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -47,6 +47,9 @@ describe("BootstrapCommand", () => {
           assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")));
           assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")));
 
+          // Make sure the `prepublish` script got run (index.js got created).
+          assert.equal(require(path.join(testDir, "packages/package-2/node_modules/package-1")), "OK");
+
           assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2")));
           assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")));
           assert.ok(pathExists.sync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")));

--- a/test/fixtures/BootstrapCommand/basic/packages/package-1/index.src.js
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-1/index.src.js
@@ -1,0 +1,1 @@
+module.exports = "OK";

--- a/test/fixtures/BootstrapCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-1/package.json
@@ -1,4 +1,7 @@
 {
   "name": "package-1",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "scripts": {
+    "prepublish": "mv index.src.js index.js"
+  }
 }


### PR DESCRIPTION
Bootstrap should leave packages with usable dependencies.

If a dependency's `prepublish` script hasn't been run then it may not be `require()`-able.

> [The prepublish script will be run before publishing, so that users can consume the functionality without requiring them to compile it themselves. In dev mode (ie, locally running npm install), it'll run this script as well, so that you can test it easily.](https://docs.npmjs.com/files/package.json#devdependencies)

Furthermore, if packages use each other _during_ `prepublish`, then order of execution is important.

This, for example, is not a viable workaround:

```bash
$ lerna bootstrap
$ lerna run prepublish
```

Because a package may require a not-yet-built module due to incorrect order of execution.

This patch runs each package's `prepublish` during bootstrap, in dependency order.