### PR TITLE
Do not check diff status if specify the forcePublish field

### DIFF
--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -66,7 +66,7 @@ export default class UpdatedPackagesCollector {
         return true;
       } else if (forcePublish.indexOf(pkg.name) > -1) {
         return true;
-      } else {
+      } else if (!this.flags.forcePublish) { // Do not check diff status if specify the forcePublish field
         return this.hasDiffSinceThatIsntIgnored(pkg, commits);
       }
     }).forEach((pkg) => {

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -218,7 +218,7 @@ describe("UpdatedCommand", () => {
       let calls = 0;
       stub(logger, "info", (message) => {
         if (calls === 0) assert.equal(message, "Checking for updated packages...");
-        if (calls === 2) assert.equal(message, "- package-2\n- package-3\n- package-4");
+        if (calls === 1) assert.equal(message, "- package-2");
         calls++;
       });
 


### PR DESCRIPTION
According to the instruction in README.md: https://github.com/lerna/lerna#--force-publish-packages

> This will skip the lerna updated check for changed packages and forces a package that didn't have a git diff change to be updated.

---

And [this test case](https://github.com/lerna/lerna/blob/d6409a6c63f999da12d6b26ed00cffb3992206c0/test/UpdatedCommand.js#L67) would never run because calls can't be `2`.