### PR TITLE
Fix importing commits which renamed files (Fixes #345)

### DIFF
--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -94,7 +94,8 @@ export default class ImportCommand extends Command {
       const patch = this.externalExecSync(`git format-patch -1 ${sha} --stdout`)
         .replace(/^([-+]{3} [ab])/mg,     replacement)
         .replace(/^(diff --git a)/mg,     replacement)
-        .replace(/^(diff --git \S+ b)/mg, replacement);
+        .replace(/^(diff --git \S+ b)/mg, replacement)
+        .replace(/^(rename (from|to)) /mg, `\$1 ${this.targetDir}/`);
 
       // Apply the modified patch to the current lerna repository, preserving
       // original commit date, author and message.

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -66,7 +66,7 @@ describe("ImportCommand", () => {
       ]);
 
       ChildProcessUtilities.execSync("git mv old-file new-file", { cwd: externalDir });
-      ChildProcessUtilities.execSync("git commit -m 'Moved old-file to new-file'", { cwd: externalDir });
+      ChildProcessUtilities.execSync("git commit -m \"Moved old-file to new-file\"", { cwd: externalDir });
 
       importCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done(err);


### PR DESCRIPTION
fixes #345 

`git format-patch` outputs something like this for renames:
```
diff --git a/test1 b/test2
similarity index 100%
rename from test1
rename to test2
```

Previously `ImportCommand` would properly replace `a/test1` and `a/test2` with the proper relative paths, but would not replace the "rename" lines, which would cause an error.