### PR TITLE
Allow concurrency to be configured via package.json

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -17,9 +17,10 @@ export default class Command {
     this.logger = logger;
     this.repository = new Repository();
     this.progressBar = progressBar;
-    this.concurrency = (!flags || flags.concurrency === undefined) ? DEFAULT_CONCURRENCY : Math.max(1, +flags.concurrency || DEFAULT_CONCURRENCY);
 
-    const {sort} = this.getOptions();
+    const {sort, concurrency} = this.getOptions();
+
+    this.concurrency = Math.max(1, +concurrency || DEFAULT_CONCURRENCY);
 
     // If the option isn't present then the default is to sort.
     this.toposort = sort == null || sort;


### PR DESCRIPTION
This allows for durable configuration.

May be set globally at the top level, or per-command.

```js
{
    "concurrency": 2,
    "commands": {
        "bootstrap": {
            "concurrency": 8
        }
    }
}
```

As with all options obtained from `Command#getOptions()` a value passed on the command-line will override configuration from package.json.

```sh
lerna bootstrap --concurrency=4
```