### PR TITLE
Improve support for --include-filtered-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ The `ignore` flag, when used with the `bootstrap` command, can also be set in `l
 
 #### --include-filtered-dependencies
 
-Used only in the `bootstrap` and `clean` commands, ensures that all dependencies (and dev dependencies) of any scoped packages (either through `--scope` or `--ignore`) are operated on as well.
+Used in combination with any command that accepts `--scope` (`bootstrap`, `clean`, `ls`, `run`, `exec`). Ensures that all dependencies (and dev dependencies) of any scoped packages (either through `--scope` or `--ignore`) are operated on as well.
 
 > Note: This will override the `--scope` and `--ignore` flags.
 > > i.e. A package matched by the `--ignore` flag will still be bootstrapped if it is depended on by another package that is being bootstrapped.

--- a/src/Command.js
+++ b/src/Command.js
@@ -147,8 +147,11 @@ export default class Command {
     try {
       this.repository.buildPackageGraph();
       this.packages = this.repository.packages;
-      this.filteredPackages = PackageUtilities.filterPackages(this.packages, {scope, ignore});
       this.packageGraph = this.repository.packageGraph;
+      this.filteredPackages = PackageUtilities.filterPackages(this.packages, {scope, ignore});
+      if (this.flags.includeFilteredDependencies) {
+        this.filteredPackages = PackageUtilities.addDependencies(this.filteredPackages, this.packageGraph);
+      }
     } catch (err) {
       this.logger.error("Errored while collecting packages and package graph", err);
       this._complete(null, 1);

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -18,7 +18,7 @@ export default class BootstrapCommand extends Command {
       if (err) {
         callback(err);
       } else {
-        this.logger.success(`Successfully bootstrapped ${this.packagesToBootstrap.length} packages.`);
+        this.logger.success(`Successfully bootstrapped ${this.filteredPackages.length} packages.`);
         callback(null, true);
       }
     });
@@ -29,15 +29,10 @@ export default class BootstrapCommand extends Command {
    * @param {Function} callback
    */
   bootstrapPackages(callback) {
-    this.packagesToBootstrap = this.filteredPackages;
-    if (this.flags.includeFilteredDependencies) {
-      this.packagesToBootstrap = PackageUtilities.addDependencies(this.filteredPackages, this.packageGraph);
-    }
- 
-    this.logger.info(`Bootstrapping ${this.packagesToBootstrap.length} packages`);
+    this.logger.info(`Bootstrapping ${this.filteredPackages.length} packages`);
     this.batchedPackages = this.toposort
-      ? PackageUtilities.topologicallyBatchPackages(this.packagesToBootstrap, this.logger)
-      : [ this.packagesToBootstrap ];
+      ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages, this.logger)
+      : [ this.filteredPackages ];
     
     async.series([
       // preinstall bootstrapped packages
@@ -54,11 +49,11 @@ export default class BootstrapCommand extends Command {
   }
 
   runScriptInPackages(scriptName, callback) {
-    if (!this.packagesToBootstrap.length) {
+    if (!this.filteredPackages.length) {
       return callback(null, true);
     }
 
-    this.progressBar.init(this.packagesToBootstrap.length);
+    this.progressBar.init(this.filteredPackages.length);
     PackageUtilities.runParallelBatches(this.batchedPackages, (pkg) => (done) => {
       pkg.runScript(scriptName, (err) => {
         this.progressBar.tick(pkg.name);
@@ -308,7 +303,7 @@ export default class BootstrapCommand extends Command {
    * @param {Function} callback
    */
   installExternalDependencies(callback) {
-    const {leaves, root} = this.getDependenciesToInstall(this.packagesToBootstrap);
+    const {leaves, root} = this.getDependenciesToInstall(this.filteredPackages);
 
     const actions = [];
 
@@ -385,9 +380,9 @@ export default class BootstrapCommand extends Command {
    */
   symlinkPackages(callback) {
     this.logger.info("Symlinking packages and binaries");
-    this.progressBar.init(this.packagesToBootstrap.length);
+    this.progressBar.init(this.filteredPackages.length);
     const actions = [];
-    this.packagesToBootstrap.forEach((filteredPackage) => {
+    this.filteredPackages.forEach((filteredPackage) => {
       // actions to run for this package
       const packageActions = [];
       Object.keys(filteredPackage.allDependencies)

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -1,22 +1,16 @@
 import async from "async";
 import Command from "../Command";
 import FileSystemUtilities from "../FileSystemUtilities";
-import PackageUtilities from "../PackageUtilities";
 import PromptUtilities from "../PromptUtilities";
 import progressBar from "../progressBar";
 
 export default class CleanCommand extends Command {
   initialize(callback) {
-    this.packagesToClean = this.filteredPackages;
-    if (this.flags.includeFilteredDependencies) {
-      this.packagesToClean = PackageUtilities.addDependencies(this.packagesToClean, this.packageGraph);
-    }
-
     if (this.flags.yes) {
       callback(null, true);
     } else {
       this.logger.info(`About to remove the following directories:\n${
-        this.packagesToClean.map((pkg) => "- " + pkg.nodeModulesLocation).join("\n")
+        this.filteredPackages.map((pkg) => "- " + pkg.nodeModulesLocation).join("\n")
       }`);
       PromptUtilities.confirm("Proceed?", (confirmed) => {
         if (confirmed) {
@@ -30,7 +24,7 @@ export default class CleanCommand extends Command {
   }
 
   execute(callback) {
-    progressBar.init(this.packagesToClean.length);
+    progressBar.init(this.filteredPackages.length);
     this.rimrafNodeModulesInPackages((err) => {
       progressBar.terminate();
       if (err) {
@@ -43,7 +37,7 @@ export default class CleanCommand extends Command {
   }
 
   rimrafNodeModulesInPackages(callback) {
-    async.parallelLimit(this.packagesToClean.map((pkg) => (cb) => {
+    async.parallelLimit(this.filteredPackages.map((pkg) => (cb) => {
       FileSystemUtilities.rimraf(pkg.nodeModulesLocation, (err) => {
         progressBar.tick(pkg.name);
         cb(err);

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -8,113 +8,118 @@ import ExecCommand from "../src/commands/ExecCommand";
 import stub from "./_stub";
 
 describe("ExecCommand", () => {
-  let testDir;
-  beforeEach((done) => {
-    testDir = initFixture("ExecCommand/basic", done);
-  });
 
-  it("should complain if invoked without command", (done) => {
-    const execCommand = new ExecCommand([], {});
-
-    execCommand.runValidations();
-    execCommand.runPreparations();
-
-    execCommand.runCommand(exitWithCode(1, (err) => {
-      assert.ok(err instanceof Error);
-      done();
-    }));
-  });
-
-  it("should filter packages with `ignore`", (done) => {
-    const execCommand = new ExecCommand(["ls"], { ignore: "package-1" });
-
-    execCommand.runValidations();
-    execCommand.runPreparations();
-
-    execCommand.initialize(function(error) {
-      assert.equal(error, null);
+  describe("in a basic repo", () => {
+    let testDir;
+    beforeEach((done) => {
+      testDir = initFixture("ExecCommand/basic", done);
     });
 
-    assert.equal(execCommand.filteredPackages.length, 1);
-    assert.equal(execCommand.filteredPackages[0].name, "package-2");
-
-    done();
-  });
-
-  it("should run a command", (done) => {
-    const execCommand = new ExecCommand(["ls"], {});
-
-    execCommand.runValidations();
-    execCommand.runPreparations();
-
-    let calls = 0;
-    stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
-      assert.equal(command, "ls");
-
-      if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
-      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2"), env: process.env });
-
-      calls++;
-      callback();
-    });
-
-    execCommand.runCommand(exitWithCode(0, () => {
-      assert.equal(calls, 2);
-      done();
-    }));
-  });
-
-  it("should run a command with parameters", (done) => {
-    const execCommand = new ExecCommand(["ls", "-la"], {});
-
-    execCommand.runValidations();
-    execCommand.runPreparations();
-
-    let calls = 0;
-    stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
-      assert.equal(command, "ls");
-
-      if (calls === 0) {
-        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
-        assert.deepEqual(args, ["-la"]);
-      }
-      if (calls === 1) {
-        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2"), env: process.env });
-        assert.deepEqual(args, ["-la"]);
-      }
-
-      calls++;
-      callback();
-    });
-
-    execCommand.runCommand(exitWithCode(0, () => {
-      assert.equal(calls, 2);
-      done();
-    }));
-  });
-
-  // Both of these commands should result in the same outcome
-  const filters = [
-    { test: "should run a command for a given scope", flag: "scope", flagValue: "package-1"},
-    { test: "should not run a command for ignored packages", flag: "ignore", flagValue: "package-@(2|3|4)"},
-  ];
-  filters.forEach((filter) => {
-    it(filter.test, (done) => {
-      const execCommand = new ExecCommand(["ls"], {[filter.flag]: filter.flagValue});
+    it("should complain if invoked without command", (done) => {
+      const execCommand = new ExecCommand([], {});
 
       execCommand.runValidations();
       execCommand.runPreparations();
 
-      const ranInPackages = [];
+      execCommand.runCommand(exitWithCode(1, (err) => {
+        assert.ok(err instanceof Error);
+        done();
+      }));
+    });
+
+    it("should filter packages with `ignore`", (done) => {
+      const execCommand = new ExecCommand(["ls"], { ignore: "package-1" });
+
+      execCommand.runValidations();
+      execCommand.runPreparations();
+
+      execCommand.initialize(function(error) {
+        assert.equal(error, null);
+      });
+
+      assert.equal(execCommand.filteredPackages.length, 1);
+      assert.equal(execCommand.filteredPackages[0].name, "package-2");
+
+      done();
+    });
+
+    it("should run a command", (done) => {
+      const execCommand = new ExecCommand(["ls"], {});
+
+      execCommand.runValidations();
+      execCommand.runPreparations();
+
+      let calls = 0;
       stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
-        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+        assert.equal(command, "ls");
+
+        if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
+        if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2"), env: process.env });
+
+        calls++;
         callback();
       });
 
       execCommand.runCommand(exitWithCode(0, () => {
-        assert.deepEqual(ranInPackages, ["package-1"]);
+        assert.equal(calls, 2);
         done();
       }));
     });
+
+    it("should run a command with parameters", (done) => {
+      const execCommand = new ExecCommand(["ls", "-la"], {});
+
+      execCommand.runValidations();
+      execCommand.runPreparations();
+
+      let calls = 0;
+      stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
+        assert.equal(command, "ls");
+
+        if (calls === 0) {
+          assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
+          assert.deepEqual(args, ["-la"]);
+        }
+        if (calls === 1) {
+          assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2"), env: process.env });
+          assert.deepEqual(args, ["-la"]);
+        }
+
+        calls++;
+        callback();
+      });
+
+      execCommand.runCommand(exitWithCode(0, () => {
+        assert.equal(calls, 2);
+        done();
+      }));
+    });
+
+    // Both of these commands should result in the same outcome
+    const filters = [
+      { test: "should run a command for a given scope", flag: "scope", flagValue: "package-1"},
+      { test: "should not run a command for ignored packages", flag: "ignore", flagValue: "package-@(2|3|4)"},
+    ];
+    filters.forEach((filter) => {
+      it(filter.test, (done) => {
+        const execCommand = new ExecCommand(["ls"], {[filter.flag]: filter.flagValue});
+
+        execCommand.runValidations();
+        execCommand.runPreparations();
+
+        const ranInPackages = [];
+        stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
+          ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+          callback();
+        });
+
+        execCommand.runCommand(exitWithCode(0, () => {
+          assert.deepEqual(ranInPackages, ["package-1"]);
+          done();
+        }));
+      });
+    });
+
   });
+
 });

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -67,4 +67,26 @@ describe("LsCommand", () => {
       lsCommand.runCommand(exitWithCode(0, done));
     });
   });
+
+  describe("with --include-filtered-dependencies", () => {
+    beforeEach((done) => {
+      initFixture("LsCommand/include-filtered-dependencies", done);
+    });
+
+    it("should list packages, including filtered ones", (done) => {
+      const lsCommand = new LsCommand([], {
+        scope: "@test/package-2",
+        includeFilteredDependencies: true
+      });
+
+      lsCommand.runValidations();
+      lsCommand.runPreparations();
+
+      stub(logger, "info", (message) => {
+        assert.equal(message, "- @test/package-2\n- @test/package-1");
+      });
+
+      lsCommand.runCommand(exitWithCode(0, done));
+    });
+  });
 });

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -10,40 +10,100 @@ import stub from "./_stub";
 import FakeChild from "./_fakeChild";
 
 describe("RunCommand", () => {
-  let testDir;
 
-  beforeEach((done) => {
-    testDir = initFixture("RunCommand/basic", done);
-  });
+  describe("in a basic repo", () => {
+    let testDir;
 
-  it("should run a command", (done) => {
-    const runCommand = new RunCommand(["my-script"], {});
-
-    runCommand.runValidations();
-    runCommand.runPreparations();
-
-    let calls = 0;
-    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
-      assert.equal(command, "npm run my-script ");
-
-      if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
-      if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-3"), env: process.env });
-
-      calls++;
-      callback();
+    beforeEach((done) => {
+      testDir = initFixture("RunCommand/basic", done);
     });
 
-    runCommand.runCommand(exitWithCode(0, done));
+    it("should run a command", (done) => {
+      const runCommand = new RunCommand(["my-script"], {});
+
+      runCommand.runValidations();
+      runCommand.runPreparations();
+
+      let calls = 0;
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        assert.equal(command, "npm run my-script ");
+
+        if (calls === 0) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), env: process.env });
+        if (calls === 1) assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-3"), env: process.env });
+
+        calls++;
+        callback();
+      });
+
+      runCommand.runCommand(exitWithCode(0, done));
+    });
+
+    // Both of these commands should result in the same outcome
+    const filters = [
+      { test: "should run a command for a given scope", flag: "scope", flagValue: "package-1"},
+      { test: "should not run a command for ignored packages", flag: "ignore", flagValue: "package-@(2|3|4)"},
+    ];
+    filters.forEach((filter) => {
+      it(filter.test, (done) => {
+        const runCommand = new RunCommand(["my-script"], {[filter.flag]: filter.flagValue});
+
+        runCommand.runValidations();
+        runCommand.runPreparations();
+
+        const ranInPackages = [];
+        stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+          ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+          callback();
+        });
+
+        runCommand.runCommand(exitWithCode(0, () => {
+          assert.deepEqual(ranInPackages, ["package-1"]);
+          done();
+        }));
+      });
+    });
+
+    it("should wait for children to exit", (done) => {
+      const runCommand = new RunCommand(["my-script"], {});
+
+      runCommand.runValidations();
+      runCommand.runPreparations();
+
+      const children = [];
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        children.unshift(new FakeChild);
+        ChildProcessUtilities.registerChild(children[0]);
+        callback();
+      });
+
+      let lastInfo;
+      stub(logger, "info", (message) => lastInfo = message);
+
+      let haveExited = false;
+      runCommand.runCommand(exitWithCode(0, (err) => {
+        assert.equal(lastInfo, "Waiting for 2 child processes to exit. CTRL-C to exit immediately.");
+        haveExited = true;
+        done(err);
+      }));
+
+      assert.equal(haveExited, false);
+
+      children.forEach((child) => child.emit("exit"));
+    });
+
   });
 
-  // Both of these commands should result in the same outcome
-  const filters = [
-    { test: "should run a command for a given scope", flag: "scope", flagValue: "package-1"},
-    { test: "should not run a command for ignored packages", flag: "ignore", flagValue: "package-@(2|3|4)"},
-  ];
-  filters.forEach((filter) => {
-    it(filter.test, (done) => {
-      const runCommand = new RunCommand(["my-script"], {[filter.flag]: filter.flagValue});
+  describe.only("with --include-filtered-dependencies", () => {
+    let testDir;
+    beforeEach((done) => {
+      testDir = initFixture("RunCommand/include-filtered-dependencies", done);
+    });
+
+    it("should run a command for the given scope, including filtered deps", (done) => {
+      const runCommand = new RunCommand(["my-script"], {
+        scope: "@test/package-2",
+        includeFilteredDependencies: true
+      });
 
       runCommand.runValidations();
       runCommand.runPreparations();
@@ -55,37 +115,11 @@ describe("RunCommand", () => {
       });
 
       runCommand.runCommand(exitWithCode(0, () => {
-        assert.deepEqual(ranInPackages, ["package-1"]);
+        const expected = ["package-1", "package-2"];
+        assert.deepEqual(ranInPackages.sort(), expected.sort());
         done();
       }));
     });
   });
 
-  it("should wait for children to exit", (done) => {
-    const runCommand = new RunCommand(["my-script"], {});
-
-    runCommand.runValidations();
-    runCommand.runPreparations();
-
-    const children = [];
-    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
-      children.unshift(new FakeChild);
-      ChildProcessUtilities.registerChild(children[0]);
-      callback();
-    });
-
-    let lastInfo;
-    stub(logger, "info", (message) => lastInfo = message);
-
-    let haveExited = false;
-    runCommand.runCommand(exitWithCode(0, (err) => {
-      assert.equal(lastInfo, "Waiting for 2 child processes to exit. CTRL-C to exit immediately.");
-      haveExited = true;
-      done(err);
-    }));
-
-    assert.equal(haveExited, false);
-
-    children.forEach((child) => child.emit("exit"));
-  });
 });

--- a/test/fixtures/ExecCommand/include-filtered-dependencies/lerna.json
+++ b/test/fixtures/ExecCommand/include-filtered-dependencies/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ExecCommand/include-filtered-dependencies/package.json
+++ b/test/fixtures/ExecCommand/include-filtered-dependencies/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/ExecCommand/include-filtered-dependencies/packages/package-1/package.json
+++ b/test/fixtures/ExecCommand/include-filtered-dependencies/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ExecCommand/include-filtered-dependencies/packages/package-2/package.json
+++ b/test/fixtures/ExecCommand/include-filtered-dependencies/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-2",
+  "version": "1.0.0",
+  "dependencies": {
+  	"@test/package-1": "1.0.0"
+  }
+}

--- a/test/fixtures/ExecCommand/include-filtered-dependencies/packages/package-3/package.json
+++ b/test/fixtures/ExecCommand/include-filtered-dependencies/packages/package-3/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-3",
+  "version": "1.0.0"
+}

--- a/test/fixtures/LsCommand/include-filtered-dependencies/lerna.json
+++ b/test/fixtures/LsCommand/include-filtered-dependencies/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/LsCommand/include-filtered-dependencies/package.json
+++ b/test/fixtures/LsCommand/include-filtered-dependencies/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/LsCommand/include-filtered-dependencies/packages/package-1/package.json
+++ b/test/fixtures/LsCommand/include-filtered-dependencies/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/LsCommand/include-filtered-dependencies/packages/package-2/package.json
+++ b/test/fixtures/LsCommand/include-filtered-dependencies/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-2",
+  "version": "1.0.0",
+  "dependencies": {
+  	"@test/package-1": "1.0.0"
+  }
+}

--- a/test/fixtures/LsCommand/include-filtered-dependencies/packages/package-3/package.json
+++ b/test/fixtures/LsCommand/include-filtered-dependencies/packages/package-3/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-3",
+  "version": "1.0.0"
+}

--- a/test/fixtures/RunCommand/include-filtered-dependencies/lerna.json
+++ b/test/fixtures/RunCommand/include-filtered-dependencies/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/RunCommand/include-filtered-dependencies/package.json
+++ b/test/fixtures/RunCommand/include-filtered-dependencies/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/RunCommand/include-filtered-dependencies/packages/package-1/package.json
+++ b/test/fixtures/RunCommand/include-filtered-dependencies/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0",
+  "scripts": {
+    "my-script": "echo @test/package-1"
+  }
+}

--- a/test/fixtures/RunCommand/include-filtered-dependencies/packages/package-2/package.json
+++ b/test/fixtures/RunCommand/include-filtered-dependencies/packages/package-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/package-2",
+  "version": "1.0.0",
+  "dependencies": {
+  	"@test/package-1": "1.0.0"
+  },
+  "scripts": {
+    "my-script": "echo @test/package-2"
+  }
+}

--- a/test/fixtures/RunCommand/include-filtered-dependencies/packages/package-3/package.json
+++ b/test/fixtures/RunCommand/include-filtered-dependencies/packages/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-3",
+  "version": "1.0.0",
+  "scripts": {
+    "my-script": "echo @test/package-3"
+  }
+}


### PR DESCRIPTION
* Adds support to `ls`,`exec`,`run`
* Removes need for additional instance variable on BootstrapCommand, CleanCommand
* Adds tests for ls, exec, run

This PR looks huge because I had to change whitespace in a couple of tests, and added new fixtures, but the "actual" work is mostly in `Command.js`, with some find-and-replace in `BootstrapCommand.js`, and `CleanCommand.js`. 