### PR TITLE
Add configuration for `lerna-changelog`

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,17 @@
+{
+  "lerna": "2.0.0-beta.32",
+  "packages": [
+    "."
+  ],
+  "changelog": {
+    "repo": "lerna/lerna",
+    "labels": {
+      "breaking": "Breaking change",
+      "enhancement": "Enhancement",
+      "bug": "Bug fix",
+      "docs": "Documentation"
+    },
+    "cacheDir": ".changelog"
+  },
+  "version": "0.0.0"
+}


### PR DESCRIPTION
This technically makes Lerna a Lerna repo, but it doesn't tackle any of the substantive changes from #174.