### PR TITLE
Install with no arguments

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -39,6 +39,16 @@ export default class FileSystemUtilities {
     fs.writeFile(filePath, ensureEndsWithNewLine(fileContents), callback);
   }
 
+  @logger.logifyAsync()
+  static rename(from, to, callback) {
+    fs.rename(from, to, callback);
+  }
+
+  @logger.logifySync()
+  static renameSync(from, to) {
+    fs.renameSync(from, to);
+  }
+
   @logger.logifySync()
   static writeFileSync(filePath, fileContents) {
     fs.writeFileSync(filePath, ensureEndsWithNewLine(fileContents));

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -93,4 +93,31 @@ describe("FileSystemUtilities", () => {
       });
     });
   });
+
+  describe(".rename()", () => {
+    it("should rename a file", (done) => {
+      const srcPath = path.join(testDir, "src");
+      const dstPath = path.join(testDir, "dst");
+      fs.writeFileSync(srcPath, "contents");
+      FileSystemUtilities.rename(srcPath, dstPath, (err) => {
+        assert.ok(pathExists.sync(dstPath));
+        assert.ok(!pathExists.sync(srcPath));
+        assert.equal(fs.readFileSync(dstPath).toString(), "contents");
+        done(err);
+      });
+    });
+  });
+
+  describe(".renameSync()", () => {
+    it("should rename a file", () => {
+      const srcPath = path.join(testDir, "src");
+      const dstPath = path.join(testDir, "dst");
+      fs.writeFileSync(srcPath, "contents");
+      FileSystemUtilities.renameSync(srcPath, dstPath);
+      assert.ok(pathExists.sync(dstPath));
+      assert.ok(!pathExists.sync(srcPath));
+      assert.equal(fs.readFileSync(dstPath).toString(), "contents");
+    });
+  });
+
 });

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -6,4 +6,19 @@ describe("NpmUtilities", () => {
   it("should exist", () => {
     assert.ok(NpmUtilities);
   });
+
+  describe(".splitVersion()", () => {
+    [
+      ["foo", ["foo", undefined], "no version"],
+      ["foo@1.0.0", ["foo", "1.0.0"], "exact version"],
+      ["foo@^1.0.0", ["foo", "^1.0.0"], "caret range"],
+      ["@foo/bar", ["@foo/bar", undefined], "scoped with no version"],
+      ["@foo/bar@1.0.0",  ["@foo/bar", "1.0.0"], "scoped with exact version"],
+      ["@foo/bar@^1.0.0", ["@foo/bar", "^1.0.0"], "scoped with caret range"],
+    ].forEach(([have, want, desc]) => {
+      it("should handle " + desc, () => {
+        assert.deepEqual(NpmUtilities.splitVersion(have), want);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Use temporary package.json files.

This is groundwork for:

- Pluggable npm clients (yarn).
- A `lerna upgrade` command.

This is a port of https://github.com/asini/asini/pull/45.  Please see original PR commentary during review.