### PR TITLE
Durable `includeFilteredDependencies` config via lerna.json

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -149,7 +149,7 @@ export default class Command {
       this.packages = this.repository.packages;
       this.packageGraph = this.repository.packageGraph;
       this.filteredPackages = PackageUtilities.filterPackages(this.packages, {scope, ignore});
-      if (this.flags.includeFilteredDependencies) {
+      if (this.getOptions().includeFilteredDependencies) {
         this.filteredPackages = PackageUtilities.addDependencies(this.filteredPackages, this.packageGraph);
       }
     } catch (err) {


### PR DESCRIPTION
Works at both the top level and also per-command.

Example:

```js
{
  ...
  "commands": {
    "bootstrap" {
      "includeFilteredDependencies": true
    }
  }
}