### PR TITLE
Fix rimraf bin resolution

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -4,7 +4,7 @@ import mkdirp from "mkdirp";
 import fs from "fs";
 import cmdShim from "cmd-shim";
 import readCmdShim from "read-cmd-shim";
-import { resolve, dirname, relative, join } from "path";
+import { resolve, dirname, relative } from "path";
 import ChildProcessUtilities from "./ChildProcessUtilities";
 
 const ENDS_WITH_NEW_LINE = /\n$/;
@@ -51,10 +51,7 @@ export default class FileSystemUtilities {
 
   @logger.logifyAsync()
   static rimraf(filePath, callback) {
-    ChildProcessUtilities.exec("npm bin", {cwd: __dirname}, (err, npmBinPath) => {
-      if (err) return callback(err);
-      ChildProcessUtilities.spawn(join(npmBinPath.trim(), "rimraf"), [filePath], {}, callback);
-    });
+    ChildProcessUtilities.spawn(require.resolve("rimraf/bin"), [filePath], {}, callback);
   }
 
   @logger.logifyAsync()

--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -51,6 +51,7 @@ export default class FileSystemUtilities {
 
   @logger.logifyAsync()
   static rimraf(filePath, callback) {
+    // Note: if rimraf moves the location of its executable, this will need to be updated
     ChildProcessUtilities.spawn(require.resolve("rimraf/bin"), [filePath], {}, callback);
   }
 


### PR DESCRIPTION
On NPM3, `rimraf` is being hoisted to the parent node_modules, so `exec("npm bin", {cwd: __dirname},` produces the wrong bin path. So in the current version of lerna, the clean command is broken.

I've simplified the logic to use `require.resolve`, which will work regardless of where rimraf is. This should also be faster as well!

Fixes bug introduced in: https://github.com/lerna/lerna/pull/547