### PR TITLE
Fix confusing example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ Successfully created Lerna files
 #### --independent, -i
 
 ```sh
-$ lerna publish --independent
+$ lerna init --independent
 ```
 
 This flag tells Lerna to use independent versioning mode.


### PR DESCRIPTION
The example for creating an independent mode lerna project said "lerna publish --i" instead of "init". This is a bit confusing. It might make sense to add the "independent" option as an example under the "publish" command additionally, if required.