### PR TITLE
Change bootstrap command to not install peerDependencies

### DIFF
--- a/src/Package.js
+++ b/src/Package.js
@@ -49,7 +49,6 @@ export default class Package {
   get allDependencies() {
     return objectAssign(
       {},
-      this.peerDependencies,
       this.devDependencies,
       this.dependencies
     );

--- a/test/Package.js
+++ b/test/Package.js
@@ -75,8 +75,7 @@ describe("Package", () => {
     it("should return the combined dependencies", () => {
       assert.deepEqual(pkg.allDependencies, {
         "my-dependency": "^1.0.0",
-        "my-dev-dependency": "^1.0.0",
-        "my-peer-dependency": "^1.0.0"
+        "my-dev-dependency": "^1.0.0"
       });
     });
   });

--- a/test/fixtures/BootstrapCommand/peer/lerna.json
+++ b/test/fixtures/BootstrapCommand/peer/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/peer/package.json
+++ b/test/fixtures/BootstrapCommand/peer/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/peer/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/peer/packages/package-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "external": "^1.0.0",
+    "package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/peer/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/peer/packages/package-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-2",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
**Reason**

`lerna bootstrap` deviates from the [peerDependencies behaviour][npmpeerdeps] found in `npm install` (npm@3)

---

This patch removes peerDependencies from `bootstrap`'s list of installable dependencies per package.

Tests added 💥 

Related:
- #160 First reporting the peer dep behaviour issue in `lerna bootstrap`
- #334 Discussion for lifting shared external packages to root directory (would be great for peer deps)

[npmpeerdeps]: https://docs.npmjs.com/files/package.json#peerdependencies