### PR TITLE
Fix logifyAsync, logifySync decorators.

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -14,47 +14,47 @@ function ensureEndsWithNewLine(string) {
 }
 
 export default class FileSystemUtilities {
-  @logger.logifySync
+  @logger.logifySync()
   static mkdirSync(filePath) {
     fs.mkdirSync(filePath);
   }
 
-  @logger.logifyAsync
+  @logger.logifyAsync()
   static mkdirp(filePath, callback) {
     mkdirp(filePath, callback);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static readdirSync(filePath) {
     return fs.readdirSync(filePath);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static existsSync(filePath) {
     return pathExists.sync(filePath);
   }
 
-  @logger.logifyAsync
+  @logger.logifyAsync()
   static writeFile(filePath, fileContents, callback) {
     fs.writeFile(filePath, ensureEndsWithNewLine(fileContents), callback);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static writeFileSync(filePath, fileContents) {
     fs.writeFileSync(filePath, ensureEndsWithNewLine(fileContents));
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static readFileSync(filePath) {
     return fs.readFileSync(filePath, "utf-8").toString().trim();
   }
 
-  @logger.logifyAsync
+  @logger.logifyAsync()
   static rimraf(filePath, callback) {
     rimraf(filePath, callback);
   }
 
-  @logger.logifyAsync
+  @logger.logifyAsync()
   static symlink(src, dest, type, callback) {
     if (type === "exec") {
       if (process.platform === "win32") {
@@ -73,12 +73,12 @@ export default class FileSystemUtilities {
     });
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static unlinkSync(filePath) {
     fs.unlinkSync(filePath);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static isSymlink(path) {
     const lstat = fs.lstatSync(path);
     const isSymlink = lstat && lstat.isSymbolicLink()

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -3,7 +3,7 @@ import logger from "./logger";
 import escapeArgs from "command-join";
 
 export default class GitUtilities {
-  @logger.logifySync
+  @logger.logifySync()
   static isInitialized() {
     try {
       ChildProcessUtilities.execSync("git rev-parse");
@@ -13,84 +13,84 @@ export default class GitUtilities {
     }
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static addFile(file) {
     ChildProcessUtilities.execSync("git add " + escapeArgs(file));
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static commit(message) {
     // Use echo to allow multi\nline strings.
     ChildProcessUtilities.execSync("git commit -m \"$(echo \"" + message + "\")\"");
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static addTag(tag) {
     ChildProcessUtilities.execSync("git tag " + tag);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static removeTag(tag) {
     ChildProcessUtilities.execSync("git tag -d " + tag);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static hasTags() {
     return !!ChildProcessUtilities.execSync("git tag");
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static getLastTaggedCommit() {
     return ChildProcessUtilities.execSync("git rev-list --tags --max-count=1");
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static getFirstCommit() {
     return ChildProcessUtilities.execSync("git rev-list --max-parents=0 HEAD");
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static pushWithTags(tags) {
     ChildProcessUtilities.execSync("git push origin " + GitUtilities.getCurrentBranch());
     ChildProcessUtilities.execSync("git push origin " + tags.join(" "));
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static describeTag(commit) {
     return ChildProcessUtilities.execSync("git describe --tags " + commit);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static diffSinceIn(since, location) {
     return ChildProcessUtilities.execSync("git diff --name-only " + since + " -- " + escapeArgs(location));
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static getCurrentSHA() {
     return ChildProcessUtilities.execSync("git rev-parse HEAD");
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static getTopLevelDirectory() {
     return ChildProcessUtilities.execSync("git rev-parse --show-toplevel");
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static checkoutChanges(changes) {
     ChildProcessUtilities.execSync("git checkout -- " + changes);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static getCurrentBranch() {
     return ChildProcessUtilities.execSync("git symbolic-ref --short HEAD");
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static init() {
     return ChildProcessUtilities.execSync("git init");
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static hasCommit() {
     try {
       ChildProcessUtilities.execSync("git log");

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -3,7 +3,7 @@ import logger from "./logger";
 import escapeArgs from "command-join";
 
 export default class NpmUtilities {
-  @logger.logifyAsync
+  @logger.logifyAsync()
   static installInDir(directory, dependencies, callback) {
     let args = ["install"];
 
@@ -19,32 +19,32 @@ export default class NpmUtilities {
     ChildProcessUtilities.spawn("npm", args, opts, callback);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static addDistTag(packageName, version, tag) {
     ChildProcessUtilities.execSync(`npm dist-tag add ${packageName}@${version} ${tag}`);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static removeDistTag(packageName, tag) {
     ChildProcessUtilities.execSync(`npm dist-tag rm ${packageName} ${tag}`);
   }
 
-  @logger.logifySync
+  @logger.logifySync()
   static checkDistTag(packageName, tag) {
     return ChildProcessUtilities.execSync(`npm dist-tag ls ${packageName}`).indexOf(tag) >= 0;
   }
 
-  @logger.logifySync
+  @logger.logifyAsync()
   static execInDir(command, args, directory, callback) {
     ChildProcessUtilities.exec(`npm ${command} ${escapeArgs(args)}`, { cwd: directory, env: process.env }, callback);
   }
 
-  @logger.logifyAsync
+  @logger.logifyAsync()
   static runScriptInDir(script, args, directory, callback) {
     NpmUtilities.execInDir(`run ${script}`, args, directory, callback);
   }
 
-  @logger.logifyAsync
+  @logger.logifyAsync()
   static publishTaggedInDir(tag, directory, callback) {
     ChildProcessUtilities.exec("cd " + escapeArgs(directory) + " && npm publish --tag " + tag, null, callback);
   }


### PR DESCRIPTION
The decorator spec requires that a function decorator either:

- returns a new /descriptor/ for the property, or
- changes the fields on the given descriptor

The logify* methods instead returned a new function implementation, which
is not correct, and caused the decorations to be silently ignored.

decorator spec: https://github.com/wycats/javascript-decorators#detailed-design
function decorator example: https://github.com/jayphelps/core-decorators.js/blob/master/src/deprecate.js

This commit changes logifySync and logifyAsync in the following ways:

- they now have no return value, and instead modify the descriptor
- they now must be called with no arguments so they can properly capture
  the `this` value (without this, the function cannot find the logger instance)
- they now log at 'verbose', because they are extremely verbose
- remove 'error' flag from non-error logging
- they truncate their serialized arguments to (arbitrarily) 100 characters because
  otherwise they they OOM the node process

Additionally, one async method was erroneously decorated with logifySync.