### PR TITLE
Import consistently in subcommands

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -4,7 +4,7 @@ import mkdirp from "mkdirp";
 import fs from "fs";
 import cmdShim from "cmd-shim";
 import readCmdShim from "read-cmd-shim";
-import { resolve, dirname, relative } from "path";
+import path from "path";
 import ChildProcessUtilities from "./ChildProcessUtilities";
 
 const ENDS_WITH_NEW_LINE = /\n$/;
@@ -83,7 +83,7 @@ export default class FileSystemUtilities {
       type = "file";
     }
     if (process.platform !== "win32") {
-      src = relative(dirname(dest), src);
+      src = path.relative(path.dirname(dest), src);
     }
     fs.lstat(dest, (err) => {
       if (!err) {
@@ -101,20 +101,20 @@ export default class FileSystemUtilities {
   }
 
   @logger.logifySync()
-  static isSymlink(path) {
-    const lstat = fs.lstatSync(path);
+  static isSymlink(filePath) {
+    const lstat = fs.lstatSync(filePath);
     let isSymlink = lstat && lstat.isSymbolicLink()
-      ? resolve(dirname(path), fs.readlinkSync(path))
+      ? path.resolve(path.dirname(filePath), fs.readlinkSync(filePath))
       : false;
     if (process.platform === "win32" && lstat) {
       if (lstat.isFile() && !isSymlink) {
         try {
-          return resolve(dirname(path), readCmdShim.sync(path));
+          return path.resolve(path.dirname(filePath), readCmdShim.sync(filePath));
         } catch (e) {
           return false;
         }
       }
-      isSymlink = isSymlink && resolve(isSymlink);
+      isSymlink = isSymlink && path.resolve(isSymlink);
     }
     return isSymlink;
   }

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -4,7 +4,7 @@ import async from "async";
 import Command from "../Command";
 import progressBar from "../progressBar";
 import PromptUtilities from "../PromptUtilities";
-import {execSync, exec} from "../ChildProcessUtilities";
+import ChildProcessUtilities from "../ChildProcessUtilities";
 
 export default class ImportCommand extends Command {
   initialize(callback) {
@@ -55,9 +55,9 @@ export default class ImportCommand extends Command {
     }
 
     // Stash the repo's pre-import head away in case something goes wrong.
-    this.preImportHead = execSync("git log --format=\"%h\" -1").split("\n")[0];
+    this.preImportHead = ChildProcessUtilities.execSync("git log --format=\"%h\" -1").split("\n")[0];
 
-    if (execSync("git diff " + this.preImportHead)) {
+    if (ChildProcessUtilities.execSync("git diff " + this.preImportHead)) {
       return callback(new Error("Local repository has un-committed changes"));
     }
 
@@ -78,7 +78,7 @@ export default class ImportCommand extends Command {
   }
 
   externalExecSync(command) {
-    return execSync(command, this.externalExecOpts).trim();
+    return ChildProcessUtilities.execSync(command, this.externalExecOpts).trim();
   }
 
   execute(callback) {
@@ -103,7 +103,7 @@ export default class ImportCommand extends Command {
       //
       // Fall back to three-way merge, which can help with duplicate commits
       // due to merge history.
-      exec("git am -3", {}, (err) => {
+      ChildProcessUtilities.exec("git am -3", {}, (err) => {
         if (err) {
 
           // Give some context for the error message.
@@ -111,8 +111,8 @@ export default class ImportCommand extends Command {
                 `Rolling back to previous HEAD (commit ${this.preImportHead}).`;
 
           // Abort the failed `git am` and roll back to previous HEAD.
-          execSync("git am --abort");
-          execSync("git reset --hard " + this.preImportHead);
+          ChildProcessUtilities.execSync("git am --abort");
+          ChildProcessUtilities.execSync("git reset --hard " + this.preImportHead);
         }
         done(err);
       }).stdin.end(patch);


### PR DESCRIPTION
95% percent of the time, we don't destructure named exports when importing them. For the sake of any future mocking or spec-related munging we need to do, let's keep them consistently importing the default export.