### PR TITLE
Drop `isarray`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "cross-spawn": "^4.0.0",
     "glob": "^7.0.6",
     "inquirer": "^3.0.1",
-    "isarray": "^2.0.1",
     "lodash.find": "^4.3.0",
     "lodash.unionwith": "^4.2.0",
     "meow": "^3.7.0",

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -5,7 +5,6 @@ import path from "path";
 import {sync as globSync} from "glob";
 import minimatch from "minimatch";
 import async from "async";
-import isArray from "isarray";
 
 export default class PackageUtilities {
   static getGlobalVersion(versionPath) {
@@ -139,7 +138,7 @@ export default class PackageUtilities {
     // The double star here is to account for scoped packages.
     if (glob === true) glob = "**";
 
-    if (!isArray(glob)) glob = [glob];
+    if (!Array.isArray(glob)) glob = [glob];
 
     const maybeNegate = negate ? (v) => !v : (v) => v;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,7 +1519,7 @@ is-path-inside@^1.0.0:
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+  resolved "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
 
 is-primitive@^2.0.0:
   version "2.0.0"
@@ -1579,8 +1579,8 @@ jodid25519@^1.0.0:
     jsbn "~0.1.0"
 
 js-tokens@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.0.tgz#a2f2a969caae142fb3cd56228358c89366957bd1"
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
 js-yaml@^3.5.1:
   version "3.7.0"
@@ -2204,7 +2204,7 @@ regenerator-transform@0.9.8:
 
 regex-cache@^0.4.2:
   version "0.4.3"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  resolved "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
   dependencies:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"


### PR DESCRIPTION
Drops `isarray` for `Array.isArray`.