### PR TITLE
[CRITICAL] Publish command is broken for 2.0.0-beta.33

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -22,6 +22,8 @@ export default class PublishCommand extends Command {
       this.logger.info("Current version: " + this.globalVersion);
     }
 
+    this.configFlags = this.repository.publishConfig;
+
     const updatedPackagesCollector = new UpdatedPackagesCollector(
       this.repository,
       this.flags,


### PR DESCRIPTION
Fixes [this reported bug](https://lernajs.slack.com/files/diogo/F3W4R0JRF/-.txt) that is not allowing people using `2.0.0-beta.33` to publish packages.

Config flags shouldn't be undefined for publish.