### PR TITLE
Fixes issue: prepublish not running in dependencies with `--scope --include-filtered-dependencies`

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -49,7 +49,7 @@ export default class BootstrapCommand extends Command {
   }
 
   runScriptInPackages(scriptName, callback) {
-    const packages = this.filteredPackages.slice();
+    const packages = this.packagesToBootstrap.slice();
     const batches = PackageUtilities.topologicallyBatchPackages(packages, this.logger);
 
     if (!batches.length) {

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -379,6 +379,9 @@ describe("BootstrapCommand", () => {
         try {
           assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
 
+          // Make sure the `prepublish` script got run (index.js got created)
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
+
           done();
         } catch (err) {
           done(err);
@@ -410,6 +413,9 @@ describe("BootstrapCommand", () => {
 
         try {
           assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+
+          // Make sure the `prepublish` script got run (index.js got created), even though we --ignored package-1
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
 
           done();
         } catch (err) {


### PR DESCRIPTION
This fixes an issue where `lerna bootstrap --scope foo --include-filtered-dependencies`
was only running `prepublish` in the specifically-named scoped packages, rather than in
all transitive dependencies. (e.g., `foo` gets prepublish run, but if `foo` depends on `bar`, `bar` doesn't get prepublished).

I think this was maybe just missed in #390?