### PR TITLE
Respect package json "style" key

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Installs all of their dependencies and links any cross-dependencies.
 When run, this command will:
 
 1. Link together all Lerna `packages` that are dependencies of each other.
-  2. This doesn't currently use [npm link](https://docs.npmjs.com/cli/link) and instead uses a proxy to the actual package in the monorepo.
+  - This doesn't currently use [npm link](https://docs.npmjs.com/cli/link) and instead uses a proxy to the actual package in the monorepo.
+  - Lerna respects a filename specified as the `"style"` key in `package.json` and will link the named CSS file.
 2. `npm install` all external dependencies of each package.
 
 Currently, what Lerna does to link internal dependencies is replace the

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -140,11 +140,17 @@ export default class BootstrapCommand extends Command {
     const destPackageJsonLocation = path.join(dest, "package.json");
     const destIndexJsLocation = path.join(dest, "index.js");
 
-    const packageJsonFileContents = JSON.stringify({
+    const srcPackageJson = require(srcPackageJsonLocation);
+    const destPackageJson = {
       name: name,
-      version: require(srcPackageJsonLocation).version
-    }, null, "  ");
+      version: srcPackageJson.version
+    };
+    const hasStylesheet = !!srcPackageJson.style;
+    if (hasStylesheet) {
+      destPackageJson.style = "style.css";
+    }
 
+    const packageJsonFileContents = JSON.stringify(destPackageJson, null, "  ");
     const prefix = this.repository.linkedFiles.prefix || "";
     const indexJsFileContents = prefix + "module.exports = require(" +  JSON.stringify(normalize(src)) + ");";
 
@@ -153,7 +159,20 @@ export default class BootstrapCommand extends Command {
         return callback(err);
       }
 
-      FileSystemUtilities.writeFile(destIndexJsLocation, indexJsFileContents, callback);
+      FileSystemUtilities.writeFile(destIndexJsLocation, indexJsFileContents, (err) => {
+        if (err) {
+          return callback(err);
+        }
+
+        if (hasStylesheet) {
+          const destStyleCssLocation = path.join(dest, "style.css");
+          const styleCssFileContents = "@import \"" + path.relative(normalize(dest), normalize(path.join(src, srcPackageJson.style))) + "\";";
+
+          FileSystemUtilities.writeFile(destStyleCssLocation, styleCssFileContents, callback);
+        } else {
+          callback();
+        }
+      });
     });
   }
 

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -166,7 +166,7 @@ export default class BootstrapCommand extends Command {
 
         if (hasStylesheet) {
           const destStyleCssLocation = path.join(dest, "style.css");
-          const styleCssFileContents = "@import \"" + path.relative(normalize(dest), normalize(path.join(src, srcPackageJson.style))) + "\";";
+          const styleCssFileContents = "@import \"" + normalize(path.relative(dest, path.join(src, srcPackageJson.style))) + "\";";
 
           FileSystemUtilities.writeFile(destStyleCssLocation, styleCssFileContents, callback);
         } else {

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -49,6 +49,7 @@ describe("BootstrapCommand", () => {
           assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1")));
           assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")));
           assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages/package-2/node_modules/package-1/style.css")));
 
           // Make sure the `prepublish` script got run (index.js got created).
           assert.equal(require(path.join(testDir, "packages/package-2/node_modules/package-1")), "OK");
@@ -75,7 +76,8 @@ describe("BootstrapCommand", () => {
           assert.ok(!pathExists.sync(path.join(testDir, "packages/package-4/node_modules/package-1")));
 
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"" + normalize(path.join(testDir, "packages/package-1")) + "\");\n");
-          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\"\n}\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\",\n  \"style\": \"style.css\"\n}\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/style.css")).toString(), "@import \"" + normalize(path.join("../../../package-1/some-style-file.css")) + "\";\n");
 
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"" + normalize(path.join(testDir, "packages/package-2")) + "\");\n");
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\"\n}\n");

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -77,7 +77,7 @@ describe("BootstrapCommand", () => {
 
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"" + normalize(path.join(testDir, "packages/package-1")) + "\");\n");
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/package.json")).toString(), "{\n  \"name\": \"package-1\",\n  \"version\": \"1.0.0\",\n  \"style\": \"style.css\"\n}\n");
-          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/style.css")).toString(), "@import \"" + normalize(path.join("../../../package-1/some-style-file.css")) + "\";\n");
+          assert.equal(fs.readFileSync(path.join(testDir, "packages/package-2/node_modules/package-1/style.css")).toString(), "@import \"" + normalize("../../../package-1/some-style-file.css") + "\";\n");
 
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/index.js")).toString(), "/**\n * @prefix\n */\nmodule.exports = require(\"" + normalize(path.join(testDir, "packages/package-2")) + "\");\n");
           assert.equal(fs.readFileSync(path.join(testDir, "packages/package-3/node_modules/package-2/package.json")).toString(), "{\n  \"name\": \"package-2\",\n  \"version\": \"1.0.0\"\n}\n");

--- a/test/fixtures/BootstrapCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-1/package.json
@@ -1,6 +1,7 @@
 {
   "name": "package-1",
   "version": "1.0.0",
+  "style": "some-style-file.css",
   "scripts": {
     "prepublish": "mv index.src.js index.js"
   }

--- a/test/fixtures/BootstrapCommand/basic/packages/package-1/some-style-file.css
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-1/some-style-file.css
@@ -1,0 +1,3 @@
+.ok {
+  style: yeah;
+}


### PR DESCRIPTION
Fixes #311. I think this is more in line with the intent of #311 than #312 (@nruhe @boxxxie).

Caveat: this uses a CSS file with a relative path for `@import`, which assumes you are using a build system that will do something useful with this path instead of just dropping a `../../../foo.css` path onto the browser client that probably won't work. Absolute paths are a little tricky, as preprocessors seem to assume you're know what you're doing and will leave them as-is. In other words, relative paths seem to "just work" more transparently. (I assume you could tweak said build system or preprocessor to tolerate them if necessary.)