### PR TITLE
use message passed as argument to the static method input() in PromptUtilities

### DIFF
--- a/src/PromptUtilities.js
+++ b/src/PromptUtilities.js
@@ -33,7 +33,7 @@ export default class PromptUtilities {
     inquirer.prompt([{
       type: "input",
       name: "input",
-      message: "Enter a custom version",
+      message: message,
       filter: filter,
       validate: validate
     }], (answers) => {


### PR DESCRIPTION
This commit uses message which is passed to the static method input() as an argument. Previously, string 'Enter a custom version' was being used instead of message passed from its caller.

See [src/commands/PublishCommand.js:222](https://github.com/lerna/lerna/blob/master/src/commands/PublishCommand.js#L222) for usage of input()