### PR TITLE
Add a --stream option to the run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,16 @@ can be used to opt out of hoisting for certain dependencies.
 $ lerna bootstrap --hoist --nohoist=babel-*
 ```
 
+#### --stream
+
+Stream output from child processes immediately, prefixed with the originating
+package name.  This can be useful for long-running processes such as "watch"
+builds.  This allows output from different packages to be interleaved.
+
+```sh
+$ lerna run watch --stream
+```
+
 #### --registry [registry]
 
 When run with this flag, forwarded npm commands will use the specified registry for your package(s).

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -32,6 +32,7 @@ var cli = meow([
   "  --npm-tag [tagname]     Publish packages with the specified npm dist-tag",
   "  --hoist [glob]          Install external dependencies matching [glob] to the repo root.  Use with no glob for all.",
   "  --nohoist [glob]        Don't hoist external dependencies matching [glob] to the repo root",
+  "  --stream                Stream output with lines prefixed by package (only 'run')",
   "  --scope [glob]          Restricts the scope to package names matching the given glob (Works only in combination with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
   "  --ignore [glob]         Ignores packages with names matching the given glob (Works only in combination with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
   "  --include-filtered-dependencies Flag to force lerna to include all dependencies and transitive dependencies when running 'bootstrap', even if they should not be included by the scope or ignore flags",

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -104,6 +104,17 @@ export default class NpmUtilities {
   }
 
   @logger.logifyAsync()
+  static runScriptInPackageStreaming(script, args, pkg, callback) {
+    ChildProcessUtilities.spawnStreaming(
+      "npm",
+      ["run", script, ...args],
+      { cwd: pkg.location, env: process.env },
+      pkg.name + ": ",
+      callback
+    );
+  }
+
+  @logger.logifyAsync()
   static publishTaggedInDir(tag, directory, registry, callback) {
     const command = ("npm publish --tag " + tag).trim();
     const opts = NpmUtilities.getTagOpts(registry);

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -50,6 +50,18 @@ export default class RunCommand extends Command {
   }
 
   runScriptInPackage(pkg, callback) {
+    if (this.getOptions().stream) {
+      this.runScriptInPackageStreaming(pkg, callback);
+    } else {
+      this.runScriptInPackageCapturing(pkg, callback);
+    }
+  }
+
+  runScriptInPackageStreaming(pkg, callback) {
+    NpmUtilities.runScriptInPackageStreaming(this.script, this.args, pkg, callback);
+  }
+
+  runScriptInPackageCapturing(pkg, callback) {
     NpmUtilities.runScriptInDir(this.script, this.args, pkg.location, (err, stdout) => {
       this.logger.info(stdout);
       if (err) {

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -38,6 +38,31 @@ describe("RunCommand", () => {
       runCommand.runCommand(exitWithCode(0, done));
     });
 
+    it("should run with streaming enabled with --stream", (done) => {
+      const runCommand = new RunCommand(["my-script"], {stream: true});
+
+      runCommand.runValidations();
+      runCommand.runPreparations();
+
+      let calls = 0;
+      stub(ChildProcessUtilities, "spawnStreaming", (command, args, options, prefix, callback) => {
+        const pkg = "package-" + ([1,3][calls]);
+
+        assert.equal(command, "npm");
+        assert.deepEqual(args, ["run", "my-script"]);
+        assert.deepEqual(options, {
+          cwd: path.join(testDir, "packages/" + pkg),
+          env: process.env,
+        });
+        assert.equal(prefix, pkg + ": ");
+
+        calls++;
+        callback();
+      });
+
+      runCommand.runCommand(exitWithCode(0, done));
+    });
+
     const defaultScripts = [ "test", "env" ];
     defaultScripts.forEach((defaultScript) => {
       it(`should always run ${defaultScript}`, (done) => {


### PR DESCRIPTION
Emit output from child processes immediately.

- Each line is prefixed with the name of the originating package.
- Output from stdout goes to stdout, and stderr goes to stderr.

```sh
$ lerna run watch --stream
```

This closes #446.