### PR TITLE
Don't chain off of `stream.setEncoding(...)`

### DIFF
--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -59,7 +59,8 @@ export default class ChildProcessUtilities {
     // If the caller overrode that to "pipe", then we'll gather that up and
     // call back with it in case of failure.
     if (childProcess.stderr) {
-      childProcess.stderr.setEncoding("utf8").on("data", (chunk) => stderr += chunk);
+      childProcess.stderr.setEncoding("utf8");
+      childProcess.stderr.on("data", (chunk) => stderr += chunk);
     }
   }
 


### PR DESCRIPTION
Turns out this wasn't supported until node v0.10.18.

https://github.com/nodejs/node/commit/f91b047891c0deb402220b385f166c08edcb0591