### PR TITLE
Add support for configurable package locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "async": "^1.5.0",
     "chalk": "^1.1.1",
     "cross-spawn": "^4.0.0",
+    "glob": "^7.0.6",
     "inquirer": "^0.12.0",
     "lodash.find": "^4.3.0",
     "lodash.unionwith": "^4.2.0",

--- a/src/Command.js
+++ b/src/Command.js
@@ -1,6 +1,5 @@
 import ChildProcessUtilities from "./ChildProcessUtilities";
 import FileSystemUtilities from "./FileSystemUtilities";
-import PackageUtilities from "./PackageUtilities";
 import ExitHandler from "./ExitHandler";
 import progressBar from "./progressBar";
 import Repository from "./Repository";
@@ -35,12 +34,6 @@ export default class Command {
   runValidations() {
     if (this.concurrency < 1) {
       this.logger.warning("command must be run with at least one thread.");
-      this._complete(null, 1);
-      return;
-    }
-
-    if (!FileSystemUtilities.existsSync(this.repository.packagesLocation)) {
-      this.logger.warning("`packages/` directory does not exist, have you run `lerna init`?");
       this._complete(null, 1);
       return;
     }
@@ -101,8 +94,9 @@ export default class Command {
 
   runPreparations() {
     try {
-      this.packages = PackageUtilities.getPackages(this.repository.packagesLocation);
-      this.packageGraph = PackageUtilities.getPackageGraph(this.packages);
+      this.repository.buildPackageGraph();
+      this.packages = this.repository.packages;
+      this.packageGraph = this.repository.packageGraph;
     } catch (err) {
       this.logger.error("Errored while collecting packages and package graph", err);
       this._complete(null, 1);

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -1,4 +1,3 @@
-import PackageUtilities from "./PackageUtilities";
 import GitUtilities from "./GitUtilities";
 import progressBar from "./progressBar";
 import minimatch from "minimatch";
@@ -13,9 +12,10 @@ class Update {
 }
 
 export default class UpdatedPackagesCollector {
-  constructor(packages, packageGraph, flags, publishConfig) {
-    this.packages = packages;
-    this.packageGraph = packageGraph;
+  constructor(repository, flags, publishConfig) {
+    this.repository = repository;
+    this.packages = repository.packages;
+    this.packageGraph = repository.packageGraph;
     this.flags = flags;
     this.publishConfig = publishConfig;
   }
@@ -140,7 +140,7 @@ export default class UpdatedPackagesCollector {
   }
 
   hasDiffSinceThatIsntIgnored(pkg, commits) {
-    const folder = PackageUtilities.getPackagePath(PackageUtilities.getPackagesPath(""), pkg.name);
+    const folder = path.relative(this.repository.rootPath, pkg.location);
     const diff = GitUtilities.diffSinceIn(commits, pkg.location);
 
     if (diff === "") {

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -25,7 +25,7 @@ export default class DiffCommand extends Command {
 
     this.filePath = this.package
       ? this.package.location
-      : this.repository.packagesLocation;
+      : this.repository.rootPath;
 
     this.lastCommit = GitUtilities.hasTags()
       ? GitUtilities.getLastTaggedCommit()

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -14,20 +14,11 @@ export default class InitCommand extends Command {
   }
 
   execute(callback) {
-    this.ensurePackagesDirectory();
     this.ensurePackageJSON();
     this.ensureLernaJson();
     this.ensureNoVersionFile();
     this.logger.success("Successfully created Lerna files");
     callback(null, true);
-  }
-
-  ensurePackagesDirectory() {
-    const packagesLocation = this.repository.packagesLocation;
-    if (!FileSystemUtilities.existsSync(packagesLocation)) {
-      this.logger.info("Creating packages folder.");
-      FileSystemUtilities.mkdirSync(packagesLocation);
-    }
   }
 
   ensurePackageJSON() {
@@ -51,7 +42,12 @@ export default class InitCommand extends Command {
   }
 
   ensureLernaJson() {
-    let {versionLocation, lernaJsonLocation, lernaJson} = this.repository;
+    let {
+      versionLocation,
+      lernaJsonLocation,
+      lernaJson,
+      packageConfigs,
+    } = this.repository;
 
     let version;
 
@@ -74,6 +70,7 @@ export default class InitCommand extends Command {
 
     objectAssign(lernaJson, {
       lerna: this.lernaVersion,
+      packages: packageConfigs,
       version: version
     });
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -21,8 +21,7 @@ export default class PublishCommand extends Command {
     }
 
     const updatedPackagesCollector = new UpdatedPackagesCollector(
-      this.packages,
-      this.packageGraph,
+      this.repository,
       this.flags,
       this.repository.publishConfig
     );

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -4,8 +4,7 @@ import Command from "../Command";
 export default class UpdatedCommand extends Command {
   initialize(callback) {
     const updatedPackagesCollector = new UpdatedPackagesCollector(
-      this.packages,
-      this.packageGraph,
+      this.repository,
       this.flags,
       this.repository.publishConfig
     );

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -136,6 +136,127 @@ describe("BootstrapCommand", () => {
     });
   });
 
+  describe("a repo with packages outside of packages/", () => {
+    let testDir;
+
+    beforeEach((done) => {
+      testDir = initFixture("BootstrapCommand/extra", done);
+    });
+
+    it("should bootstrap packages", (done) => {
+      const bootstrapCommand = new BootstrapCommand([], {});
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      assertStubbedCalls([
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-1"), stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-2"), stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "@test/package-1@^0.0.0"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "package-3"), stdio: STDIO_OPT }] }
+        ]],
+      ]);
+
+      bootstrapCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          // Make sure the `prepublish` script got run (index.js got created).
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
+          // package-1 should not have any packages symlinked
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-2")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-3")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-4")));
+          // package-2 package dependencies are symlinked
+          assert.equal(
+            fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "@test", "package-1")),
+            path.join(testDir, "packages", "package-1"),
+            "package-1 should be symlinked to package-2"
+          );
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-3")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-4")));
+          // package-3 package dependencies are symlinked
+          assert.equal(
+            fs.readlinkSync(path.join(testDir, "package-3", "node_modules", "@test", "package-1")),
+            path.join(testDir, "packages", "package-1"),
+            "package-1 should be symlinked to package-3"
+          );
+          assert.equal(
+            fs.readlinkSync(path.join(testDir, "package-3", "node_modules", "package-2")),
+            path.join(testDir, "packages", "package-2"),
+            "package-2 should be symlinked to package-3"
+          );
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "package-3", "node_modules", "package-4")));
+          // package-4 package dependencies are symlinked
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-1")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-2")));
+          assert.equal(
+            fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-3")),
+            path.join(testDir, "package-3"),
+            "package-3 should be symlinked to package-4"
+          );
+          // package binaries are symlinked
+          assert.equal(
+            fs.readlinkSync(path.join(testDir, "package-3", "node_modules", ".bin", "package-2")),
+            path.join(testDir, "packages", "package-2", "cli.js"),
+            "package-2 binary should be symlinked in package-3"
+          );
+          assert.equal(
+            fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1")),
+            path.join(testDir, "package-3", "cli1.js"),
+            "package-3 binary should be symlinked in package-4"
+          );
+          assert.equal(
+            fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2")),
+            path.join(testDir, "package-3", "cli2.js"),
+            "package-3 binary should be symlinked in package-4"
+          );
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
+
+    it("should not bootstrap ignored packages", (done) => {
+      const bootstrapCommand = new BootstrapCommand([], {
+        ignore: "package-@(3|4)"
+      });
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      assertStubbedCalls([
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-1"), stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-2"), stdio: STDIO_OPT }] }
+        ]]
+      ]);
+
+      bootstrapCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
+  });
+
   describe("external dependencies that haven't been installed", () => {
     let testDir;
 

--- a/test/Command.js
+++ b/test/Command.js
@@ -61,9 +61,9 @@ describe("Command", () => {
   });
 
   describe(".run()", () => {
-    it.skip("should exist", (done) => {
+    it("should exist", (done) => {
       class TestCommand extends Command {
-        initialize(callback) { callback(); }
+        initialize(callback) { callback(null, true); }
         execute() {
 
           done();

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -25,7 +25,7 @@ describe("DiffCommand", () => {
       assert.equal(args[0], "diff");
       assert.equal(args[1].length, 40); // commit
       assert.equal(args[2], "--color=auto");
-      assert.equal(args[3], path.join(testDir, "packages"));
+      assert.equal(args[3], testDir);
       callback(0);
     });
 

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -7,20 +7,42 @@ import logger from "../src/logger";
 import stub from "./_stub";
 
 describe("LsCommand", () => {
-  beforeEach((done) => {
-    initFixture("LsCommand/basic", done);
-  });
 
-  it("should list changes", (done) => {
-    const lsCommand = new LsCommand([], {});
-
-    lsCommand.runValidations();
-    lsCommand.runPreparations();
-
-    stub(logger, "info", (message) => {
-      assert.equal(message, "- package-1\n- package-2\n- package-3\n- package-4");
+  describe("in a basic repo", () => {
+    beforeEach((done) => {
+      initFixture("LsCommand/basic", done);
     });
 
-    lsCommand.runCommand(exitWithCode(0, done));
+    it("should list packages", (done) => {
+      const lsCommand = new LsCommand([], {});
+
+      lsCommand.runValidations();
+      lsCommand.runPreparations();
+
+      stub(logger, "info", (message) => {
+        assert.equal(message, "- package-1\n- package-2\n- package-3\n- package-4");
+      });
+
+      lsCommand.runCommand(exitWithCode(0, done));
+    });
+  });
+
+  describe("in a repo with packages outside of packages/", () => {
+    beforeEach((done) => {
+      initFixture("LsCommand/extra", done);
+    });
+
+    it("should list packages", (done) => {
+      const lsCommand = new LsCommand([], {});
+
+      lsCommand.runValidations();
+      lsCommand.runPreparations();
+
+      stub(logger, "info", (message) => {
+        assert.equal(message, "- package-1\n- package-2\n- package-3");
+      });
+
+      lsCommand.runCommand(exitWithCode(0, done));
+    });
   });
 });

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -3,8 +3,16 @@ import path from "path";
 
 import PackageUtilities from "../src/PackageUtilities";
 import Package from "../src/Package";
+import Repository from "../src/Repository";
+import initFixture from "./_initFixture";
 
 describe("PackageUtilities", () => {
+  let testDir;
+
+  beforeEach((done) => {
+    testDir = initFixture("PackageUtilities/basic", done);
+  });
+
   describe(".getPackagesPath()", () => {
     it("should append the packages path to the repo path given", () => {
       assert.equal(
@@ -34,7 +42,7 @@ describe("PackageUtilities", () => {
 
   describe(".getPackageConfig()", () => {
     it("should get the config file for the given package in the given packages directory", () => {
-      const fixture = path.join(__dirname, "fixtures/PackageUtilities/basic/packages");
+      const fixture = path.join(testDir, "packages");
 
       assert.deepEqual(
         PackageUtilities.getPackageConfig(fixture, "package-1"),
@@ -48,8 +56,8 @@ describe("PackageUtilities", () => {
 
   describe(".getPackages()", () => {
     it("should collect all the packages from the given packages directory", () => {
-      const fixture = path.join(__dirname, "fixtures/PackageUtilities/basic/packages");
-      const result = PackageUtilities.getPackages(fixture);
+      const fixture = path.join(testDir, "packages");
+      const result = PackageUtilities.getPackages(new Repository);
 
       assert.equal(result.length, 4);
       assert(result[0] instanceof Package);
@@ -60,8 +68,14 @@ describe("PackageUtilities", () => {
   });
 
   describe(".filterPackages()", () => {
-    const fixture = path.join(__dirname, "fixtures/PackageUtilities/filtering/packages");
-    const packages = PackageUtilities.getPackages(fixture);
+    let packages;
+
+    beforeEach((done) => {
+      initFixture("PackageUtilities/filtering", () => {
+        packages = PackageUtilities.getPackages(new Repository);
+        done();
+      });
+    });
 
     it("should throw when --scope is given but empty", () => {
       assert.throws(() => {

--- a/test/fixtures/BootstrapCommand/extra/lerna.json
+++ b/test/fixtures/BootstrapCommand/extra/lerna.json
@@ -1,0 +1,8 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "packages": [
+    {"glob": "packages/*/package.json"},
+    {"glob": "package-3/package.json"}
+  ]
+}

--- a/test/fixtures/BootstrapCommand/extra/package-3/cli1.js
+++ b/test/fixtures/BootstrapCommand/extra/package-3/cli1.js
@@ -1,0 +1,2 @@
+#! /usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/extra/package-3/cli2.js
+++ b/test/fixtures/BootstrapCommand/extra/package-3/cli2.js
@@ -1,0 +1,2 @@
+#! /usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/extra/package-3/package.json
+++ b/test/fixtures/BootstrapCommand/extra/package-3/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "bin": {
+    "package3cli1": "cli1.js",
+    "package3cli2": "cli2.js"
+  },
+  "devDependencies": {
+    "@test/package-1": "^1.0.0",
+    "package-2": "^1.0.0",
+    "foo": "0.1.12"
+  }
+}

--- a/test/fixtures/BootstrapCommand/extra/package.json
+++ b/test/fixtures/BootstrapCommand/extra/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/extra/packages/package-1/index.src.js
+++ b/test/fixtures/BootstrapCommand/extra/packages/package-1/index.src.js
@@ -1,0 +1,1 @@
+module.exports = "OK";

--- a/test/fixtures/BootstrapCommand/extra/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/extra/packages/package-1/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "foo": "^1.0.0"
+  },
+  "scripts": {
+    "prepublish": "mv index.src.js index.js"
+  }
+}

--- a/test/fixtures/BootstrapCommand/extra/packages/package-2/cli.js
+++ b/test/fixtures/BootstrapCommand/extra/packages/package-2/cli.js
@@ -1,0 +1,2 @@
+#! /usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/extra/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/extra/packages/package-2/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "bin": "cli.js",
+  "dependencies": {
+    "@test/package-1": "^1.0.0",
+    "foo": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/extra/packages/package-4/package.json
+++ b/test/fixtures/BootstrapCommand/extra/packages/package-4/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/package-1": "^0.0.0",
+    "package-3": "^1.0.0"
+  }
+}

--- a/test/fixtures/LsCommand/extra/lerna.json
+++ b/test/fixtures/LsCommand/extra/lerna.json
@@ -1,0 +1,8 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "packages": [
+    {"glob": "packages/*/package.json"},
+    {"glob": "package-3/package.json"}
+  ]
+}

--- a/test/fixtures/LsCommand/extra/package-3/package.json
+++ b/test/fixtures/LsCommand/extra/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "devDependencies": {
+    "package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/LsCommand/extra/package.json
+++ b/test/fixtures/LsCommand/extra/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/LsCommand/extra/packages/package-1/package.json
+++ b/test/fixtures/LsCommand/extra/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/LsCommand/extra/packages/package-2/package.json
+++ b/test/fixtures/LsCommand/extra/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}


### PR DESCRIPTION
This adds a `packages` configuration option to `lerna.json`:

```json
{
  "lerna": "2.0.0-beta.27",
  "version": "0.2.3",
  "packages": [
    {"glob": "packages/{core,plugins}/*/package.json"},
    {"glob": "build-tools/package.json"},
    {"glob": "integration-tests/**/package.json"}
  ]
}
```

The default is `[{"glob": "packages/*/package.json"}]`, which is equivalent to
the historical layout of a Lerna repo.

This addresses #126 and #231.

----
Still TODO:

- [ ] documentation
- [x] new tests