### PR TITLE
Fix --ignore flag when globs are expanded to an array

### DIFF
--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -140,10 +140,11 @@ export default class PackageUtilities {
 
     if (!Array.isArray(glob)) glob = [glob];
 
-    const maybeNegate = negate ? (v) => !v : (v) => v;
-    const boolReducer = negate ? Array.prototype.every : Array.prototype.some;
-
-    return boolReducer.call(glob, (glob) => maybeNegate(minimatch(pkg.name, glob)));
+    if (negate) {
+      return glob.every((glob) => !minimatch(pkg.name, glob));
+    } else {
+      return glob.some((glob) => minimatch(pkg.name, glob));
+    }
   }
 
   static getFilteredPackage(pkg, {scope, ignore}) {

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -141,8 +141,9 @@ export default class PackageUtilities {
     if (!Array.isArray(glob)) glob = [glob];
 
     const maybeNegate = negate ? (v) => !v : (v) => v;
+    const boolReducer = negate ? Array.prototype.every : Array.prototype.some;
 
-    return glob.some((glob) => maybeNegate(minimatch(pkg.name, glob)));
+    return boolReducer.call(glob, (glob) => maybeNegate(minimatch(pkg.name, glob)));
   }
 
   static getFilteredPackage(pkg, {scope, ignore}) {

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -207,6 +207,15 @@ describe("PackageUtilities", () => {
       );
     });
 
+    it("should filter --ignored packages", () => {
+      /* NOTE: ignore value is array at this point if option is "package-{3,4}" */
+      const flags = { ignore: ["package-3", "package-4"]};
+      assert.deepEqual(
+        PackageUtilities.filterPackages(packages, flags).map((pkg) => pkg.name),
+        ["package-a-1", "package-a-2"]
+      );
+    });
+
     it("should filter --ignored  and --scoped packages", () => {
       const flags = { scope: "package-a-*", ignore: "package-a-2"};
       assert.deepEqual(


### PR DESCRIPTION
Suppose we have:
- `package-a`
- `package-b`
- `package-c`

<hr/>

The following works as expected:
```
lerna bootstrap --ignore=package-@(a|b)
```

The message is:
```
Ignoring packages that match 'package-@(a|b)'
```

And the following packages are bootstrapped:
- `package-c`

<hr/>

The following does *not* work as expected:
```
lerna bootstrap --ignore=package-{a,b}
```

The message is:
```
Ignoring packages that match 'package-a,package-b'
```

And the following packages are bootstrapped:
- `package-a` (incorrect)
- `package-b` (incorrect)
- `package-c`

The latter glob is expanded to an array even before reaching `filterPackage` in `PackageUtilities`. (Notice the difference in messages). However, the logic regarding negation (i.e. `maybeNegate`) was only *within* `glob.some`, which would not work in the case that `glob.length > 1`.

This PR changes the boolean reducer depending on the desired negation (i.e. `Array.prototype.some` for the standard case, and `Array.prototype.every` for the negated case.