### PR TITLE
Use close event to wait for spawned processes to finish

### DIFF
--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -57,7 +57,7 @@ export default class ChildProcessUtilities {
         stdio: "inherit"
       }, opts))
         .on("error", () => {})
-        .on("exit", (code) => {
+        .on("close", (code) => {
           callback(code && (stderr || `Command failed: ${command} ${args.join(" ")}`));
         })
     );


### PR DESCRIPTION
As per https://nodejs.org/api/child_process.html#child_process_event_close, the close event is emitted when the stdio streams of a child process have been closed, which is important as there is a chance for race condition when process has exited (process's exit event), but collecting  stderr hasn't been finished yet (stderr stream's done event). Using close event seems to be pretty common if you look at implementations of child_process.exec, grunt.utils.spawn, etc.