### PR TITLE
Don't try to publish private modules

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -29,6 +29,11 @@ export default class PublishCommand extends Command {
 
     try {
       this.updates = updatedPackagesCollector.getUpdates();
+
+      this.packagesToPublish = this.updates
+        .map((update) => update.package)
+        .filter((pkg) => !pkg.isPrivate());
+
     } catch (err) {
       throw err;
     }
@@ -338,11 +343,9 @@ export default class PublishCommand extends Command {
       this.execScript(update.package, "prepublish");
     });
 
-    this.progressBar.init(this.updates.length);
+    this.progressBar.init(this.packagesToPublish.length);
 
-    async.parallelLimit(this.updates.map((update) => {
-      const pkg = update.package;
-
+    async.parallelLimit(this.packagesToPublish.map((pkg) => {
       let attempts = 0;
 
       const run = (cb) => {
@@ -381,11 +384,9 @@ export default class PublishCommand extends Command {
   }
 
   npmUpdateAsLatest(callback) {
-    this.progressBar.init(this.updates.length);
+    this.progressBar.init(this.packagesToPublish.length);
 
-    async.parallelLimit(this.updates.map((update) => (cb) => {
-      const pkg = update.package;
-
+    async.parallelLimit(this.packagesToPublish.map((pkg) => (cb) => {
       let attempts = 0;
 
       while (true) {

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -47,6 +47,7 @@ describe("PublishCommand", () => {
           { args: ["git add " + path.join(testDir, "packages/package-2/package.json")] },
           { args: ["git add " + path.join(testDir, "packages/package-3/package.json")] },
           { args: ["git add " + path.join(testDir, "packages/package-4/package.json")] },
+          { args: ["git add " + path.join(testDir, "packages/package-5/package.json")] },
           { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
           { args: ["git tag v1.0.1"] }
         ]],
@@ -55,6 +56,7 @@ describe("PublishCommand", () => {
           { args: ["cd " + path.join(testDir, "packages/package-2") + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + path.join(testDir, "packages/package-3") + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + path.join(testDir, "packages/package-4") + " && npm publish --tag lerna-temp"] }
+          // No package-5.  It's private.
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
@@ -73,6 +75,8 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.1 latest"] },
 
+          // No package-5.  It's private.
+
           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
           { args: ["git push origin master"] },
           { args: ["git push origin v1.0.1"] }
@@ -90,10 +94,12 @@ describe("PublishCommand", () => {
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
           done();
         } catch (err) {
@@ -486,6 +492,7 @@ describe("PublishCommand", () => {
           { args: ["git add " + path.join(testDir, "packages/package-2/package.json")] },
           { args: ["git add " + path.join(testDir, "packages/package-3/package.json")] },
           { args: ["git add " + path.join(testDir, "packages/package-4/package.json")] },
+          { args: ["git add " + path.join(testDir, "packages/package-5/package.json")] },
           { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
           { args: ["git tag v1.0.1"] }
         ]],
@@ -502,10 +509,12 @@ describe("PublishCommand", () => {
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
           done();
         } catch (err) {
@@ -606,6 +615,7 @@ describe("PublishCommand", () => {
           { args: ["git add " + path.join(testDir, "packages/package-2/package.json")] },
           { args: ["git add " + path.join(testDir, "packages/package-3/package.json")] },
           { args: ["git add " + path.join(testDir, "packages/package-4/package.json")] },
+          { args: ["git add " + path.join(testDir, "packages/package-5/package.json")] },
           { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
           { args: ["git tag v1.0.1"] }
         ]],
@@ -614,6 +624,7 @@ describe("PublishCommand", () => {
           { args: ["cd " + path.join(testDir, "packages/package-2") + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + path.join(testDir, "packages/package-3") + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + path.join(testDir, "packages/package-4") + " && npm publish --tag lerna-temp"] }
+          // No package-5.  It's private.
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
@@ -632,6 +643,8 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.1 prerelease"] },
 
+          // No package-5.  It's private.
+
           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
           { args: ["git push origin master"] },
           { args: ["git push origin v1.0.1"] }
@@ -649,10 +662,12 @@ describe("PublishCommand", () => {
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
           done();
         } catch (err) {
@@ -705,6 +720,7 @@ describe("PublishCommand", () => {
          { args: ["git add " + path.join(testDir, "packages/package-2/package.json")] },
          { args: ["git add " + path.join(testDir, "packages/package-3/package.json")] },
          { args: ["git add " + path.join(testDir, "packages/package-4/package.json")] },
+         { args: ["git add " + path.join(testDir, "packages/package-5/package.json")] },
          { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
          { args: ["git tag v1.0.1"] }
        ]],
@@ -713,6 +729,7 @@ describe("PublishCommand", () => {
          { args: ["cd " + path.join(testDir, "packages/package-2") + " && npm publish --tag lerna-temp"] },
          { args: ["cd " + path.join(testDir, "packages/package-3") + " && npm publish --tag lerna-temp"] },
          { args: ["cd " + path.join(testDir, "packages/package-4") + " && npm publish --tag lerna-temp"] }
+         // No package-5.  It's private.
        ], true],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
@@ -731,6 +748,8 @@ describe("PublishCommand", () => {
          { args: ["npm dist-tag rm package-4 lerna-temp"] },
          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
 
+         // No package-5.  It's private.
+
          { args: ["git symbolic-ref --short HEAD"], returns: "master" },
          { args: ["git push origin master"] },
          { args: ["git push origin v1.0.1"] }
@@ -748,10 +767,12 @@ describe("PublishCommand", () => {
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
           assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
           assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
           done();
         } catch (err) {

--- a/test/fixtures/PublishCommand/normal/packages/package-5/package.json
+++ b/test/fixtures/PublishCommand/normal/packages/package-5/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-5",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  },
+  "private": true,
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Private modules may need to be updated during publish to keep their dependency
versions up to date, but they can't actually be published to the npm registry.

This addresses #303 (and #286 also, I think?)