### PR TITLE
Add --message option for custom commit msgs when publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,16 @@ $ lerna publish --repo-version 1.0.1
 When run with this flag, `publish` will skip the version selection prompt and use the specified version.
 Useful for bypassing the user input prompt if you already know which version to publish.
 
+#### --message, -m [msg]
+
+```sh
+$ lerna publish -m "chore: Publish"
+```
+
+When run with this flag, `publish` will use the provided message when committing the version updates
+for publication. Useful for integrating lerna into projects that expect commit messages to adhere
+to certain guidelines, such as projects which use [commitizen](https://github.com/commitizen/cz-cli) and/or [semantic-release](https://github.com/semantic-release/semantic-release).
+
 ### updated
 
 ```sh

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -27,6 +27,7 @@ var cli = meow([
   "  --git-remote [remote]   Push git changes to the specified remote instead of 'origin'",
   "  --skip-git              Skip commiting, tagging, and pushing git changes (only affects publish)",
   "  --skip-npm              Stop before actually publishing change to npm (only affects publish)",
+  "  --message, -m [msg]  Use a custom commit message when creating the publish commit (only affects publish)",
   "  --npm-tag [tagname]     Publish packages with the specified npm dist-tag",
   "  --scope [glob]          Restricts the scope to package names matching the given glob (Works only in combination with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
   "  --ignore [glob]         Ignores packages with names matching the given glob (Works only in combination with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
@@ -40,6 +41,7 @@ var cli = meow([
   alias: {
     independent: "i",
     canary: "c",
+    message: "m",
     forcePublish: "force-version"
   }
 });

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -310,13 +310,8 @@ export default class PublishCommand extends Command {
   }
 
   gitCommitAndTagVersionForUpdates() {
-    let message = "Publish" + EOL;
-
-    const tags = this.updates.map((update) => {
-      const tag = `${update.package.name}@${this.updatesVersions[update.package.name]}`;
-      message += `${EOL} - ${tag}`;
-      return tag;
-    });
+    const tags = this.updates.map((update) => `${update.package.name}@${this.updatesVersions[update.package.name]}`);
+    const message = this.flags.message || tags.reduce((msg, tag) => msg + `${EOL} - ${tag}`, `Publish${EOL}`);
 
     GitUtilities.commit(message);
     tags.forEach(GitUtilities.addTag);
@@ -325,7 +320,8 @@ export default class PublishCommand extends Command {
 
   gitCommitAndTagVersion(version) {
     const tag = "v" + version;
-    GitUtilities.commit(tag);
+    const message = this.flags.message || tag;
+    GitUtilities.commit(message);
     GitUtilities.addTag(tag);
     return tag;
   }

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -978,4 +978,197 @@ describe("PublishCommand", () => {
       }));
     });
   });
+
+  /** =========================================================================
+   * NORMAL - MESSAGE
+   * ======================================================================= */
+
+  describe("normal mode with --message", () => {
+    let testDir;
+
+    beforeEach((done) => {
+      testDir = initFixture("PublishCommand/normal", done);
+    });
+
+    it("should publish the changed packages, committing the publish changes with a custom message", (done) => {
+      const publishCommand = new PublishCommand([], {
+        message: "A custom publish message"
+      });
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      assertStubbedCalls([
+       [ChildProcessUtilities, "execSync", {}, [
+         { args: ["git tag"] }
+       ]],
+       [PromptUtilities, "select", { valueCallback: true }, [
+         { args: ["Select a new version (currently 1.0.0)"], returns: "1.0.1" }
+       ]],
+       [PromptUtilities, "confirm", { valueCallback: true }, [
+         { args: ["Are you sure you want to publish the above changes?"], returns: true }
+       ]],
+       [ChildProcessUtilities, "execSync", {}, [
+         { args: ["git add " + escapeArgs(path.join(testDir, "lerna.json"))] },
+         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
+         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
+         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
+         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
+         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
+         { args: ["git commit -m \"$(echo \"A custom publish message\")\""] },
+         { args: ["git tag v1.0.1"] }
+       ]],
+       [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+         // No package-5.  It's private.
+       ], true],
+       [ChildProcessUtilities, "execSync", {}, [
+         { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+         { args: ["npm dist-tag rm package-1 lerna-temp"] },
+         { args: ["npm dist-tag add package-1@1.0.1 latest"] },
+
+         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+         { args: ["npm dist-tag rm package-2 lerna-temp"] },
+         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
+
+         { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+         { args: ["npm dist-tag rm package-3 lerna-temp"] },
+         { args: ["npm dist-tag add package-3@1.0.1 latest"] },
+
+         { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+         { args: ["npm dist-tag rm package-4 lerna-temp"] },
+         { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+
+         // No package-5.  It's private.
+
+         { args: ["git symbolic-ref --short HEAD"], returns: "master" },
+         { args: ["git push origin master"] },
+         { args: ["git push origin v1.0.1"] }
+       ]],
+      ]);
+
+      publishCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
+
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
+  });
+
+  /** =========================================================================
+   * INDEPENDENT - MESSAGE
+   * ======================================================================= */
+
+  describe("independent mode with --message", () => {
+    let testDir;
+
+    beforeEach((done) => {
+      testDir = initFixture("PublishCommand/independent", done);
+    });
+
+    it("should publish the changed packages in independent mode, committing with a custom msg", (done) => {
+      const publishCommand = new PublishCommand([], {
+        independent: true,
+        message: "A custom publish message"
+      });
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      assertStubbedCalls([
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git tag"] }
+        ]],
+        [PromptUtilities, "select", { valueCallback: true }, [
+          { args: ["Select a new version for package-1 (currently 1.0.0)"], returns: "1.0.1" },
+          { args: ["Select a new version for package-2 (currently 2.0.0)"], returns: "1.1.0" },
+          { args: ["Select a new version for package-3 (currently 3.0.0)"], returns: "2.0.0" },
+          { args: ["Select a new version for package-4 (currently 4.0.0)"], returns: "1.1.0" }
+        ]],
+        [PromptUtilities, "confirm", { valueCallback: true }, [
+          { args: ["Are you sure you want to publish the above changes?"], returns: true }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
+          { args: ["git commit -m \"$(echo \"A custom publish message\")\""] },
+          { args: ["git tag package-1@1.0.1"] },
+          { args: ["git tag package-2@1.1.0"] },
+          { args: ["git tag package-3@2.0.0"] },
+          { args: ["git tag package-4@1.1.0"] }
+        ]],
+        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-1 lerna-temp"] },
+          { args: ["npm dist-tag add package-1@1.0.1 latest"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.1.0 latest"] },
+
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 2.0.0" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-3 lerna-temp"] },
+          { args: ["npm dist-tag add package-3@2.0.0 latest"] },
+
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-4 lerna-temp"] },
+          { args: ["npm dist-tag add package-4@1.1.0 latest"] },
+
+          { args: ["git symbolic-ref --short HEAD"], returns: "master" },
+          { args: ["git push origin master"] },
+          { args: ["git push origin package-1@1.0.1 package-2@1.1.0 package-3@2.0.0 package-4@1.1.0"] },
+        ]]
+      ]);
+
+      publishCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "2.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
+
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
+  });
 });


### PR DESCRIPTION
This commit introduces a new option for publish: --message. When given
this option, lerna will use the supplied message as the commit message
when it commits updates while publishing. If no message flag is
specified, the default hard-coded messages are used.

Resolves #395