### PR TITLE
Resolve symlink path on windows to add trailing slash.

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -81,15 +81,18 @@ export default class FileSystemUtilities {
   @logger.logifySync
   static isSymlink(path) {
     const lstat = fs.lstatSync(path);
-    const isSymlink = lstat && lstat.isSymbolicLink()
+    let isSymlink = lstat && lstat.isSymbolicLink()
       ? fs.readlinkSync(path)
       : false;
-    if (process.platform === "win32" && lstat && lstat.isFile() && !isSymlink) {
-      try {
-        return resolve(dirname(path), readCmdShim.sync(path));
-      } catch (e) {
-        return false;
+    if (process.platform === "win32" && lstat) {
+      if (lstat.isFile() && !isSymlink) {
+        try {
+          return resolve(dirname(path), readCmdShim.sync(path));
+        } catch (e) {
+          return false;
+        }
       }
+      isSymlink = isSymlink && resolve(isSymlink);
     }
     return isSymlink;
   }


### PR DESCRIPTION
If the symlink exists, the check in BootstrapCommand will incorrectly fail despite the path being correct as pkgDependencyLocation symlink path is returned without trailing slash, whereas the dependencyPackage location does have the trailing slash.  Only effects Windows.
