### PR TITLE
Publish npm packages in topological order.

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -40,7 +40,7 @@ var cli = meow([
   "  --repo-version          Specify repo version to publish",
   "  --concurrency           How many threads to use if lerna parallelises the tasks (defaults to 4)",
   "  --loglevel              What level of logs to report (defaults to \"info\").  On failure, all logs are written to lerna-debug.log in the current working directory.",
-  "  --no-sort            When executing tasks, ignore the dependency ordering of packages (only affects run, exec and bootstrap)",
+  "  --no-sort            When executing tasks, ignore the dependency ordering of packages (only affects run, exec, publish and bootstrap)",
 ], {
   alias: {
     independent: "i",

--- a/src/PackageGraph.js
+++ b/src/PackageGraph.js
@@ -16,9 +16,11 @@ export class PackageGraphNode {
  * Represents a node in a PackageGraph.
  * @constructor
  * @param {!Array.<Package>} packages An array of Packages to build the graph out of.
+ * @param {boolean} [depsOnly=false] True to create a graph of only dependencies, excluding the
+ *    devDependencies that would normally be included.
  */
 export default class PackageGraph {
-  constructor(packages) {
+  constructor(packages, depsOnly = false) {
     this.nodes = [];
     this.nodesByName = {};
 
@@ -31,7 +33,7 @@ export default class PackageGraph {
 
     for (let n = 0; n < this.nodes.length; n++) {
       const node = this.nodes[n];
-      const dependencies = node.package.allDependencies;
+      const dependencies = node.package[depsOnly ? "dependencies" : "allDependencies"] || {};
       const depNames = Object.keys(dependencies);
 
       for (let d = 0; d < depNames.length; d++) {

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -53,8 +53,8 @@ export default class PackageUtilities {
     return packages;
   }
 
-  static getPackageGraph(packages) {
-    return new PackageGraph(packages);
+  static getPackageGraph(packages, depsOnly = false) {
+    return new PackageGraph(packages, depsOnly);
   }
 
   /**
@@ -153,10 +153,13 @@ export default class PackageUtilities {
     ) && pkg;
   }
 
-  static topologicallyBatchPackages(packagesToBatch, logger = null) {
+  static topologicallyBatchPackages(packagesToBatch, {
+    depsOnly = false,
+    logger = null,
+  } = {}) {
     // We're going to be chopping stuff out of this array, so copy it.
     const packages = packagesToBatch.slice();
-    const packageGraph = PackageUtilities.getPackageGraph(packages);
+    const packageGraph = PackageUtilities.getPackageGraph(packages, depsOnly);
 
     // This maps package names to the number of packages that depend on them.
     // As packages are completed their names will be removed from this object.

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -31,9 +31,9 @@ export default class BootstrapCommand extends Command {
   bootstrapPackages(callback) {
     this.logger.info(`Bootstrapping ${this.filteredPackages.length} packages`);
     this.batchedPackages = this.toposort
-      ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages, this.logger)
+      ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages, {logger: this.logger})
       : [ this.filteredPackages ];
-    
+
     async.series([
       // preinstall bootstrapped packages
       (cb) => this.preinstallPackages(cb),

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -13,7 +13,7 @@ export default class ExecCommand extends Command {
     }
 
     this.batchedPackages = this.toposort
-      ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages, this.logger)
+      ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages, {logger: this.logger})
       : [ this.filteredPackages ];
 
     callback(null, true);

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -21,7 +21,7 @@ export default class RunCommand extends Command {
     }
 
     this.batchedPackages = this.toposort
-      ? PackageUtilities.topologicallyBatchPackages(this.packagesWithScript, this.logger)
+      ? PackageUtilities.topologicallyBatchPackages(this.packagesWithScript, {logger: this.logger})
       : [ this.packagesWithScript ];
 
     callback(null, true);

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -55,19 +55,15 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           // No package-5.  It's private.
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 latest"] },
-
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -76,6 +72,10 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
           // No package-5.  It's private.
 
@@ -156,18 +156,14 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 latest"] },
-
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@1.1.0 latest"] },
 
           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 2.0.0" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -176,6 +172,10 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.1.0 latest"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.1.0 latest"] },
 
           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
           { args: ["git push origin master"] },
@@ -236,9 +236,9 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git checkout -- packages/*/package.json"] },
@@ -247,10 +247,6 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.0-alpha.81e3b443" + EOL + "stable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@1.0.0-alpha.81e3b443 canary"] },
-
           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.0-alpha.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
           { args: ["npm dist-tag add package-3@1.0.0-alpha.81e3b443 canary"] },
@@ -258,6 +254,10 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.0-alpha.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.0-alpha.81e3b443 canary"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.0-alpha.81e3b443" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.0-alpha.81e3b443 canary"] },
 
           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
           { args: ["git push origin master"] },
@@ -325,9 +325,9 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git checkout -- packages/*/package.json"] },
@@ -336,10 +336,6 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.0-alpha.81e3b443 canary"] },
 
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 2.0.0-alpha.81e3b443" + EOL + "stable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@2.0.0-alpha.81e3b443 canary"] },
-
           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 3.0.0-alpha.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
           { args: ["npm dist-tag add package-3@3.0.0-alpha.81e3b443 canary"] },
@@ -347,6 +343,10 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 4.0.0-alpha.81e3b443" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@4.0.0-alpha.81e3b443 canary"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 2.0.0-alpha.81e3b443" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@2.0.0-alpha.81e3b443 canary"] },
 
           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
           { args: ["git push origin master"] },
@@ -412,18 +412,14 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 latest"] },
-
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -431,7 +427,11 @@ describe("PublishCommand", () => {
 
           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
-          { args: ["npm dist-tag add package-4@1.0.1 latest"] }
+          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
         ]],
       ]);
 
@@ -623,19 +623,15 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           // No package-5.  It's private.
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 prerelease"] },
-
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@1.0.1 prerelease"] },
 
           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -644,6 +640,10 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.1 prerelease"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.1 prerelease"] },
 
           // No package-5.  It's private.
 
@@ -728,19 +728,15 @@ describe("PublishCommand", () => {
        ]],
        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
          // No package-5.  It's private.
        ], true],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-1 lerna-temp"] },
          { args: ["npm dist-tag add package-1@1.0.1 latest"] },
-
-         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-2 lerna-temp"] },
-         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -749,6 +745,10 @@ describe("PublishCommand", () => {
          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-4 lerna-temp"] },
          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+
+         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+         { args: ["npm dist-tag rm package-2 lerna-temp"] },
+         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
          // No package-5.  It's private.
 
@@ -823,19 +823,15 @@ describe("PublishCommand", () => {
        ]],
        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
          // No package-5.  It's private.
        ], true],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-1 lerna-temp"] },
          { args: ["npm dist-tag add package-1@1.0.1 latest"] },
-
-         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-2 lerna-temp"] },
-         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -844,6 +840,10 @@ describe("PublishCommand", () => {
          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-4 lerna-temp"] },
          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+
+         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+         { args: ["npm dist-tag rm package-2 lerna-temp"] },
+         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
          // No package-5.  It's private.
 
@@ -923,19 +923,15 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           // No package-5.  It's private.
         ], true],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 latest"] },
-
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -944,6 +940,10 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
           // No package-5.  It's private.
 
@@ -1020,19 +1020,15 @@ describe("PublishCommand", () => {
        ]],
        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
          // No package-5.  It's private.
        ], true],
        [ChildProcessUtilities, "execSync", {}, [
          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-1 lerna-temp"] },
          { args: ["npm dist-tag add package-1@1.0.1 latest"] },
-
-         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-2 lerna-temp"] },
-         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -1041,6 +1037,10 @@ describe("PublishCommand", () => {
          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
          { args: ["npm dist-tag rm package-4 lerna-temp"] },
          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+
+         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+         { args: ["npm dist-tag rm package-2 lerna-temp"] },
+         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
          // No package-5.  It's private.
 
@@ -1122,18 +1122,14 @@ describe("PublishCommand", () => {
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
           { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag lerna-temp"] },
-          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] }
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag lerna-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag lerna-temp"] },
         ]],
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-1 lerna-temp"] },
           { args: ["npm dist-tag add package-1@1.0.1 latest"] },
-
-          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp"] },
-          { args: ["npm dist-tag add package-2@1.1.0 latest"] },
 
           { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 2.0.0" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-3 lerna-temp"] },
@@ -1142,6 +1138,10 @@ describe("PublishCommand", () => {
           { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
           { args: ["npm dist-tag rm package-4 lerna-temp"] },
           { args: ["npm dist-tag add package-4@1.1.0 latest"] },
+
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.1.0" + EOL + "stable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.1.0 latest"] },
 
           { args: ["git symbolic-ref --short HEAD"], returns: "master" },
           { args: ["git push origin master"] },


### PR DESCRIPTION
Expanding on the work done in https://github.com/lerna/lerna/pull/412 by @seansfkelley.

This makes the `publish` command publish packages to npm in topological order so that there is never a time where npm could have a package whose dependencies do not yet exist in the registry. There's already some `dist-tags` toggling going on, but that doesn't have any effect on users who already have dependencies on a version range in their deps.

Feedback welcome. Main questions:

If you have dependency cycles in your repo, this means Lerna will start logging `"Encountered a cycle in the dependency graph. This may cause instability!"` on every call to `lerna publish` where it wouldn't have before, is that cool?