### PR TITLE
Make log levels more like npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,3 +524,9 @@ $ lerna publish --only-explicit-updates
 ```
 
 Ex: in Babel, `babel-types` is depended upon by all packages in the monorepo (over 100). However, Babel uses `^` for most of it's dependencies so it isn't necessary to bump the versions of all packages if only `babel-types` is updated. This option allows only the packages that have been explicitly updated to make a new version.
+
+#### --loglevel [silent|error|warn|success|info|verbose|silly]
+
+What level of logs to report.  On failure, all logs are written to lerna-debug.log in the current working directory.
+
+Any logs of a higher level than the setting are shown.  The default is "info".

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var lerna = require("../lib/index");
+var logger = require("../lib/logger");
 var chalk = require("chalk");
 var meow = require("meow");
 
@@ -31,7 +32,8 @@ var cli = meow([
   "  --force-publish      Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)",
   "  --yes                Skip all confirmation prompts",
   "  --repo-version       Specify repo version to publish",
-  "  --concurrency        How many threads to use if lerna parallelises the tasks (defaults to 4)"
+  "  --concurrency        How many threads to use if lerna parallelises the tasks (defaults to 4)",
+  "  --loglevel           What level of logs to report (defaults to \"info\").  On failure, all logs are written to lerna-debug.log in the current working directory.",
 ], {
   alias: {
     independent: "i",
@@ -41,6 +43,8 @@ var cli = meow([
 });
 
 require("signal-exit").unload();
+
+logger.setLogLevel(cli.flags.loglevel);
 
 var commandName = cli.input[0];
 var Command = lerna.__commands__[commandName];

--- a/src/Command.js
+++ b/src/Command.js
@@ -34,31 +34,31 @@ export default class Command {
 
   runValidations() {
     if (this.concurrency < 1) {
-      this.logger.warning("command must be run with at least one thread.");
+      this.logger.warn("command must be run with at least one thread.");
       this._complete(null, 1);
       return;
     }
 
     if (!FileSystemUtilities.existsSync(this.repository.packagesLocation)) {
-      this.logger.warning("`packages/` directory does not exist, have you run `lerna init`?");
+      this.logger.warn("`packages/` directory does not exist, have you run `lerna init`?");
       this._complete(null, 1);
       return;
     }
 
     if (!FileSystemUtilities.existsSync(this.repository.packageJsonLocation)) {
-      this.logger.warning("`package.json` does not exist, have you run `lerna init`?");
+      this.logger.warn("`package.json` does not exist, have you run `lerna init`?");
       this._complete(null, 1);
       return;
     }
 
     if (!FileSystemUtilities.existsSync(this.repository.lernaJsonLocation)) {
-      this.logger.warning("`lerna.json` does not exist, have you run `lerna init`?");
+      this.logger.warn("`lerna.json` does not exist, have you run `lerna init`?");
       this._complete(null, 1);
       return;
     }
 
     if (this.flags.independent && !this.repository.isIndependent()) {
-      this.logger.warning(
+      this.logger.warn(
         "You ran lerna with `--independent` or `-i`, but the repository is not set to independent mode. " +
         "To use independent mode you need to set your `lerna.json` \"version\" to \"independent\". " +
         "Then you won't need to pass the `--independent` or `-i` flags."
@@ -71,7 +71,7 @@ export default class Command {
       process.env.NODE_ENV !== "test" &&
       this.lernaVersion !== this.repository.lernaVersion
     ) {
-      this.logger.warning(
+      this.logger.warn(
         `Lerna version mismatch: The current version of lerna is ${this.lernaVersion}, ` +
         `but the Lerna version in \`lerna.json\` is ${this.repository.lernaVersion}. ` +
         `You can either run \`lerna init\` again or install \`lerna@${this.repository.lernaVersion}\`.`
@@ -81,19 +81,19 @@ export default class Command {
     }
 
     if (FileSystemUtilities.existsSync(this.repository.versionLocation)) {
-      this.logger.warning("You have a `VERSION` file in your repository, this is leftover from a previous ");
+      this.logger.warn("You have a `VERSION` file in your repository, this is leftover from a previous ");
       this._complete(null, 1);
       return;
     }
 
     if (process.env.NPM_DIST_TAG !== undefined) {
-      this.logger.warning("`NPM_DIST_TAG=[tagname] lerna publish` is deprecated, please use `lerna publish --tag [tagname]` instead.");
+      this.logger.warn("`NPM_DIST_TAG=[tagname] lerna publish` is deprecated, please use `lerna publish --tag [tagname]` instead.");
       this._complete(null, 1);
       return;
     }
 
     if (process.env.FORCE_VERSION !== undefined) {
-      this.logger.warning("`FORCE_VERSION=[package/*] lerna updated/publish` is deprecated, please use `lerna updated/publish --force-publish [package/*]` instead.");
+      this.logger.warn("`FORCE_VERSION=[package/*] lerna updated/publish` is deprecated, please use `lerna updated/publish --force-publish [package/*]` instead.");
       this._complete(null, 1);
       return;
     }
@@ -122,17 +122,17 @@ export default class Command {
     const methodName = `${this.constructor.name}.${method}`;
 
     try {
-      this.logger.debug(`Attempting running ${methodName}`);
+      this.logger.verbose(`Attempting running ${methodName}`);
 
       this[method]((err, completed) => {
         if (err) {
           this.logger.error(`Errored while running ${methodName}`, err);
           this._complete(err, 1, callback);
         } else if (!completed) {
-          this.logger.debug(`Exited early while running ${methodName}`);
+          this.logger.verbose(`Exited early while running ${methodName}`);
           this._complete(null, 1, callback);
         } else {
-          this.logger.debug(`Successfully ran ${methodName}`);
+          this.logger.verbose(`Successfully ran ${methodName}`);
           next();
         }
       });

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -91,7 +91,7 @@ export default class BootstrapCommand extends Command {
       // then we've encountered a cycle in the dependency graph.  Run a
       // single-package batch with the package that has the most dependents.
       if (todoPackages.length && !batch.length) {
-        this.logger.warning(
+        this.logger.warn(
           "Encountered a cycle in the dependency graph.  " +
           "This may cause instability if dependencies are used during `prepublish`."
         );

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -334,7 +334,7 @@ export default class PublishCommand extends Command {
     if (FileSystemUtilities.existsSync(scriptLocation)) {
       require(scriptLocation);
     } else {
-      this.logger.debug(`No ${script} script found at ${scriptLocation}`);
+      this.logger.verbose(`No ${script} script found at ${scriptLocation}`);
     }
   }
 
@@ -349,7 +349,7 @@ export default class PublishCommand extends Command {
       let attempts = 0;
 
       const run = (cb) => {
-        this.logger.debug("Publishing " + pkg.name + "...");
+        this.logger.verbose("Publishing " + pkg.name + "...");
 
         NpmUtilities.publishTaggedInDir("lerna-temp", pkg.location, (err) => {
           err = err && err.stack || err;

--- a/src/logger.js
+++ b/src/logger.js
@@ -7,13 +7,13 @@ const cwd = process.cwd();
 const DEFAULT_LOGLEVEL = "info";
 
 const LEVELS = [
-  [ "silly",   "purple" ],
-  [ "verbose", "blue"   ],
-  [ "info",    "white"  ],
-  [ "success", "green"  ],
-  [ "warn",    "yellow" ],
-  [ "error",   "red"    ],
-  [ "silent",           ],
+  [ "silly",   "magenta" ],
+  [ "verbose", "blue"    ],
+  [ "info",    "white"   ],
+  [ "success", "green"   ],
+  [ "warn",    "yellow"  ],
+  [ "error",   "red"     ],
+  [ "silent",            ],
 ];
 
 const TYPE_TO_LEVEL = LEVELS

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -39,9 +39,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-2\n- package-3");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 
@@ -64,9 +62,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-1\n- package-2\n- package-3\n- package-4");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 
@@ -89,9 +85,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-2\n- package-3\n- package-4");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 
@@ -120,9 +114,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-3");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 
@@ -145,9 +137,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-2");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 
@@ -180,9 +170,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-3\n- package-4");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 
@@ -205,9 +193,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-1\n- package-2\n- package-3\n- package-4");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 
@@ -230,9 +216,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-2\n- package-3\n- package-4");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 
@@ -261,9 +245,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 1) assert.equal(message, "");
         if (calls === 2) assert.equal(message, "- package-3\n- package-4");
-        if (calls === 3) assert.equal(message, "");
         calls++;
       });
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,9 +1,37 @@
 import assert from "assert";
+import stub from "./_stub";
 
 import logger from "../src/logger";
 
 describe("logger", () => {
   it("should exist", () => {
     assert.ok(logger);
+  });
+  describe("log levels", () => {
+    let called;
+    beforeEach(() => {
+      called = false;
+      stub(logger, "_emit", () => called = true);
+    });
+    afterEach(() => logger.setLogLevel());
+
+    it("should suppress verbose by default", () => {
+      logger.verbose("test");
+      assert.ok(!called);
+    });
+    it("should emit verbose if configured", () => {
+      logger.setLogLevel("verbose");
+      logger.verbose("test");
+      assert.ok(called);
+    });
+    it("should emit error by default", () => {
+      logger.error("test");
+      assert.ok(called);
+    });
+    it("should suppress error if silent", () => {
+      logger.setLogLevel("silent");
+      logger.error("test");
+      assert.ok(!called);
+    });
   });
 });


### PR DESCRIPTION
Currently Lerna has log _types_ and a logging verbose flag, which has
different default values for different types (e.g. `false` for "debug",
`true` for "error").  It also has log types that are close to, but don't
_quite_ match their npm counterparts.

This PR makes Lerna's logging configuration more similar to npm's.

It:

- Adds a `--loglevel` CLI option
- Drops the `verbose` argument to logger methods
- Renames some logger methods to be more like their `npm` equivalents
    - `logger.debug` => `logger.verbose`
    - `logger.warning` => `logger.warn` (also more like `console.warn`)
- Allows an optional error object to be included with any log level

The update to the README is basically cribbed from `npm help 7 config`.

Differences with `npm`:
- Lerna has a `success` log level in place of npm's `http`
- Lerna's default is `info`, while npm's default is `warn`