### PR TITLE
Bump `object-assigned-sorted`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.1",
     "normalize-path": "^2.0.1",
-    "object-assign-sorted": "^1.0.0",
+    "object-assign-sorted": "^2.0.1",
     "pad": "^1.0.0",
     "path-exists": "^2.1.0",
     "progress": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,7 +1519,7 @@ is-path-inside@^1.0.0:
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
-  resolved "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
 
 is-primitive@^2.0.0:
   version "2.0.0"
@@ -1944,11 +1944,10 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign-sorted@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/object-assign-sorted/-/object-assign-sorted-1.0.0.tgz#e739f698164014ec1f050f38decabad1e9b228bf"
+object-assign-sorted@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object-assign-sorted/-/object-assign-sorted-2.0.1.tgz#c9983fa9e3ed5807b49cf1a9943378f245d9395b"
   dependencies:
-    object-assign "^4.0.1"
     sorted-object "^2.0.0"
 
 object-assign@^4.0.1, object-assign@^4.1.0:
@@ -2205,7 +2204,7 @@ regenerator-transform@0.9.8:
 
 regex-cache@^0.4.2:
   version "0.4.3"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  resolved "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
   dependencies:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"


### PR DESCRIPTION
`object-assigned-sorted@2.0.1` drops the `object-assign` dependency.