### PR TITLE
run/exec: forward env variables

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -35,7 +35,7 @@ export default class NpmUtilities {
 
   @logger.logifySync
   static execInDir(command, args, directory, callback) {
-    ChildProcessUtilities.exec(`npm ${command} ${args.join(" ")}`, { cwd: directory }, callback);
+    ChildProcessUtilities.exec(`npm ${command} ${args.join(" ")}`, { cwd: directory, env: process.env }, callback);
   }
 
   @logger.logifyAsync

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -33,7 +33,10 @@ export default class ExecCommand extends Command {
   }
 
   runCommandInPackage(pkg, callback) {
-    ChildProcessUtilities.spawn(this.command, this.args, { cwd: pkg.location }, (code) => {
+    ChildProcessUtilities.spawn(this.command, this.args, {
+      cwd: pkg.location,
+      env: process.env
+    }, (code) => {
       if (code) {
         this.logger.error(`Errored while running command '${this.command}' ` +
                           `with arguments '${this.args.join(" ")}' in '${pkg.name}'`);

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -35,8 +35,8 @@ describe("ExecCommand", () => {
     stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
       assert.equal(command, "ls");
 
-      if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") });
-      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2") });
+      if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
+      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2"), env: process.env });
 
       calls++;
       callback();
@@ -59,11 +59,11 @@ describe("ExecCommand", () => {
       assert.equal(command, "ls");
 
       if (calls === 0) {
-        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") });
+        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
         assert.deepEqual(args, ["-la"]);
       }
       if (calls === 1) {
-        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2") });
+        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2"), env: process.env });
         assert.deepEqual(args, ["-la"]);
       }
 

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -24,8 +24,8 @@ describe("RunCommand", () => {
     stub(ChildProcessUtilities, "exec", (command, options, callback) => {
       assert.equal(command, "npm run my-script ")
 
-      if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1") });
-      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-3") });
+      if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
+      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-3"), env: process.env });
 
       calls++;
       callback();


### PR DESCRIPTION
Useful for passing some configuration to tasks, like: `DIALECT=bar lerna run foo`