### PR TITLE
Short-circuit out of install with no packages

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -7,6 +7,10 @@ import semver from "semver";
 export default class NpmUtilities {
   @logger.logifyAsync()
   static installInDir(directory, dependencies, callback) {
+
+    // Nothing to do if we weren't given any deps.
+    if (!(dependencies && dependencies.length)) return callback();
+
     let args = ["install"];
 
     if (dependencies) {


### PR DESCRIPTION
The degenerate case of `NpmUtilities.installInDir` is an install of no packages.  The _behavior_ in this case was previously to run an `npm install` with no arguments, which installs _everything_.

This patch short-circuits out of the noop.