### PR TITLE
Bump `signal-exit`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "read-cmd-shim": "^1.0.1",
     "rimraf": "^2.4.4",
     "semver": "^5.1.0",
-    "signal-exit": "^2.1.2",
+    "signal-exit": "^3.0.2",
     "sync-exec": "^0.6.2"
   },
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,7 +2204,7 @@ regenerator-transform@0.9.8:
 
 regex-cache@^0.4.2:
   version "0.4.3"
-  resolved "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
   dependencies:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"
@@ -2336,10 +2336,6 @@ shelljs@^0.6.0:
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
-
-signal-exit@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-2.1.2.tgz#375879b1f92ebc3b334480d038dc546a6d558564"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Bumps `signal-exit` from `^2.1.2` to `^3.0.2`.  This way, it will dedupe with the version used by `loud-rejection`.  I don't think `lerna` was doing anything with SIGPROF, so it shouldn't be breaking.