### PR TITLE
Always run test and env scripts

### DIFF
--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -12,8 +12,12 @@ export default class RunCommand extends Command {
       return;
     }
 
-    this.packagesWithScript = this.filteredPackages
-      .filter((pkg) => pkg.scripts && pkg.scripts[this.script]);
+    if (this.script === "test" || this.script === "env") {
+      this.packagesWithScript = this.packages;
+    } else {
+      this.packagesWithScript = this.filteredPackages
+        .filter((pkg) => pkg.scripts && pkg.scripts[this.script]);
+    }
 
     if (!this.packagesWithScript.length) {
       callback(new Error(`No packages found with the npm script '${this.script}'`));

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -13,7 +13,7 @@ export default class RunCommand extends Command {
     }
 
     if (this.script === "test" || this.script === "env") {
-      this.packagesWithScript = this.packages;
+      this.packagesWithScript = this.filteredPackages;
     } else {
       this.packagesWithScript = this.filteredPackages
         .filter((pkg) => pkg.scripts && pkg.scripts[this.script]);

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -38,6 +38,31 @@ describe("RunCommand", () => {
       runCommand.runCommand(exitWithCode(0, done));
     });
 
+    const defaultScripts = [ "test", "env" ];
+    defaultScripts.forEach((defaultScript) => {
+      it(`should always run ${defaultScript}`, (done) => {
+        const runCommand = new RunCommand([defaultScript], {});
+
+        runCommand.runValidations();
+        runCommand.runPreparations();
+
+        let calls = 0;
+        stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+          calls++;
+
+          assert.equal(command, `npm run ${defaultScript} `);
+
+          callback();
+        });
+
+        runCommand.runCommand(exitWithCode(0, () => {
+          assert.equal(4, calls);
+
+          done();
+        }));
+      });
+    });
+
     // Both of these commands should result in the same outcome
     const filters = [
       { test: "should run a command for a given scope", flag: "scope", flagValue: "package-1"},


### PR DESCRIPTION
Fixes #491

npm defines default scripts for `test` and `env`. Lerna only runs
scripts when they’re defined in `package.json`, but this could lead to
unexpected behaviour in these two cases. In particular, it could lead
to `pretest` and `posttest` not being run by Lerna, when npm would have
run them.