### PR TITLE
Lerna checks changes between last tag in current branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ init:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install
+  - appveyor-retry npm install --force
 
 test_script:
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ init:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install --global npm@^3.0.0
   - npm install
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ init:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - appveyor-retry npm install --force
+  - npm install
 
 test_script:
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ init:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm cache clean
   - npm install
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ init:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm cache clean
   - npm install
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ init:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm install --global npm@^3.0.0
   - npm install
 
 test_script:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "babel -w src -d lib",
     "lint": "eslint src test",
     "fix": "eslint src test --fix",
-    "test": "mocha -t 5000",
+    "test": "mocha -t 20000",
     "ci": "npm run lint && cross-env DEBUG_CALLS=true npm run test",
     "prepublish": "npm run build"
   },

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -63,12 +63,7 @@ export default class GitUtilities {
 
   @logger.logifySync()
   static getLastTag() {
-    try {
-      return ChildProcessUtilities.execSync("git describe --tags --abbrev=0");
-    } catch (e) {
-      return "0.0.0";
-    }
-
+    return ChildProcessUtilities.execSync("git describe --tags --abbrev=0");
   }
 
   @logger.logifySync()

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -46,7 +46,8 @@ export default class GitUtilities {
 
   @logger.logifySync()
   static getLastTaggedCommitInBranch() {
-    return ChildProcessUtilities.execSync("git rev-list -n 1 $(git describe --abbrev=0 --tags)");
+    const tagName = GitUtilities.getLastTag();
+    return ChildProcessUtilities.execSync("git rev-list -n 1 " + tagName);
   }
 
   @logger.logifySync()
@@ -62,7 +63,12 @@ export default class GitUtilities {
 
   @logger.logifySync()
   static getLastTag() {
-    return ChildProcessUtilities.execSync("git describe --tags --abbrev=0");
+    try {
+      return ChildProcessUtilities.execSync("git describe --tags --abbrev=0");
+    } catch(e) {
+      return '0.0.0';
+    }
+
   }
 
   @logger.logifySync()

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -45,6 +45,11 @@ export default class GitUtilities {
   }
 
   @logger.logifySync()
+  static getLastTaggedCommitInBranch() {
+    return ChildProcessUtilities.execSync("git rev-list -n 1 $(git describe --abbrev=0 --tags)");
+  }
+
+  @logger.logifySync()
   static getFirstCommit() {
     return ChildProcessUtilities.execSync("git rev-list --max-parents=0 HEAD");
   }
@@ -53,6 +58,11 @@ export default class GitUtilities {
   static pushWithTags(remote, tags) {
     ChildProcessUtilities.execSync(`git push ${remote} ${GitUtilities.getCurrentBranch()}`);
     ChildProcessUtilities.execSync(`git push ${remote} ${tags.join(" ")}`);
+  }
+
+  @logger.logifySync()
+  static getLastTag() {
+    return ChildProcessUtilities.execSync("git describe --tags --abbrev=0");
   }
 
   @logger.logifySync()
@@ -83,6 +93,11 @@ export default class GitUtilities {
   @logger.logifySync()
   static getCurrentBranch() {
     return ChildProcessUtilities.execSync("git symbolic-ref --short HEAD");
+  }
+
+  @logger.logifySync()
+  static getCurrentBranchDescription() {
+    return ChildProcessUtilities.execSync("git branch | sed -n '/\* /s///p'");
   }
 
   @logger.logifySync()

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -65,8 +65,8 @@ export default class GitUtilities {
   static getLastTag() {
     try {
       return ChildProcessUtilities.execSync("git describe --tags --abbrev=0");
-    } catch(e) {
-      return '0.0.0';
+    } catch (e) {
+      return "0.0.0";
     }
 
   }

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -98,7 +98,7 @@ export default class GitUtilities {
 
   @logger.logifySync()
   static getCurrentBranchDescription() {
-    return ChildProcessUtilities.execSync("git branch | sed -n '/\* /s///p'");
+    return ChildProcessUtilities.execSync("git symbolic-ref --short -q HEAD");
   }
 
   @logger.logifySync()

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -27,6 +27,15 @@ export default class UpdatedPackagesCollector {
 
   collectUpdatedPackages() {
     logger.info("Checking for updated packages...");
+
+    const currentBranch = GitUtilities.getCurrentBranchDescription();
+    if (currentBranch !== "master") {
+      logger.info("Working not on master! Current branch: " + currentBranch);
+    }
+
+    const tag = GitUtilities.getLastTag();
+    logger.info("Comparing with: " + tag);
+
     progressBar.init(this.packages.length);
 
     const hasTags = GitUtilities.hasTags();
@@ -43,7 +52,7 @@ export default class UpdatedPackagesCollector {
 
       commits = this.getAssociatedCommits(currentSHA);
     } else if (hasTags) {
-      commits = GitUtilities.describeTag(GitUtilities.getLastTaggedCommit());
+      commits = GitUtilities.describeTag(GitUtilities.getLastTaggedCommitInBranch());
     }
 
     const updatedPackages = {};

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -30,10 +30,6 @@ export default class UpdatedPackagesCollector {
 
     const currentBranch = GitUtilities.getCurrentBranchDescription();
 
-    if (currentBranch !== "master") {
-      logger.info("Working not on master! Current branch: " + currentBranch);
-    }
-
     const hasTags = GitUtilities.hasTags();
 
     if (hasTags) {

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -34,12 +34,17 @@ export default class UpdatedPackagesCollector {
       logger.info("Working not on master! Current branch: " + currentBranch);
     }
 
-    const tag = GitUtilities.getLastTag();
-    logger.info("Comparing with: " + tag);
+    const hasTags = GitUtilities.hasTags();
+
+    if (hasTags) {
+      const tag = GitUtilities.getLastTag();
+      logger.info("Comparing with: " + tag);
+    } else {
+      logger.info("No tags found! Comparing with initial commit.");
+    }
 
     progressBar.init(this.packages.length);
 
-    const hasTags = GitUtilities.hasTags();
     let commits;
 
     if (this.flags.canary) {

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -28,8 +28,6 @@ export default class UpdatedPackagesCollector {
   collectUpdatedPackages() {
     logger.info("Checking for updated packages...");
 
-    const currentBranch = GitUtilities.getCurrentBranchDescription();
-
     const hasTags = GitUtilities.hasTags();
 
     if (hasTags) {

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -29,6 +29,7 @@ export default class UpdatedPackagesCollector {
     logger.info("Checking for updated packages...");
 
     const currentBranch = GitUtilities.getCurrentBranchDescription();
+
     if (currentBranch !== "master") {
       logger.info("Working not on master! Current branch: " + currentBranch);
     }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -18,6 +18,11 @@ export default class PublishCommand extends Command {
       this.logger.info("Publishing canary build");
     }
 
+    const currentBranch = GitUtilities.getCurrentBranchDescription();
+    if (currentBranch.includes("detached at")) {
+      callback("You are working on detached branch, create new branch to publish changes.");
+    }
+
     if (!this.repository.isIndependent()) {
       this.globalVersion = this.repository.version;
       this.logger.info("Current version: " + this.globalVersion);

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -19,7 +19,7 @@ export default class PublishCommand extends Command {
     }
 
     const currentBranch = GitUtilities.getCurrentBranchDescription();
-    if (currentBranch.includes("detached at")) {
+    if (currentBranch && currentBranch.includes("detached at")) {
       callback("You are working on detached branch, create new branch to publish changes.");
     }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -19,7 +19,7 @@ export default class PublishCommand extends Command {
     }
 
     const currentBranch = GitUtilities.getCurrentBranchDescription();
-    if (currentBranch && currentBranch.includes("detached at")) {
+    if (currentBranch === "") {
       callback("You are working on detached branch, create new branch to publish changes.");
     }
 

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -50,6 +50,12 @@ describe("GitUtilities", () => {
     });
   });
 
+  describe(".getLastTaggedCommitInBranch()", () => {
+    it("should exist", () => {
+      assert.ok(GitUtilities.getLastTaggedCommitInBranch);
+    });
+  });
+
   describe(".getFirstCommit()", () => {
     it("should exist", () => {
       assert.ok(GitUtilities.getFirstCommit);
@@ -59,6 +65,12 @@ describe("GitUtilities", () => {
   describe(".pushWithTags()", () => {
     it("should exist", () => {
       assert.ok(GitUtilities.pushWithTags);
+    });
+  });
+
+  describe(".getLastTag()", () => {
+    it("should exist", () => {
+      assert.ok(GitUtilities.getLastTag);
     });
   });
 
@@ -77,6 +89,12 @@ describe("GitUtilities", () => {
   describe(".getCurrentSHA()", () => {
     it("should exist", () => {
       assert.ok(GitUtilities.getCurrentSHA);
+    });
+  });
+
+  describe(".getCurrentBranchDescription()", () => {
+    it("should exist", () => {
+      assert.ok(GitUtilities.getCurrentBranchDescription);
     });
   });
 

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -35,6 +35,15 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -132,6 +141,15 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -227,6 +245,15 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" }
@@ -316,6 +343,15 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" }
@@ -402,6 +438,15 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -480,6 +525,15 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -548,6 +602,15 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -602,6 +665,15 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
@@ -859,6 +931,15 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git describe --tags --abbrev=0"] }
+        ]],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["git tag"] }
        ]],

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -1012,6 +1012,12 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["git tag"] }
        ]],
@@ -1110,6 +1116,12 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -1206,6 +1218,12 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["git tag"] }
        ]],
@@ -1304,6 +1322,12 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git branch | sed -n '/\* /s///p'"] }
+        ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -740,6 +740,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "confirm", { valueCallback: true }, [
@@ -774,7 +775,7 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag ls package-4", {env: {"npm_config_registry":"https://my-private-registry"}}], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp", {env: {"npm_config_registry":"https://my-private-registry"}}] },
           { args: ["npm dist-tag add package-4@1.0.1 latest", {env: {"npm_config_registry":"https://my-private-registry"}}] },
-          
+
           { args: ["npm dist-tag ls package-2", {env: {"npm_config_registry":"https://my-private-registry"}}], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
           { args: ["npm dist-tag rm package-2 lerna-temp", {env: {"npm_config_registry":"https://my-private-registry"}}] },
           { args: ["npm dist-tag add package-2@1.0.1 latest", {env: {"npm_config_registry":"https://my-private-registry"}}] },
@@ -834,6 +835,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "confirm", { valueCallback: true }, [

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -38,9 +38,6 @@ describe("PublishCommand", () => {
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -137,9 +134,6 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
-        [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
@@ -242,9 +236,6 @@ describe("PublishCommand", () => {
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] },
         ]],
         [ChildProcessUtilities, "execSync", {}, [
@@ -335,9 +326,6 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
-        [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
@@ -433,9 +421,6 @@ describe("PublishCommand", () => {
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -517,9 +502,6 @@ describe("PublishCommand", () => {
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -591,9 +573,6 @@ describe("PublishCommand", () => {
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -648,9 +627,6 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
-        [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
@@ -915,9 +891,6 @@ describe("PublishCommand", () => {
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
        [PromptUtilities, "confirm", { valueCallback: true }, [
@@ -1012,9 +985,6 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
-        [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
@@ -1119,9 +1089,6 @@ describe("PublishCommand", () => {
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -1218,9 +1185,6 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
-        [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
@@ -1322,9 +1286,6 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
-        [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -41,9 +41,6 @@ describe("PublishCommand", () => {
           { args: ["git branch | sed -n '/\* /s///p'"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -147,9 +144,6 @@ describe("PublishCommand", () => {
           { args: ["git branch | sed -n '/\* /s///p'"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -251,10 +245,9 @@ describe("PublishCommand", () => {
           { args: ["git branch | sed -n '/\* /s///p'"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
+          { args: ["git tag"] },
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git tag"] },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" }
         ]],
@@ -349,10 +342,9 @@ describe("PublishCommand", () => {
           { args: ["git branch | sed -n '/\* /s///p'"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
+          { args: ["git tag"] },
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git tag"] },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" }
         ]],
@@ -444,9 +436,6 @@ describe("PublishCommand", () => {
           { args: ["git branch | sed -n '/\* /s///p'"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -531,9 +520,6 @@ describe("PublishCommand", () => {
           { args: ["git branch | sed -n '/\* /s///p'"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -608,9 +594,6 @@ describe("PublishCommand", () => {
           { args: ["git branch | sed -n '/\* /s///p'"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -670,9 +653,6 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git branch | sed -n '/\* /s///p'"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -938,11 +918,8 @@ describe("PublishCommand", () => {
           { args: ["git branch | sed -n '/\* /s///p'"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git describe --tags --abbrev=0"] }
+          { args: ["git tag"] }
         ]],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["git tag"] }
-       ]],
        [PromptUtilities, "confirm", { valueCallback: true }, [
          { args: ["Are you sure you want to publish the above changes?"], returns: true }
        ]],

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -35,10 +35,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -138,10 +138,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -239,10 +239,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] },
@@ -336,10 +336,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] },
@@ -430,10 +430,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -514,10 +514,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -588,10 +588,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -649,10 +649,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -912,10 +912,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -1013,10 +1013,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["git tag"] }
@@ -1116,10 +1116,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
@@ -1219,10 +1219,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["git tag"] }
@@ -1323,10 +1323,10 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git branch | sed -n '/\* /s///p'"] }
+          { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -61,7 +61,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 2) assert.equal(message, `- package-1\n- package-2\n- package-3\n- package-4\n- package-5 (${chalk.red("private")}`);
+        if (calls === 2) assert.equal(message, `- package-1\n- package-2\n- package-3\n- package-4\n- package-5 (${chalk.red("private")})`);
         calls++;
       });
 
@@ -192,7 +192,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 2) assert.equal(message, `- package-1\n- package-2\n- package-3\n- package-4\n- package-5 (${chalk.red("private")}`);
+        if (calls === 2) assert.equal(message, `- package-1\n- package-2\n- package-3\n- package-4\n- package-5 (${chalk.red("private")})`);
         calls++;
       });
 

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -38,7 +38,25 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, "- package-2\n- package-3");
+        calls++;
+      });
+
+      updatedCommand.runCommand(exitWithCode(0, done));
+    });
+
+    it("should list all packages when no tag is found", (done) => {
+      const updatedCommand = new UpdatedCommand([], {});
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      let calls = 0;
+      stub(logger, "info", (message) => {
+        if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "No tags found! Comparing with initial commit.");
+        if (calls === 2) assert.equal(message, `- package-1\n- package-2\n- package-3\n- package-4\n- package-5 (${chalk.red("private")})`);
         calls++;
       });
 
@@ -61,6 +79,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, `- package-1\n- package-2\n- package-3\n- package-4\n- package-5 (${chalk.red("private")})`);
         calls++;
       });
@@ -84,6 +103,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, "- package-2\n- package-3\n- package-4");
         calls++;
       });
@@ -113,6 +133,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, "- package-3");
         calls++;
       });
@@ -136,6 +157,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, "- package-2");
         calls++;
       });
@@ -169,6 +191,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, "- package-3\n- package-4");
         calls++;
       });
@@ -192,6 +215,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, `- package-1\n- package-2\n- package-3\n- package-4\n- package-5 (${chalk.red("private")})`);
         calls++;
       });
@@ -215,6 +239,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, "- package-2\n- package-3\n- package-4");
         calls++;
       });
@@ -244,6 +269,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
+        if (calls === 1) assert.equal(message, "Comparing with: v1.0.0");
         if (calls === 2) assert.equal(message, "- package-3\n- package-4");
         calls++;
       });

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -114,8 +114,10 @@ describe("UpdatedCommand", () => {
     it("should list changes without ignored files", (done) => {
       const lernaJsonLocation = path.join(testDir, "lerna.json");
       const lernaJson = JSON.parse(fs.readFileSync(lernaJsonLocation));
-      lernaJson.publishConfig = {
-        ignore: ["ignored-file"]
+      lernaJson.commands = {
+        publish: {
+          ignore: ["ignored-file"],
+        },
       };
       fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
 
@@ -250,8 +252,10 @@ describe("UpdatedCommand", () => {
     it("should list changes without ignored files", (done) => {
       const lernaJsonLocation = path.join(testDir, "lerna.json");
       const lernaJson = JSON.parse(fs.readFileSync(lernaJsonLocation));
-      lernaJson.publishConfig = {
-        ignore: ["ignored-file"]
+      lernaJson.commands = {
+        publish: {
+          ignore: ["ignored-file"],
+        },
       };
       fs.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
 


### PR DESCRIPTION
Lerna by default now check changes between last tag in current branch (instead of current latest tag in whole repository), it allows to publish older versions of project. (Issue 89).

Checks that user is in a branch and not a detached commit, because lerna can't publish without git branch.

(Issue #89). Reopened pull request #415, because I couldn't work on it anymore.