### PR TITLE
Added --package-version

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -142,6 +142,18 @@ export default class PublishCommand extends Command {
       });
     }
 
+    // Declare that each package has an updated and correct version
+    if (this.flags.packageVersion) {
+      const versions = {};
+      const version = this.globalVersion;
+
+      this.updates.forEach(update => {
+        versions[update.package.name] = update.package.version;
+      });
+
+      return callback(null, { version, versions });
+    }
+
     // Non-Independent Canary Mode
     if (!this.repository.isIndependent() && this.flags.canary) {
       const version = this.globalVersion + this.getCanaryVersionSuffix();

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -759,4 +759,92 @@ describe("PublishCommand", () => {
       }));
     });
   });
+
+  /** =========================================================================
+   * NORMAL - PACKAGE VERSION
+   * ======================================================================= */
+
+  describe("normal mode with --package-version", () => {
+    let testDir;
+
+    beforeEach(done => {
+      testDir = initFixture("PublishCommand/normal", done);
+    });
+
+    it("should publish the changed packages", done => {
+      const publishCommand = new PublishCommand([], {
+        packageVersion: true,
+      });
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      assertStubbedCalls([
+         [ChildProcessUtilities, "execSync", {}, [
+           { args: ["git tag"] }
+         ]],
+         [PromptUtilities, "confirm", { valueCallback: true }, [
+           { args: ["Are you sure you want to publish the above changes?"], returns: true }
+         ]],
+         [ChildProcessUtilities, "execSync", {}, [
+           { args: ["git add " + path.join(testDir, "lerna.json")] },
+           { args: ["git add " + path.join(testDir, "packages/package-1/package.json")] },
+           { args: ["git add " + path.join(testDir, "packages/package-2/package.json")] },
+           { args: ["git add " + path.join(testDir, "packages/package-3/package.json")] },
+           { args: ["git add " + path.join(testDir, "packages/package-4/package.json")] },
+           { args: ["git commit -m \"$(echo \"v1.0.0\")\""] },
+           { args: ["git tag v1.0.0"] }
+         ]],
+         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+           { args: ["cd " + path.join(testDir, "packages/package-1") + " && npm publish --tag lerna-temp"] },
+           { args: ["cd " + path.join(testDir, "packages/package-2") + " && npm publish --tag lerna-temp"] },
+           { args: ["cd " + path.join(testDir, "packages/package-3") + " && npm publish --tag lerna-temp"] },
+           { args: ["cd " + path.join(testDir, "packages/package-4") + " && npm publish --tag lerna-temp"] }
+         ], true],
+         [ChildProcessUtilities, "execSync", {}, [
+           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.0\nstable: 1.0.0" },
+           { args: ["npm dist-tag rm package-1 lerna-temp"] },
+           { args: ["npm dist-tag add package-1@1.0.0 latest"] },
+
+           { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.0\nstable: 1.0.0" },
+           { args: ["npm dist-tag rm package-2 lerna-temp"] },
+           { args: ["npm dist-tag add package-2@1.0.0 latest"] },
+
+           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.0\nstable: 1.0.0" },
+           { args: ["npm dist-tag rm package-3 lerna-temp"] },
+           { args: ["npm dist-tag add package-3@1.0.0 latest"] },
+
+           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.0\nstable: 1.0.0" },
+           { args: ["npm dist-tag rm package-4 lerna-temp"] },
+           { args: ["npm dist-tag add package-4@1.0.0 latest"] },
+
+           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
+           { args: ["git push origin master"] },
+           { args: ["git push origin v1.0.0"] }
+         ]],
+      ]);
+
+      publishCommand.runCommand(exitWithCode(0, err => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(fs.readFileSync(path.join(testDir, "lerna.json")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.0\"\n}\n");
+
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.0");
+
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
+  });
 });


### PR DESCRIPTION
This is in reference to #229 on the discussion to include a `--package-version` command.

**What this does:**
Running `lerna publish --package-version` will assume that each package that has changed has the correct version already in its package.json file.

**Why have it?**
Here's my use case. My team has a repo that has multiple packages in it and is managed by Lerna. However, when a teammate submits a PR for a package (within the main repo) they will discuss with the team, in the PR, what kind of version this package should be (major, minor, patch). This way the team can decide on the correct version for the package and leave less room for versioning error.

**The main part**
When the PR is accepted and merged to master, our build tools will run Lerna and use this `--package-version` command to publish our package updates without having to interface with the Lerna versioning prompt that one would get in normal mode.

I hope this makes sense. All feedback is appreciated, thank you and I hope this is useful for others!

