### PR TITLE
Add missing folder in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Your repository should now look like this:
 
 ```
 lerna-repo/
+  packages/
   package.json
   lerna.json
 ```


### PR DESCRIPTION
In the website, the `packages` folder exists in the [_Getting Started_](https://lernajs.io/#getting-started) section, but it doesn't exist in the README.md file in the repository.