### PR TITLE
docs(lerna-publish): add hint to indicate which packages will be published

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ More specifically, this command will:
 
 > A temporary dist-tag is used at the start to prevent the case where only some of the packages are published; this can cause issues for users installing a package that only has some updated packages.
 
+> Lerna won't publish packages which are marked as private (`"private": true` in the `package.json`).
+
 #### --npm-tag [tagname]
 
 ```sh


### PR DESCRIPTION
If you use lerna without the intention to publish your packages on npm, it might be unclear, which packages are affected by `lerna publish`.

We use lerna internally and use `lerna publish` with `--skip-npm` to manage git releases. We accidentally had some of our packages marked as private, from when they were standalone. `lerna pubslish` and `lerna ls` gave us quite the headache, because it listed/published only "some" of our packages, though linking the packages worked just fine (`bootstrap`).