### PR TITLE
Change testing NODE_ENV to "lerna-test" (Fixes #406)

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -68,7 +68,7 @@ export default class Command {
     }
 
     if (
-      process.env.NODE_ENV !== "test" &&
+      process.env.NODE_ENV !== "lerna-test" &&
       this.lernaVersion !== this.repository.lernaVersion
     ) {
       this.logger.warn(
@@ -164,7 +164,7 @@ export default class Command {
         callback(err, code);
       }
 
-      if (process.env.NODE_ENV !== "test") {
+      if (process.env.NODE_ENV !== "lerna-test") {
         process.exit(code);
       }
     };

--- a/src/logger.js
+++ b/src/logger.js
@@ -54,7 +54,7 @@ class Logger {
   }
 
   _emit(message) {
-    if (process.env.NODE_ENV !== "test") {
+    if (process.env.NODE_ENV !== "lerna-test") {
       console.log(message);
     }
   }

--- a/src/progressBar.js
+++ b/src/progressBar.js
@@ -18,7 +18,7 @@ class ProgressBarController {
     }
 
     // Don't do any of this while testing
-    if (process.env.NODE_ENV === "test") {
+    if (process.env.NODE_ENV === "lerna-test") {
       return;
     }
 

--- a/test/_env.js
+++ b/test/_env.js
@@ -1,1 +1,1 @@
-process.env.NODE_ENV = "test";
+process.env.NODE_ENV = "lerna-test";


### PR DESCRIPTION
fixes #406 

Previously, when running Lerna with `NODE_ENV` set to "test", it would output nothing to stdout and always exit with a code of `0`. Now the output and exit code will not be suppressed.