### PR TITLE
Use unprivileged alternatives to symlinks on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ When run, this command will:
 
 1. `npm install` all external dependencies of each package.
 2. Symlink together all Lerna `packages` that are dependencies of each other.
-    * This requires Administrator privileges on Windows
-2. `npm prepublish` all bootstrapped packages.
+3. `npm prepublish` all bootstrapped packages.
 
 `lerna bootstrap` respects the `--ignore` flag (see below).
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "chalk": "^1.1.1",
+    "cmd-shim": "^2.0.2",
     "cross-spawn": "^4.0.0",
     "inquirer": "^0.12.0",
     "lodash.find": "^4.3.0",
@@ -38,6 +39,7 @@
     "pad": "^1.0.0",
     "path-exists": "^2.1.0",
     "progress": "^1.1.8",
+    "read-cmd-shim": "^1.0.1",
     "rimraf": "^2.4.4",
     "semver": "^5.1.0",
     "signal-exit": "^2.1.2",

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -146,7 +146,7 @@ export default class BootstrapCommand extends Command {
     const actions = [(cb) => FileSystemUtilities.mkdirp(destBinFolder, cb)];
     // symlink each binary
     srcBinFiles.forEach((binFile, idx) => {
-      actions.push((cb) => FileSystemUtilities.symlink(binFile, destBinFiles[idx], "file", cb));
+      actions.push((cb) => FileSystemUtilities.symlink(binFile, destBinFiles[idx], "junction", cb));
     });
     async.series(actions, callback);
   }
@@ -241,7 +241,7 @@ export default class BootstrapCommand extends Command {
             ));
             // create package symlink
             packageActions.push((cb) => FileSystemUtilities.symlink(
-              dependencyLocation, pkgDependencyLocation, "dir", cb
+              dependencyLocation, pkgDependencyLocation, "junction", cb
             ));
             const dependencyPackageJson = require(dependencyPackageJsonLocation);
             if (dependencyPackageJson.bin) {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -146,7 +146,7 @@ export default class BootstrapCommand extends Command {
     const actions = [(cb) => FileSystemUtilities.mkdirp(destBinFolder, cb)];
     // symlink each binary
     srcBinFiles.forEach((binFile, idx) => {
-      actions.push((cb) => FileSystemUtilities.symlink(binFile, destBinFiles[idx], "junction", cb));
+      actions.push((cb) => FileSystemUtilities.symlink(binFile, destBinFiles[idx], "exec", cb));
     });
     async.series(actions, callback);
   }

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -5,6 +5,7 @@ import fs from "fs";
 import normalize from "normalize-path";
 
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
+import FileSystemUtilities from "../src/FileSystemUtilities";
 import BootstrapCommand from "../src/commands/BootstrapCommand";
 import exitWithCode from "./_exitWithCode";
 import initFixture from "./_initFixture";
@@ -85,17 +86,17 @@ describe("BootstrapCommand", () => {
           );
           // package binaries are symlinked
           assert.equal(
-            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", ".bin", "package-2"))),
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-3", "node_modules", ".bin", "package-2"))),
             normalize(path.join(testDir, "packages", "package-2", "cli.js")),
             "package-2 binary should be symlinked in package-3"
           );
           assert.equal(
-            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
             normalize(path.join(testDir, "packages", "package-3", "cli1.js")),
             "package-3 binary should be symlinked in package-4"
           );
           assert.equal(
-            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
             normalize(path.join(testDir, "packages", "package-3", "cli2.js")),
             "package-3 binary should be symlinked in package-4"
           );

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -2,6 +2,7 @@ import pathExists from "path-exists";
 import assert from "assert";
 import path from "path";
 import fs from "fs";
+import normalize from "normalize-path";
 
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import BootstrapCommand from "../src/commands/BootstrapCommand";
@@ -56,21 +57,21 @@ describe("BootstrapCommand", () => {
           assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-4")));
           // package-2 package dependencies are symlinked
           assert.equal(
-            fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "@test", "package-1")),
-            path.join(testDir, "packages", "package-1"),
+            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "@test", "package-1"))),
+            normalize(path.join(testDir, "packages", "package-1")),
             "package-1 should be symlinked to package-2"
           );
           assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-3")));
           assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-4")));
           // package-3 package dependencies are symlinked
           assert.equal(
-            fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "@test", "package-1")),
-            path.join(testDir, "packages", "package-1"),
+            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "@test", "package-1"))),
+            normalize(path.join(testDir, "packages", "package-1")),
             "package-1 should be symlinked to package-3"
           );
           assert.equal(
-            fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "package-2")),
-            path.join(testDir, "packages", "package-2"),
+            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "package-2"))),
+            normalize(path.join(testDir, "packages", "package-2")),
             "package-2 should be symlinked to package-3"
           );
           assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "package-4")));
@@ -78,24 +79,24 @@ describe("BootstrapCommand", () => {
           assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-1")));
           assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-2")));
           assert.equal(
-            fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-3")),
-            path.join(testDir, "packages", "package-3"),
+            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-3"))),
+            normalize(path.join(testDir, "packages", "package-3")),
             "package-3 should be symlinked to package-4"
           );
           // package binaries are symlinked
           assert.equal(
-            fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", ".bin", "package-2")),
-            path.join(testDir, "packages", "package-2", "cli.js"),
+            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", ".bin", "package-2"))),
+            normalize(path.join(testDir, "packages", "package-2", "cli.js")),
             "package-2 binary should be symlinked in package-3"
           );
           assert.equal(
-            fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1")),
-            path.join(testDir, "packages", "package-3", "cli1.js"),
+            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
+            normalize(path.join(testDir, "packages", "package-3", "cli1.js")),
             "package-3 binary should be symlinked in package-4"
           );
           assert.equal(
-            fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2")),
-            path.join(testDir, "packages", "package-3", "cli2.js"),
+            normalize(fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
+            normalize(path.join(testDir, "packages", "package-3", "cli2.js")),
             "package-3 binary should be symlinked in package-4"
           );
           done();


### PR DESCRIPTION
Fixes #339 and allows `lerna bootstrap` to run as a regular user on Windows.

For the record, the calls to `normalize()` are there to remove any trailing slashes from the paths (I forget which had them - the `path.join` results or the `readlinkSync` results).