### PR TITLE
Improved error handling for the import command

### DIFF
--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -144,5 +144,24 @@ describe("ImportCommand", () => {
         done();
       }));
     });
+
+    it("should fail if repo has uncommitted changes", done => {
+      const importCommand = new ImportCommand([externalDir], {});
+
+      const uncommittedFile = path.join(testDir, "ucommittedFile");
+
+      fs.writeFileSync(uncommittedFile, "");
+
+      ChildProcessUtilities.execSync("git add " + uncommittedFile);
+
+      importCommand.runValidations();
+      importCommand.runPreparations();
+
+      importCommand.runCommand(exitWithCode(1, err => {
+        const expect = "Local repository has un-committed changes";
+        assert.equal((err || {}).message, expect);
+        done();
+      }));
+    });
   });
 });


### PR DESCRIPTION
Noticed while investigating #251 that error handling during the `execute` phase of the import command is poor.  This patch includes the following:

- No "Import complete!" message on failure
- Emit an error message with:
    - All stderr output from `git am`
    - The sha of the failed commit
    - Intent to roll back
- Abort the failed `git am` and roll back to previous HEAD
- Don't allow import with uncommitted changes

Error output looks like:
![image](https://cloud.githubusercontent.com/assets/115908/16395542/5777382e-3c6f-11e6-8136-9bb67b4f9fd1.png)
