### PR TITLE
Add export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,22 @@ repo.  Each commit is modified to make changes relative to the package
 directory.  So, for example, the commit that added `package.json` will
 instead add `packages/<directory-name>/package.json`.
 
+### export
+
+```sh
+$ lerna export <package-name> <path-to-external-directory>
+```
+
+Export the package at `<package-name>` into a new directory, at
+`<path-to-external-directory>`.  Both parameters are optional; if
+`<package-name>` is omitted, all packages are ejected; if
+`<path-to-external-directory>` is not provided, the package or packages are
+exported to the user's home directory.  Also respects the `dry-run` option, in
+which case it only logs what would be moved.
+
+This allows you to move packages out of an existing lerna repository and into
+its own repository, in case it turns out to be easier to manage on its own.
+
 ## Misc
 
 Lerna will log to a `lerna-debug.log` file (same as `npm-debug.log`) when it encounters an error running a command.

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -14,6 +14,7 @@ var cli = meow([
   "  publish    Publish updated packages to npm",
   "  updated    Check which packages have changed since the last release",
   "  import     Import a package with git history from an external repository",
+  "  export     Remove all packages or a single package from the repository",
   "  clean      Remove the node_modules directory from all packages",
   "  diff       Diff all packages or a single package since the last release",
   "  init       Initialize a lerna repo",
@@ -34,6 +35,7 @@ var cli = meow([
   "  --repo-version       Specify repo version to publish",
   "  --concurrency        How many threads to use if lerna parallelises the tasks (defaults to 4)",
   "  --loglevel           What level of logs to report (defaults to \"info\").  On failure, all logs are written to lerna-debug.log in the current working directory.",
+  "  --dry-run            Only log what would have changed instead of commiting changes (export only)",
 ], {
   alias: {
     independent: "i",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "rimraf": "^2.4.4",
     "semver": "^5.1.0",
     "signal-exit": "^2.1.2",
-    "sync-exec": "^0.6.2"
+    "sync-exec": "^0.6.2",
+    "user-home": "^2.0.0"
   },
   "bin": {
     "lerna": "./bin/lerna.js"

--- a/src/commands/ExportCommand.js
+++ b/src/commands/ExportCommand.js
@@ -1,0 +1,68 @@
+import Command from "../Command";
+import ChildProcessUtilities from "../ChildProcessUtilities";
+import FileSystemUtilities from "../FileSystemUtilities";
+import async from "async";
+import path from "path";
+import userHome from "user-home";
+
+export default class ExportCommand extends Command {
+  initialize(callback) {
+    this.dry = this.flags.dryRun;
+
+    this.pkg = this.input[0];
+    this.to = this.input[1] || userHome;
+
+    if (this.dry) {
+      this.logger.info("The following directories would be moved");
+    }
+
+    callback(null, true);
+  }
+
+  execute(callback) {
+    if (!this.to) {
+      // we actually know that this is an error earlier, during initialization,
+      // but calling the initialization errback with an error doesn't halt
+      // execution and print a nice error like the execute errback.
+      return callback(new Error("no directory found to export to; please provide a second argument"));
+    }
+
+    if (this.pkg) {
+      const pkg = this.packageGraph.get(this.pkg);
+
+      if (!pkg) {
+        if (this.to) {
+          return callback(`no such package to export ${this.pkg}`);
+        } else {
+          // they're not exporting a single package to their home directory,
+          // they're exporting everything to a provided directory!
+          this.to = this.pkg;
+          this.pkg = undefined; // http://jsperf.com/delete-vs-undefined-vs-null/16
+        }
+      }
+
+      this.runCommandInPackage(pkg.package, callback);
+    } else {
+      async.parallelLimit(this.filteredPackages.map((pkg) => (cb) => {
+        this.runCommandInPackage(pkg, cb);
+      }), this.concurrency, callback);
+    }
+  }
+
+  runCommandInPackage(pkg, callback) {
+    const to = path.join(this.to, path.basename(pkg._location));
+
+    if (this.dry) {
+      this.logger.info(`  - ${pkg._location} -> ${to}`);
+      return callback(null, true);
+    } else {
+      const branchName = `export-${pkg.name}`;
+      ChildProcessUtilities.execSync(`git subtree split -P ${pkg._location.replace(process.cwd() + "/", "")} -b ${branchName}`);
+      FileSystemUtilities.mkdirSync(to);
+      ChildProcessUtilities.execSync("git init", {cwd: to});
+      ChildProcessUtilities.execSync(`git pull ${process.cwd()} ${branchName}`, {cwd: to});
+      ChildProcessUtilities.execSync(`git rm -r ${pkg._location}`);
+      return callback(null, true);
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import CleanCommand from "./commands/CleanCommand";
 import DiffCommand from "./commands/DiffCommand";
 import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
+import ExportCommand from "./commands/ExportCommand";
 import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
 
@@ -14,6 +15,7 @@ export const __commands__ = {
   publish: PublishCommand,
   updated: UpdatedCommand,
   import: ImportCommand,
+  export: ExportCommand,
   clean: CleanCommand,
   diff: DiffCommand,
   init: InitCommand,

--- a/test/ExportCommand.js
+++ b/test/ExportCommand.js
@@ -1,0 +1,142 @@
+import assert from "assert";
+import exitWithCode from "./_exitWithCode";
+import initFixture from "./_initFixture";
+import ExportCommand from "../src/commands/ExportCommand";
+import FileSystemUtilities from "../src/FileSystemUtilities";
+import ChildProcessUtilities from "../src/ChildProcessUtilities";
+import userHome from "user-home";
+import logger from "../src/logger";
+import stub from "./_stub";
+import path from "path";
+import assertStubbedCalls from "./_assertStubbedCalls";
+
+describe("ExportCommand", () => {
+
+  let testDir;
+  describe("in a basic repo", () => {
+    beforeEach((done) => {
+      testDir = initFixture("ExportCommand/basic", done);
+    });
+
+    it("should export all packages", (done) => {
+      const exportCommand = new ExportCommand([], {"dry-run": true});
+
+      exportCommand.runValidations();
+      exportCommand.runPreparations();
+
+      stub(ChildProcessUtilities, "execSync", () => {});
+      stub(FileSystemUtilities, "mkdirSync", () => {});
+
+      assertStubbedCalls([]
+        .concat(getStubbedAssertions({ FileSystemUtilities, ChildProcessUtilities, testDir, to: userHome, pkg: "package-1" }))
+        .concat(getStubbedAssertions({ FileSystemUtilities, ChildProcessUtilities, testDir, to: userHome, pkg: "package-2" }))
+        .concat(getStubbedAssertions({ FileSystemUtilities, ChildProcessUtilities, testDir, to: userHome, pkg: "package-3" }))
+        .concat(getStubbedAssertions({ FileSystemUtilities, ChildProcessUtilities, testDir, to: userHome, pkg: "package-4" }))
+      );
+
+
+      exportCommand.runCommand(exitWithCode(0, done));
+    });
+
+    it("should export a single package", (done) => {
+      const to = "/path/to/the/mls/cup";
+      const pkg = "package-2";
+      const exportCommand = new ExportCommand([pkg, to], {"dry-run": true});
+
+      exportCommand.runValidations();
+      exportCommand.runPreparations();
+
+      stub(ChildProcessUtilities, "execSync", () => {});
+      stub(FileSystemUtilities, "mkdirSync", () => {});
+
+      assertStubbedCalls(getStubbedAssertions({ FileSystemUtilities, ChildProcessUtilities, testDir, to, pkg }));
+
+      exportCommand.runCommand(exitWithCode(0, done));
+    });
+
+    describe("while doing a dry run", () => {
+      it("should export a single package", (done) => {
+        const pkg = "package-1";
+        const exportCommand = new ExportCommand([pkg], {dryRun: true});
+
+        exportCommand.runValidations();
+        exportCommand.runPreparations();
+
+        let index = 0;
+        const patterns = [
+          "The following directories would be moved",
+          pkg
+        ];
+        stub(logger, "info", (message) => {
+          assert.ok(message.includes(patterns[index]));
+          index++;
+        });
+
+        exportCommand.runCommand(exitWithCode(0, done));
+      });
+
+      it("should export all packages", (done) => {
+        const exportCommand = new ExportCommand([], {dryRun: true});
+
+        exportCommand.runValidations();
+        exportCommand.runPreparations();
+
+        let index = 0;
+        const patterns = [
+          "The following directories would be moved",
+          "package-1",
+          "package-2",
+          "package-3",
+          "package-4"
+        ];
+        stub(logger, "info", (message) => {
+          assert.ok(message.includes(patterns[index]));
+          index++;
+        });
+
+        exportCommand.runCommand(exitWithCode(0, done));
+      });
+
+      it("should allow you to specify a target directory", (done) => {
+        const to = "/path/to/the/mls/cup";
+        const pkg = "package-2";
+        const exportCommand = new ExportCommand([pkg, to], {dryRun: true});
+
+        exportCommand.runValidations();
+        exportCommand.runPreparations();
+
+        let index = 0;
+        const patterns = [
+          "The following directories would be moved",
+          pkg
+        ];
+        stub(logger, "info", (message) => {
+          assert.ok(message.includes(patterns[index]));
+          index++;
+        });
+
+        exportCommand.runCommand(exitWithCode(0, done));
+      });
+    });
+  });
+});
+
+function getStubbedAssertions({ FileSystemUtilities, ChildProcessUtilities, testDir, to, pkg }) {
+  return [
+    [ChildProcessUtilities, "execSync", { nodeCallback: true }, [
+      { args: [`git subtree split -P ${testDir}/packages/${pkg} -b export-${pkg}`] }
+    ]],
+    [FileSystemUtilities, "mkdirSync", { nodeCallback: true }, [
+      { filePath: path.join(to, pkg) }
+    ]],
+    [ChildProcessUtilities, "execSync", { nodeCallback: true }, [
+      { args: ["git init"] }
+    ]],
+    [ChildProcessUtilities, "execSync", { nodeCallback: true }, [
+      { args: [`git pull ${testDir} export-${pkg}`] }
+    ]],
+    [ChildProcessUtilities, "execSync", { nodeCallback: true }, [
+      { args: [`git rm -r ${testDir}/packages/${pkg}`] }
+    ]],
+  ];
+}

--- a/test/fixtures/ExportCommand/basic/asini.json
+++ b/test/fixtures/ExportCommand/basic/asini.json
@@ -1,0 +1,4 @@
+{
+  "asini": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ExportCommand/basic/package.json
+++ b/test/fixtures/ExportCommand/basic/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/ExportCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/ExportCommand/basic/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ExportCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/ExportCommand/basic/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/ExportCommand/basic/packages/package-3/package.json
+++ b/test/fixtures/ExportCommand/basic/packages/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "devDependencies": {
+    "package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/ExportCommand/basic/packages/package-4/package.json
+++ b/test/fixtures/ExportCommand/basic/packages/package-4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^0.0.0"
+  }
+}


### PR DESCRIPTION
This pr adds a new command, an export command.  This is conceptually similar to create-react-app's eject functionality, and is (somewhat paradoxically) intended to increase and ease adoption of lerna by making new users feel that they aren't "locked in" to the framework, and is the companion to the existing "import" command.