### PR TITLE
Fix ordered list syntax at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Create a new Lerna repo or upgrade an existing repo to the current version of Le
 > Lerna assumes the repo has already been initialized with `git init`.
 
 When run, this command will:
+
 1. Add `lerna` as a [`devDependency`](https://docs.npmjs.com/files/package.json#devdependencies) in `package.json` if it doesn't already exist.
 2. Create a `lerna.json` config file to store the `version` number.
 3. Create a `packages` directory if it hasn't been created already.


### PR DESCRIPTION
Add empty line becouse of not be ordered list on GitHub Markdown preview.
It will not happen on Atom Editor Markdown Preview.