### PR TITLE
Let `git am` to fall back to three way merge during import

### DIFF
--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -91,7 +91,10 @@ export default class ImportCommand extends Command {
 
       // Apply the modified patch to the current lerna repository, preserving
       // original commit date, author and message.
-      ChildProcessUtilities.exec("git am", {}, done).stdin.end(patch);
+      //
+      // Fall back to three-way merge, which can help with duplicate commits
+      // due to merge history.
+      ChildProcessUtilities.exec("git am -3", {}, done).stdin.end(patch);
     }), err => {
       progressBar.terminate();
       this.logger.info("Import complete!");


### PR DESCRIPTION
This allows it to skip duplicate commits due to merge history.

This fixes #251.