### PR TITLE
Don't include unnecesary files in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-src
-test
-tmp

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+appveyor.yml
+.babelrc
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+.editorconfig
+.eslintrc
+.gitignore
+lerna.json
+.travis.yml
+yarn.lock
+src
+test
+tmp
+.npmignore

--- a/package.json
+++ b/package.json
@@ -50,10 +50,6 @@
   "bin": {
     "lerna": "./bin/lerna.js"
   },
-  "files": [
-    "bin",
-    "lib"
-  ],
   "devDependencies": {
     "babel-cli": "^6.7.5",
     "babel-eslint": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
   "bin": {
     "lerna": "./bin/lerna.js"
   },
+  "files": [
+    "bin",
+    "lib"
+  ],
   "devDependencies": {
     "babel-cli": "^6.7.5",
     "babel-eslint": "^6.0.2",


### PR DESCRIPTION
Fixes #516 

Looks to me like only bin/lib are needed (well, and package.json, CHANGELOG.md, LICENSE, README.md which are included by default)--so I switched out the `.npmignore` for a 2 entry `files`.
Edit: ^ undid the switch

I wasn't 100% sure about the yarn files; looks like the answer is don't publish them: see the last line of https://yarnpkg.com/en/docs/yarn-lock

I sanity checked with:
```
npm pack
tar xvf lerna-2.0.0-beta.33.tgz
cd package
ls -a  # => bin  CHANGELOG.md  lib  LICENSE  package.json  README.md
./bin/lerna.js # => prints help message
```

Cuts the package size in half :) 
```
$ du -b --apparent-size lerna-2.0.0-beta.33.tgz after.tgz             
72884   lerna-2.0.0-beta.33.tgz
33347   after.tgz
```