### PR TITLE
Diff compaction for package binary PR

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -52,12 +52,13 @@ export default class FileSystemUtilities {
   }
 
   @logger.logifyAsync
-  static symlink(src, dest, type = "file", callback) {
+  static symlink(src, dest, callback) {
     fs.lstat(dest, (err) => {
       if (!err) {
-        fs.unlink(dest, () => fs.symlink(src, dest, type, callback));
+        // Something exists at `dest`.  Need to remove it first.
+        fs.unlink(dest, () => fs.symlink(src, dest, callback));
       } else {
-        fs.symlink(src, dest, type, callback);
+        fs.symlink(src, dest, callback);
       }
     });
   }

--- a/test/fixtures/BootstrapCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-2/package.json
@@ -1,8 +1,8 @@
 {
   "name": "package-2",
   "version": "1.0.0",
+  "bin": "cli.js",
   "dependencies": {
     "package-1": "^1.0.0"
-  },
-  "bin": "cli.js"
+  }
 }

--- a/test/fixtures/BootstrapCommand/basic/packages/package-3/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-3/package.json
@@ -1,11 +1,11 @@
 {
   "name": "package-3",
   "version": "1.0.0",
-  "devDependencies": {
-    "package-2": "^1.0.0"
-  },
   "bin": {
     "package3cli1": "cli1.js",
     "package3cli2": "cli2.js"
+  },
+  "devDependencies": {
+    "package-2": "^1.0.0"
   }
 }

--- a/test/fixtures/BootstrapCommand/basic/packages/package-4/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-4/package.json
@@ -2,7 +2,7 @@
   "name": "package-4",
   "version": "1.0.0",
   "dependencies": {
-    "package-1": "^0.0.0",
-    "package-3": "^1.0.0"
+    "package-3": "^1.0.0",
+    "package-1": "^0.0.0"
   }
 }


### PR DESCRIPTION
This is an attempt to get @rygine's #192 merged by trimming extraneous changes
to slim down the diff.

None of the following changes reflect _disapproval_ of the code in the
original PR.  This is pure change-set minimization.

Changes:
- Revert incidental code reorganization in:
    - `createLinkDependency`
    - `linkDependencies`
    - `createLinkedDependencyFiles`
- Thin interface of `createBinaryLink`
- Eliminate unused optional argument to `FileSystemUtilities.symlink`
- Simplify `createBinaryLink`
- Remove jsdoc comments

With this patch the diff against master is now pure addition.

@hzoo, @thejameskyle - If this looks good to you, please merge #192 _first_, to preserve authorship.  This will apply cleanly on top of that with a rebase.