### PR TITLE
[Feature] lerna init assumes lerna in devDependencies

### DIFF
--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -33,19 +33,27 @@ export default class InitCommand extends Command {
   ensurePackageJSON() {
     let {packageJsonLocation, packageJson} = this.repository;
 
-    if (!packageJson) packageJson = {};
-    // if (!packageJson.private) packageJson.private = true;
-    if (!packageJson.devDependencies) packageJson.devDependencies = {};
-
-    objectAssignSorted(packageJson.devDependencies, {
-      lerna: this.lernaVersion
-    });
-
     if (!packageJson) {
+      packageJson = {};
       this.logger.info("Creating package.json.");
     } else {
       this.logger.info("Updating package.json.");
     }
+    // if (!packageJson.private) packageJson.private = true;
+
+    let targetDependencies;
+    if (packageJson.dependencies && packageJson.dependencies.lerna) {
+      // lerna is a dependency in the current project
+      targetDependencies = packageJson.dependencies;
+    } else {
+      // lerna is a devDependency or no dependency, yet
+      if (!packageJson.devDependencies) packageJson.devDependencies = {};
+      targetDependencies = packageJson.devDependencies;
+    }
+
+    objectAssignSorted(targetDependencies, {
+      lerna: this.lernaVersion
+    });
 
     FileSystemUtilities.writeFileSync(packageJsonLocation, JSON.stringify(packageJson, null, "  "));
   }


### PR DESCRIPTION
The current implementation assumes lerna to be a devDependency. Our project has lerna as a dependency (because the shell project is only build tools, which makes lerna a dependency in that sense). However when we run `lerna init` (after a lerna upgrade for example), lerna gets added to the `devDependencies` and not updated in the dependencies. This PR fixes this.
