### PR TITLE
Indicate private modules in output from `updated`

### DIFF
--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -16,7 +16,7 @@ export default class UpdatedCommand extends Command {
 
   execute(callback) {
     const formattedUpdates = this.updates
-      .map((update) => `- ${update.package.name}`)
+      .map((update) => `- ${update.package.name}${update.package.isPrivate() ? " (private)" : ""}`)
       .join("\n");
 
     this.logger.newLine();


### PR DESCRIPTION
This is helpful for figuring out what will actually be published.

Goes along with #321.

Looks like:

![image](https://cloud.githubusercontent.com/assets/115908/18217708/5011dc8c-7113-11e6-8ec0-e7947fb9b1f0.png)
