### PR TITLE
Proposal: Spawn child process for rimraf

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -1,11 +1,11 @@
 import pathExists from "path-exists";
 import logger from "./logger";
 import mkdirp from "mkdirp";
-import rimraf from "rimraf";
 import fs from "fs";
 import cmdShim from "cmd-shim";
 import readCmdShim from "read-cmd-shim";
-import { resolve, dirname, relative } from "path";
+import { resolve, dirname, relative, join } from "path";
+import ChildProcessUtilities from "./ChildProcessUtilities";
 
 const ENDS_WITH_NEW_LINE = /\n$/;
 
@@ -51,7 +51,10 @@ export default class FileSystemUtilities {
 
   @logger.logifyAsync()
   static rimraf(filePath, callback) {
-    rimraf(filePath, callback);
+    ChildProcessUtilities.exec("npm bin", {cwd: __dirname}, (err, npmBinPath) => {
+      if (err) return callback(err);
+      ChildProcessUtilities.spawn(join(npmBinPath.trim(), "rimraf"), [filePath], {}, callback);
+    });
   }
 
   @logger.logifyAsync()


### PR DESCRIPTION
Improves performance of `lerna clean` on large projects.

I fully recognize that this could be contentious, but I also didn't see an issue/conversation about it, so I figured it couldn't hurt to submit. This shaves ~19s (21% improvement!) off our monorepo build with `lerna`:

```
# external rimraf (this PR)
lerna clean --concurrency 6 --loglevel debug --yes  81.95s user 114.90s system 281% cpu 1:10.00 total
lerna clean --concurrency 6 --loglevel debug --yes  78.54s user 117.52s system 282% cpu 1:09.41 total

lerna clean --concurrency 3 --loglevel debug --yes  71.90s user 108.78s system 249% cpu 1:12.42 total


#internal rimraf
lerna clean --concurrency 6 --loglevel debug --yes  55.34s user 85.40s system 156% cpu 1:29.84 total

lerna clean --concurrency 1 --loglevel debug --yes  59.14s user 94.69s system 142% cpu 1:48.14 total
```

For the purposes of conversation, I did the simplest thing I could think of, but I'm also open to exploring alternative solutions. I suspect that shelling out to `rm` and/or the windows equivalent would be even faster still, but I'll resist the urge to do that. :grin:

Update: One downside to this approach is that `rimraf` isn't a require-time dependency anymore, which might cause static analysis (or a human with a restrictive regex) to erroneously conclude that it's not actually being used.

Update 2: Added a couple of additional timings for posterity (`--concurrency 3` for external, `--concurrency 1` for internal).