### PR TITLE
Add prompts for prerelease versions

### DIFF
--- a/src/PromptUtilities.js
+++ b/src/PromptUtilities.js
@@ -20,6 +20,7 @@ export default class PromptUtilities {
       name: "prompt",
       message: message,
       choices: choices,
+      pageSize: choices.length,
       filter: filter,
       validate: validate
     }]).then((answers) => callback(answers.prompt));

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -213,6 +213,10 @@ export default class PublishCommand extends Command {
     const patch = semver.inc(currentVersion, "patch");
     const minor = semver.inc(currentVersion, "minor");
     const major = semver.inc(currentVersion, "major");
+    const prepatch = semver.inc(currentVersion, "prepatch");
+    const preminor = semver.inc(currentVersion, "preminor");
+    const premajor = semver.inc(currentVersion, "premajor");
+    const prerelease = semver.inc(currentVersion, "prerelease");
 
     let message = "Select a new version";
     if (packageName) message += ` for ${packageName}`;
@@ -223,6 +227,10 @@ export default class PublishCommand extends Command {
         { value: patch, name: `Patch (${patch})` },
         { value: minor, name: `Minor (${minor})` },
         { value: major, name: `Major (${major})` },
+        { value: prepatch, name: `Prepatch (${prepatch})` },
+        { value: preminor, name: `Preminor (${preminor})` },
+        { value: premajor, name: `Premajor (${premajor})` },
+        { value: prerelease, name: `Prerelease (${prerelease})` },
         { value: false, name: "Custom" }
       ]
     }, (choice) => {


### PR DESCRIPTION
Added prompts for `prepatch`, `preminor`, `premajor`, and `prerelease` which correspond to the same functionality in `npm version`