### PR TITLE
Avoid exception after successful `lerna diff`

### DIFF
--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -36,7 +36,7 @@ export default class DiffCommand extends Command {
 
   execute(callback) {
     ChildProcessUtilities.spawn("git", ["diff", this.lastCommit, "--color=auto", this.filePath], {}, (code) => {
-      if (code !== 0) {
+      if (code) {
         callback(new Error("Errored while spawning `git diff`."));
       } else {
         callback(null, true);

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -26,7 +26,7 @@ describe("DiffCommand", () => {
       assert.equal(args[1].length, 40); // commit
       assert.equal(args[2], "--color=auto");
       assert.equal(args[3], testDir);
-      callback(0);
+      callback();
     });
 
     diffCommand.runCommand(exitWithCode(0, done));
@@ -44,7 +44,7 @@ describe("DiffCommand", () => {
       assert.equal(args[1].length, 40); // commit
       assert.equal(args[2], "--color=auto");
       assert.equal(args[3], path.join(testDir, "packages/package-1"));
-      callback(0);
+      callback();
     });
 
     diffCommand.runCommand(exitWithCode(0, done));


### PR DESCRIPTION
Fixes #585 

Basically, the test was behaving inconsistently with all of the other myriad `spawn` stubs, and the source reflected this incorrect test behaviour. A simple falsy check (consistent with all other usage) seemed the way to go.