### PR TITLE
[Feature] Add `--scope` to LsCommand to determine which packages are being depended upon

### DIFF
--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -84,9 +84,7 @@ export default class PackageUtilities {
     return packages;
   }
 
-  static filterNonDependentPackages(packages, scope) {
-    const filteredGraph = PackageUtilities.getPackageGraph(packages);
-
+  static filterNonDependentPackages(packages, packageGraph, scope) {
     let dependentPackages = [];
     let fringe = [];
     fringe.push(scope);
@@ -95,7 +93,7 @@ export default class PackageUtilities {
     while (fringe.length !== 0) {
       let pkg = fringe.shift();
 
-      dependencies = filteredGraph.get(pkg).dependencies;
+      dependencies = packageGraph.get(pkg).dependencies;
 
       dependencies.forEach((dependency) => {
         if (!~dependentPackages.indexOf(dependency) && !~fringe.indexOf(dependency)) {

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -88,23 +88,22 @@ export default class PackageUtilities {
     const filteredGraph = PackageUtilities.getPackageGraph(packages);
 
     let dependentPackages = [];
-    let fringe = new Set();
-    fringe.add(scope);
+    let fringe = [];
+    fringe.push(scope);
 
     let dependencies;
-    while (fringe.size !== 0) {
-      let pkg = fringe.values().next().value;
+    while (fringe.length !== 0) {
+      let pkg = fringe.shift();
 
       dependencies = filteredGraph.get(pkg).dependencies;
 
       dependencies.forEach((dependency) => {
         if (!~dependentPackages.indexOf(dependency)) {
-          fringe.add(dependency);
+          fringe.push(dependency);
         }
       });
 
       dependentPackages.push(pkg);
-      fringe.delete(pkg);
     }
 
     return packages.filter((pkg) =>

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -96,7 +96,7 @@ export default class PackageUtilities {
       dependencies = packageGraph.get(pkg).dependencies;
 
       dependencies.forEach((dependency) => {
-        if (!~dependentPackages.indexOf(dependency) && !~fringe.indexOf(dependency)) {
+        if (dependentPackages.indexOf(dependency) < 0 && fringe.indexOf(dependency) < 0) {
           fringe.push(dependency);
         }
       });
@@ -105,7 +105,7 @@ export default class PackageUtilities {
     }
 
     return packages.filter((pkg) =>
-      ~dependentPackages.indexOf(pkg.name)
+      dependentPackages.indexOf(pkg.name) >= 0
     );
   }
 }

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -83,4 +83,32 @@ export default class PackageUtilities {
     }
     return packages;
   }
+
+  static filterNonDependentPackages(packages, scope) {
+    const filteredGraph = PackageUtilities.getPackageGraph(packages);
+
+    let dependentPackages = [];
+    let fringe = new Set();
+    fringe.add(scope);
+
+    let dependencies;
+    while (fringe.size !== 0) {
+      let pkg = fringe.values().next().value;
+
+      dependencies = filteredGraph.get(pkg).dependencies;
+
+      dependencies.forEach((dependency) => {
+        if (!~dependentPackages.indexOf(dependency)) {
+          fringe.add(dependency);
+        }
+      });
+
+      dependentPackages.push(pkg);
+      fringe.delete(pkg);
+    }
+
+    return packages.filter((pkg) =>
+      ~dependentPackages.indexOf(pkg.name)
+    );
+  }
 }

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -98,7 +98,7 @@ export default class PackageUtilities {
       dependencies = filteredGraph.get(pkg).dependencies;
 
       dependencies.forEach((dependency) => {
-        if (!~dependentPackages.indexOf(dependency)) {
+        if (!~dependentPackages.indexOf(dependency) && !~fringe.indexOf(dependency)) {
           fringe.push(dependency);
         }
       });

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -1,15 +1,25 @@
 import Command from "../Command";
+import PackageUtilities from "../PackageUtilities";
 
 export default class LsCommand extends Command {
   initialize(callback) {
-    // Nothing to do...
+
+    if (this.flags.scope) {
+      try {
+        this.packages = PackageUtilities.filterNonDependentPackages(this.packages, this.flags.scope);
+      } catch (err) {
+        callback(err);
+        return;
+      }
+    }
+
     callback(null, true);
   }
 
   execute(callback) {
     const formattedPackages = this.packages
       .filter((pkg) => !pkg.isPrivate())
-      .map((pkg) => `- ${pkg.name}`)
+      .map((pkg) => `${pkg.name}`)
       .join("\n");
 
     this.logger.info(formattedPackages);

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -3,10 +3,15 @@ import PackageUtilities from "../PackageUtilities";
 
 export default class LsCommand extends Command {
   initialize(callback) {
+    if (this.input.length) {
+      const inputPackage = this.input[0];
+      if (!this.packageGraph.get(inputPackage)) {
+        callback(new Error(`The package ${inputPackage} does not exist`));
+        return;
+      }
 
-    if (this.flags.scope) {
       try {
-        this.packages = PackageUtilities.filterNonDependentPackages(this.packages, this.flags.scope);
+        this.packages = PackageUtilities.filterNonDependentPackages(this.packages, this.packageGraph, inputPackage);
       } catch (err) {
         callback(err);
         return;

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -25,9 +25,7 @@ describe("LsCommand", () => {
   });
 
   it("should list local packages in package-1's dependency tree", (done) => {
-    const lsCommand = new LsCommand([], {
-      scope: "package-1"
-    });
+    const lsCommand = new LsCommand(["package-1"], {});
 
     lsCommand.runValidations();
     lsCommand.runPreparations();
@@ -40,9 +38,7 @@ describe("LsCommand", () => {
   });
 
   it("should list local packages in package-3's dependency tree", (done) => {
-    const lsCommand = new LsCommand([], {
-      scope: "package-3"
-    });
+    const lsCommand = new LsCommand(["package-3"], {});
 
     lsCommand.runValidations();
     lsCommand.runPreparations();
@@ -55,9 +51,7 @@ describe("LsCommand", () => {
   });
 
   it("should list local packages in package-4's dependency tree", (done) => {
-    const lsCommand = new LsCommand([], {
-      scope: "package-4"
-    });
+    const lsCommand = new LsCommand(["package-4"], {});
 
     lsCommand.runValidations();
     lsCommand.runPreparations();

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -18,7 +18,52 @@ describe("LsCommand", () => {
     lsCommand.runPreparations();
 
     stub(logger, "info", (message) => {
-      assert.equal(message, "- package-1\n- package-2\n- package-3\n- package-4");
+      assert.equal(message, "package-1\npackage-2\npackage-3\npackage-4");
+    });
+
+    lsCommand.runCommand(exitWithCode(0, done));
+  });
+
+  it("should list local packages in package-1's dependency tree", (done) => {
+    const lsCommand = new LsCommand([], {
+      scope: "package-1"
+    });
+
+    lsCommand.runValidations();
+    lsCommand.runPreparations();
+
+    stub(logger, "info", (message) => {
+      assert.equal(message, "package-1");
+    });
+
+    lsCommand.runCommand(exitWithCode(0, done));
+  });
+
+  it("should list local packages in package-3's dependency tree", (done) => {
+    const lsCommand = new LsCommand([], {
+      scope: "package-3"
+    });
+
+    lsCommand.runValidations();
+    lsCommand.runPreparations();
+
+    stub(logger, "info", (message) => {
+      assert.equal(message, "package-1\npackage-2\npackage-3");
+    });
+
+    lsCommand.runCommand(exitWithCode(0, done));
+  });
+
+  it("should list local packages in package-4's dependency tree", (done) => {
+    const lsCommand = new LsCommand([], {
+      scope: "package-4"
+    });
+
+    lsCommand.runValidations();
+    lsCommand.runPreparations();
+
+    stub(logger, "info", (message) => {
+      assert.equal(message, "package-1\npackage-4");
     });
 
     lsCommand.runCommand(exitWithCode(0, done));

--- a/test/fixtures/LsCommand/basic/packages/package-4/package.json
+++ b/test/fixtures/LsCommand/basic/packages/package-4/package.json
@@ -2,6 +2,6 @@
   "name": "package-4",
   "version": "1.0.0",
   "dependencies": {
-    "package-1": "^0.0.0"
+    "package-1": "^1.0.0"
   }
 }


### PR DESCRIPTION
Issue: https://github.com/lerna/lerna/issues/381
Previous PR: https://github.com/lerna/lerna/pull/382

Uses breadth-first search on the packageGraph to determine dependent packages. 
Removed dashes from output for easier cli parsing.
Removed quiet flag from previous pull request. It would have silenced the lerna version line of output but that should be it's own feature.
