### PR TITLE
[Feature] Symlink top-level packages

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -101,6 +101,7 @@ export default class Command {
 
   runPreparations() {
     try {
+      this.mainPackage = PackageUtilities.getPackage(this.repository.rootPath, this.repository.packageJsonLocation);
       this.packages = PackageUtilities.getPackages(this.repository.packagesLocation);
       this.packageGraph = PackageUtilities.getPackageGraph(this.packages);
     } catch (err) {

--- a/src/Package.js
+++ b/src/Package.js
@@ -99,7 +99,7 @@ export default class Package {
     }
 
     if (showWarning) {
-      logger.warning(
+      logger.warn(
         `Version mismatch inside "${this.name}". ` +
         `Depends on "${dependency.name}@${expectedVersion}" ` +
         `instead of "${dependency.name}@${actualVersion}".`

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -42,13 +42,17 @@ export default class PackageUtilities {
         return;
       }
 
-      const packageJson = require(packageConfigPath);
-      const pkg = new Package(packageJson, packagePath);
+      const pkg = PackageUtilities.getPackage(packagePath, packageConfigPath);
 
       packages.push(pkg);
     });
 
     return packages;
+  }
+
+  static getPackage(packagePath, packageConfigPath) {
+    const packageJson = require(packageConfigPath);
+    return new Package(packageJson, packagePath);
   }
 
   static getPackageGraph(packages) {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -50,7 +50,8 @@ export default class BootstrapCommand extends Command {
     if (ignore) {
       this.logger.info(`Ignoring packages that match '${ignore}'`);
     }
-    return PackageUtilities.filterPackages(this.packages, ignore, true);
+    const filteredPackages = PackageUtilities.filterPackages(this.packages, ignore, true);
+    return filteredPackages.concat(this.mainPackage);
   }
 
   /**
@@ -221,13 +222,13 @@ export default class BootstrapCommand extends Command {
               const isDepSymlink = FileSystemUtilities.isSymlink(pkgDependencyLocation);
               // installed dependency is a symlink pointing to a different location
               if (isDepSymlink !== false && isDepSymlink !== dependencyLocation) {
-                this.logger.warning(
+                this.logger.warn(
                   `Symlink already exists for ${dependency} dependency of ${filteredPackage.name}, ` +
                   "but links to different location. Replacing with updated symlink..."
                 );
               // installed dependency is not a symlink
               } else if (isDepSymlink === false) {
-                this.logger.warning(
+                this.logger.warn(
                   `${dependency} is already installed for ${filteredPackage.name}. ` +
                   "Replacing with symlink..."
                 );

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -42,6 +42,9 @@ describe("BootstrapCommand", () => {
         ]],
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
           { args: ["npm", ["install", "@test/package-1@^0.0.0"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", {nodeCallback: true}, [
+          { args: ["npm", ["install","package-1@^1.0.0"], { cwd: path.join(testDir), stdio: STDIO_OPT }]}
         ]]
       ]);
 

--- a/test/fixtures/BootstrapCommand/basic/package.json
+++ b/test/fixtures/BootstrapCommand/basic/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "independent"
+  "name": "independent",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
 }


### PR DESCRIPTION
The [Debugger](https://github.com/devtools-html/debugger.html) recently made the [move](https://github.com/devtools-html/debugger.html/pull/905) to a mono-repo project. We debated moving the Debugger's src into a package in the packages directory, but settled on a simpler approach where the Debugger stayed in the top level. The one catch was that the top-level package does not currently link with the packages. This patch fixes that by including the root package in the list of linked packages.

Notes
- I started working on the test, ran into a couple of issues so I'm sharing early for feedback.
- Thanks! Lerna has been great so far and the mono-repo approach will be really helpful for other DevTool panes. 
