### PR TITLE
Actually warn when a matching dependency version is not satisfied

### DIFF
--- a/src/Package.js
+++ b/src/Package.js
@@ -1,7 +1,6 @@
 import path from "path";
 import semver from "semver";
 import NpmUtilities from "./NpmUtilities";
-import logger from "./logger";
 
 export default class Package {
   constructor(pkg, location) {
@@ -81,10 +80,10 @@ export default class Package {
   /**
    * Determine if a dependency version satisfies the requirements of this package
    * @param {Package} dependency
-   * @param {Boolean} showWarning
+   * @param {Logger} logger
    * @returns {Boolean}
    */
-  hasMatchingDependency(dependency, showWarning = false) {
+  hasMatchingDependency(dependency, logger) {
     const expectedVersion = this.allDependencies[dependency.name];
     const actualVersion = dependency.version;
 
@@ -97,7 +96,7 @@ export default class Package {
       return true;
     }
 
-    if (showWarning) {
+    if (logger) {
       logger.warn(
         `Version mismatch inside "${this.name}". ` +
         `Depends on "${dependency.name}@${expectedVersion}" ` +

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -226,7 +226,7 @@ export default class BootstrapCommand extends Command {
         .map((name) => findPackage(name, pkg.allDependencies[name]) || { name, version: pkg.allDependencies[name] })
 
         // match external and version mismatched local packages
-        .filter((dep) => !hasPackage(dep.name, dep.version) || !pkg.hasMatchingDependency(dep))
+        .filter((dep) => !hasPackage(dep.name, dep.version) || !pkg.hasMatchingDependency(dep, this.logger))
 
         .forEach(({name, version}) => {
 

--- a/test/Package.js
+++ b/test/Package.js
@@ -123,10 +123,17 @@ describe("Package", () => {
       }), true);
     });
     it("should not match included dependency", () => {
+      let called;
+      const logger = {
+        warn(msg) {
+          called = msg;
+        }
+      };
       assert.equal(pkg.hasMatchingDependency({
         name: "my-dev-dependency",
         version: "2.0.7"
-      }), false);
+      }, logger), false);
+      assert.ok(called);
     });
   });
 });


### PR DESCRIPTION
Passing in the logger works just as well as a boolean flag (just like the topological sorting method).

However, in both instances that `Package##hasMatchingDependency()` is actually called, neither of them ever passed `true` in the second arg, so it was basically dead code.

If it was intentional to omit logging in all use cases, then we can delete the dead code.