### PR TITLE
Bundle rimraf for predictable executable location

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "signal-exit": "^3.0.2",
     "sync-exec": "^0.6.2"
   },
+  "bundledDependencies": [
+    "rimraf"
+  ],
   "bin": {
     "lerna": "./bin/lerna.js"
   },


### PR DESCRIPTION
This is necessary to make #547 work when Lerna is installed locally.

Lerna is looking for the `rimraf` executable in its own `$(npm bin)` directory, but npm 3+ hoists the executable to the _containing_ package's `.bin` so `rimraf` winds up not being found.

This patch bundles `rimraf` _with_ Lerna so it's always where we expect it.