### PR TITLE
[clean] Support --include-filtered-dependencies flag

### DIFF
--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -1,16 +1,22 @@
 import async from "async";
 import Command from "../Command";
 import FileSystemUtilities from "../FileSystemUtilities";
+import PackageUtilities from "../PackageUtilities";
 import PromptUtilities from "../PromptUtilities";
 import progressBar from "../progressBar";
 
 export default class CleanCommand extends Command {
   initialize(callback) {
+    this.packagesToClean = this.filteredPackages;
+    if (this.flags.includeFilteredDependencies) {
+      this.packagesToClean = PackageUtilities.addDependencies(this.packagesToClean, this.packageGraph);
+    }
+
     if (this.flags.yes) {
       callback(null, true);
     } else {
       this.logger.info(`About to remove the following directories:\n${
-        this.filteredPackages.map((pkg) => "- " + pkg.nodeModulesLocation).join("\n")
+        this.packagesToClean.map((pkg) => "- " + pkg.nodeModulesLocation).join("\n")
       }`);
       PromptUtilities.confirm("Proceed?", (confirmed) => {
         if (confirmed) {
@@ -24,7 +30,7 @@ export default class CleanCommand extends Command {
   }
 
   execute(callback) {
-    progressBar.init(this.filteredPackages.length);
+    progressBar.init(this.packagesToClean.length);
     this.rimrafNodeModulesInPackages((err) => {
       progressBar.terminate();
       if (err) {
@@ -37,7 +43,7 @@ export default class CleanCommand extends Command {
   }
 
   rimrafNodeModulesInPackages(callback) {
-    async.parallelLimit(this.filteredPackages.map((pkg) => (cb) => {
+    async.parallelLimit(this.packagesToClean.map((pkg) => (cb) => {
       FileSystemUtilities.rimraf(pkg.nodeModulesLocation, (err) => {
         progressBar.tick(pkg.name);
         cb(err);

--- a/test/CleanCommand.js
+++ b/test/CleanCommand.js
@@ -10,59 +10,103 @@ import stub from "./_stub";
 import assertStubbedCalls from "./_assertStubbedCalls";
 
 describe("CleanCommand", () => {
-  let testDir;
 
-  beforeEach((done) => {
-    testDir = initFixture("CleanCommand/basic", done);
-  });
+  describe("basic tests", () => {
+    let testDir;
 
-  it("should rm -rf the node_modules", (done) => {
-    const cleanCommand = new CleanCommand([], {});
-
-    assertStubbedCalls([
-      [PromptUtilities, "confirm", { valueCallback: true }, [
-        { args: ["Proceed?"], returns: true }
-      ]],
-    ]);
-
-    cleanCommand.runValidations();
-    cleanCommand.runPreparations();
-
-    let curPkg = 1;
-    stub(FileSystemUtilities, "rimraf", (actualDir, callback) => {
-      const expectedDir = path.join(
-        testDir, "packages/package-" + curPkg, "node_modules"
-      );
-
-      assert.equal(actualDir, expectedDir);
-
-      curPkg++;
-      callback();
+    beforeEach((done) => {
+      testDir = initFixture("CleanCommand/basic", done);
     });
 
-    cleanCommand.runCommand(exitWithCode(0, done));
-  });
+    it("should rm -rf the node_modules", (done) => {
+      const cleanCommand = new CleanCommand([], {});
 
-  it("should be possible to skip asking for confirmation", (done) => {
-    const cleanCommand = new CleanCommand([], {
-      yes: true
+      assertStubbedCalls([
+        [PromptUtilities, "confirm", { valueCallback: true }, [
+          { args: ["Proceed?"], returns: true }
+        ]],
+      ]);
+
+      cleanCommand.runValidations();
+      cleanCommand.runPreparations();
+
+      let curPkg = 1;
+      stub(FileSystemUtilities, "rimraf", (actualDir, callback) => {
+        const expectedDir = path.join(
+          testDir, "packages/package-" + curPkg, "node_modules"
+        );
+
+        assert.equal(actualDir, expectedDir);
+
+        curPkg++;
+        callback();
+      });
+
+      cleanCommand.runCommand(exitWithCode(0, done));
     });
 
-    cleanCommand.runValidations();
-    cleanCommand.runPreparations();
-
-    cleanCommand.initialize(done);
-  });
-
-  // Both of these commands should result in the same outcome
-  const filters = [
-    { test: "should only clean scoped packages", flag: "scope", flagValue: "package-@(1|2)"},
-    { test: "should not clean ignored packages", flag: "ignore", flagValue: "package-@(3|4)"},
-  ];
-  filters.forEach((filter) => {
-    it(filter.test, (done) => {
+    it("should be possible to skip asking for confirmation", (done) => {
       const cleanCommand = new CleanCommand([], {
-        [filter.flag]: filter.flagValue
+        yes: true
+      });
+
+      cleanCommand.runValidations();
+      cleanCommand.runPreparations();
+
+      cleanCommand.initialize(done);
+    });
+
+    // Both of these commands should result in the same outcome
+    const filters = [
+      { test: "should only clean scoped packages", flag: "scope", flagValue: "package-@(1|2)"},
+      { test: "should not clean ignored packages", flag: "ignore", flagValue: "package-@(3|4)"},
+    ];
+    filters.forEach((filter) => {
+      it(filter.test, (done) => {
+        const cleanCommand = new CleanCommand([], {
+          [filter.flag]: filter.flagValue
+        });
+
+        assertStubbedCalls([
+          [PromptUtilities, "confirm", { valueCallback: true }, [
+            { args: ["Proceed?"], returns: true }
+          ]],
+        ]);
+
+        cleanCommand.runValidations();
+        cleanCommand.runPreparations();
+
+        const actualDirToPackageName = (dir) => {
+          const prefixLength = path.join(testDir, "packages/").length;
+          const suffixLength = "/node_modules".length;
+          const packageNameLength = dir.length - prefixLength - suffixLength;
+          return dir.substr(prefixLength, packageNameLength);
+        };
+        const ranInPackages = [];
+        stub(FileSystemUtilities, "rimraf", (actualDir, callback) => {
+          ranInPackages.push(actualDirToPackageName(actualDir));
+          callback();
+        });
+
+        cleanCommand.runCommand(exitWithCode(0, () => {
+          assert.deepEqual(ranInPackages, ["package-1", "package-2"]);
+          done();
+        }));
+      });
+    });
+  });
+
+  describe("--include-filtered-dependencies", () => {
+    let testDir;
+
+    beforeEach((done) => {
+      testDir = initFixture("CleanCommand/include-filtered-dependencies", done);
+    });
+
+    it("should not remove node_modules from unaffiliated packages", (done) => {
+      const cleanCommand = new CleanCommand([], {
+        scope: "@test/package-2",
+        includeFilteredDependencies: true
       });
 
       assertStubbedCalls([
@@ -74,22 +118,18 @@ describe("CleanCommand", () => {
       cleanCommand.runValidations();
       cleanCommand.runPreparations();
 
-      const actualDirToPackageName = (dir) => {
-        const prefixLength = path.join(testDir, "packages/").length;
-        const suffixLength = "/node_modules".length;
-        const packageNameLength = dir.length - prefixLength - suffixLength;
-        return dir.substr(prefixLength, packageNameLength);
-      };
       const ranInPackages = [];
       stub(FileSystemUtilities, "rimraf", (actualDir, callback) => {
-        ranInPackages.push(actualDirToPackageName(actualDir));
+        ranInPackages.push(actualDir);
         callback();
       });
 
       cleanCommand.runCommand(exitWithCode(0, () => {
-        assert.deepEqual(ranInPackages, ["package-1", "package-2"]);
+        const expected = ["package-1", "package-2"].map((pkg) => path.join(testDir, "packages", pkg, "node_modules"));
+        assert.deepEqual(ranInPackages.sort(), expected.sort());
         done();
       }));
     });
+
   });
 });

--- a/test/fixtures/CleanCommand/include-filtered-dependencies/lerna.json
+++ b/test/fixtures/CleanCommand/include-filtered-dependencies/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/CleanCommand/include-filtered-dependencies/package.json
+++ b/test/fixtures/CleanCommand/include-filtered-dependencies/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/CleanCommand/include-filtered-dependencies/packages/package-1/package.json
+++ b/test/fixtures/CleanCommand/include-filtered-dependencies/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/CleanCommand/include-filtered-dependencies/packages/package-2/package.json
+++ b/test/fixtures/CleanCommand/include-filtered-dependencies/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-2",
+  "version": "1.0.0",
+  "dependencies": {
+  	"@test/package-1": "1.0.0"
+  }
+}

--- a/test/fixtures/CleanCommand/include-filtered-dependencies/packages/package-3/package.json
+++ b/test/fixtures/CleanCommand/include-filtered-dependencies/packages/package-3/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-3",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Sorry about the horkage in the CleanCommand test. I moved the existing tests into their own `describe`, which caused whitespace changes, which... you can see the results.