### PR TITLE
Install with all dependencies when installing

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -316,7 +316,7 @@ export default class BootstrapCommand extends Command {
       // If we have anything to install in the root then we'll install
       // _everything_ that needs to go there.  This is important for
       // consistent behavior across npm clients.
-      const depsToInstallInRoot = root.filter(({isSatisfied}) => !isSatisfied).length
+      const depsToInstallInRoot = root.some(({isSatisfied}) => !isSatisfied)
         ? root.map(({dependency}) => dependency)
         : [];
 
@@ -369,7 +369,7 @@ export default class BootstrapCommand extends Command {
 
         // If we have any unsatisfied deps then we need to install everything.
         // This is important for consistent behavior across npm clients.
-        if (deps.filter(({isSatisfied}) => !isSatisfied).length) {
+        if (deps.some(({isSatisfied}) => !isSatisfied)) {
           actions.push(
             (cb) => NpmUtilities.installInDir(
               pkg.location, deps.map(({dependency}) => dependency), this.npmConfig, (err) => {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -208,6 +208,14 @@ export default class BootstrapCommand extends Command {
      */
     const depsToInstall = {};
 
+    Object.keys(this.repository.package.allDependencies).forEach((name) => {
+      const version = this.repository.package.allDependencies[name];
+      depsToInstall[name] = {
+        versions   : {[version]: 0},
+        dependents : {[version]: []},
+      };
+    });
+
     // get the map of external dependencies to install
     packages.forEach((pkg) => {
 

--- a/test/fixtures/BootstrapCommand/tepid/lerna.json
+++ b/test/fixtures/BootstrapCommand/tepid/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/tepid/package.json
+++ b/test/fixtures/BootstrapCommand/tepid/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/tepid/packages/package-1/node_modules/external-1/package.json
+++ b/test/fixtures/BootstrapCommand/tepid/packages/package-1/node_modules/external-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "external-1",
+  "version": "1.0.1"
+}

--- a/test/fixtures/BootstrapCommand/tepid/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/tepid/packages/package-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "external-1": "^1.0.0",
+    "external-2": "^1.0.0"
+  }
+}


### PR DESCRIPTION
This makes install all-or-nothing.  If a single dependency is missing then
Lerna will install all dependencies for that location.  This is mostly a noop,
but it's necessary for consistent behavior across npm clients such as Yarn.

It preserves the _true_ noop when there's nothing to install.

This addresses https://github.com/lerna/lerna/issues/630.