### PR TITLE
Add documentation about "watch" commands next to --no-sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,8 @@ By default, all tasks execute on packages in topologically sorted order as to re
 
 Topological sorting can cause concurrency bottlenecks if there are a small number of packages with many dependents or if some packages take a disproportionately long time to execute. The `--no-sort` option disables sorting, instead executing tasks in an arbitrary order with maximum concurrency.
 
+This option can also help if you run multiple "watch" commands. Since `lerna run` will execute commands in topologically sorted order, it can end up waiting for a command before moving on. This will block execution when you run "watch" commands, since they typically never end. An example of a "watch" command is [running `babel` with the `--watch` CLI flag](https://babeljs.io/docs/usage/cli/#babel-compile-files).
+
 #### --hoist [glob]
 
 Install external dependencies matching `glob` at the repo root so they're


### PR DESCRIPTION
I ran into an issue where `lerna run build:watch` ("build:watch" being a
babel command with the `--watch` flag) would only run for one package
(called "core"). It turns out to be caused by lerna running commands in
a topologically sorted order, executing packages that others depend on
first before moving on.

The nature of "watch" commands is usually to never end. In my case that
meant that lerna was waiting indefinitely for the "core" package command
to finish.

By reading the documentation I came across the `--no-sort` flag, which
helped resolve my issue. It wasn't super clear in the README that this
flag would help out with my problem, so I decided to add a little bit
about "watch" commands right next to it.

Relevant discussion:
https://github.com/lerna/lerna/issues/449#issuecomment-283463490