### PR TITLE
Use class properties instead of singleton imports

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -220,7 +220,7 @@ export default class Command {
 
     const childProcessCount = ChildProcessUtilities.getChildProcessCount();
     if (childProcessCount > 0) {
-      logger.info(
+      this.logger.info(
         `Waiting for ${childProcessCount} child ` +
         `process${childProcessCount === 1 ? "" : "es"} to exit. ` +
         "CTRL-C to exit immediately."
@@ -234,7 +234,7 @@ export default class Command {
   _legacyOptions() {
     return ["bootstrap", "publish"].reduce((opts, command) => {
       if (this.name === command && this.repository.lernaJson[`${command}Config`]) {
-        logger.warn(`\`${command}Config.ignore\` is deprecated.  Use \`commands.${command}.ignore\`.`);
+        this.logger.warn(`\`${command}Config.ignore\` is deprecated.  Use \`commands.${command}.ignore\`.`);
         opts.ignore = this.repository.lernaJson[`${command}Config`].ignore;
       }
       return opts;

--- a/src/Command.js
+++ b/src/Command.js
@@ -205,7 +205,7 @@ export default class Command {
   _complete(err, code, callback) {
     if (code !== 0) {
       const exitHandler = new ExitHandler();
-      exitHandler.writeLogs();
+      exitHandler.writeLogs(this.logger);
     }
 
     const finish = function() {

--- a/src/ExitHandler.js
+++ b/src/ExitHandler.js
@@ -1,5 +1,4 @@
 import FileSystemUtilities from "./FileSystemUtilities";
-import logger from "./logger";
 import path from "path";
 import padEnd from "lodash/padEnd";
 
@@ -8,7 +7,7 @@ export default class ExitHandler {
     this.errorsSeen = {};
   }
 
-  writeLogs() {
+  writeLogs(logger) {
     const filePath = path.join(process.cwd(), "lerna-debug.log");
     const fileContent = this._formatLogs(logger.logs);
 

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -1,6 +1,5 @@
 import GitUtilities from "./GitUtilities";
 import minimatch from "minimatch";
-import logger from "./logger";
 import find from "lodash/find";
 import path from "path";
 
@@ -12,6 +11,7 @@ class Update {
 
 export default class UpdatedPackagesCollector {
   constructor(command) {
+    this.logger = command.logger;
     this.repository = command.repository;
     this.packages = command.repository.packages;
     this.packageGraph = command.repository.packageGraph;
@@ -26,15 +26,15 @@ export default class UpdatedPackagesCollector {
   }
 
   collectUpdatedPackages() {
-    logger.info("Checking for updated packages...");
+    this.logger.info("Checking for updated packages...");
 
     const hasTags = GitUtilities.hasTags();
 
     if (hasTags) {
       const tag = GitUtilities.getLastTag();
-      logger.info("Comparing with: " + tag);
+      this.logger.info("Comparing with: " + tag);
     } else {
-      logger.info("No tags found! Comparing with initial commit.");
+      this.logger.info("No tags found! Comparing with initial commit.");
     }
 
     this.progressBar.init(this.packages.length);

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -1,5 +1,4 @@
 import GitUtilities from "./GitUtilities";
-import progressBar from "./progressBar";
 import minimatch from "minimatch";
 import logger from "./logger";
 import find from "lodash/find";
@@ -16,6 +15,7 @@ export default class UpdatedPackagesCollector {
     this.repository = command.repository;
     this.packages = command.repository.packages;
     this.packageGraph = command.repository.packageGraph;
+    this.progressBar = command.progressBar;
     this.flags = command.getOptions();
   }
 
@@ -37,7 +37,7 @@ export default class UpdatedPackagesCollector {
       logger.info("No tags found! Comparing with initial commit.");
     }
 
-    progressBar.init(this.packages.length);
+    this.progressBar.init(this.packages.length);
 
     let commits;
 
@@ -58,7 +58,7 @@ export default class UpdatedPackagesCollector {
     const updatedPackages = {};
 
     this.packages.filter((pkg) => {
-      progressBar.tick(pkg.name);
+      this.progressBar.tick(pkg.name);
 
       if (!hasTags) {
         return true;
@@ -77,7 +77,7 @@ export default class UpdatedPackagesCollector {
       updatedPackages[pkg.name] = pkg;
     });
 
-    progressBar.terminate();
+    this.progressBar.terminate();
 
     return updatedPackages;
   }

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -2,7 +2,6 @@ import async from "async";
 import Command from "../Command";
 import FileSystemUtilities from "../FileSystemUtilities";
 import PromptUtilities from "../PromptUtilities";
-import progressBar from "../progressBar";
 
 export default class CleanCommand extends Command {
   initialize(callback) {
@@ -24,9 +23,9 @@ export default class CleanCommand extends Command {
   }
 
   execute(callback) {
-    progressBar.init(this.filteredPackages.length);
+    this.progressBar.init(this.filteredPackages.length);
     this.rimrafNodeModulesInPackages((err) => {
-      progressBar.terminate();
+      this.progressBar.terminate();
       if (err) {
         callback(err);
       } else {
@@ -39,7 +38,7 @@ export default class CleanCommand extends Command {
   rimrafNodeModulesInPackages(callback) {
     async.parallelLimit(this.filteredPackages.map((pkg) => (cb) => {
       FileSystemUtilities.rimraf(pkg.nodeModulesLocation, (err) => {
-        progressBar.tick(pkg.name);
+        this.progressBar.tick(pkg.name);
         cb(err);
       });
     }), this.concurrency, callback);

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -2,7 +2,6 @@ import fs from "fs";
 import path from "path";
 import async from "async";
 import Command from "../Command";
-import progressBar from "../progressBar";
 import PromptUtilities from "../PromptUtilities";
 import {execSync, exec} from "../ChildProcessUtilities";
 
@@ -84,10 +83,10 @@ export default class ImportCommand extends Command {
   execute(callback) {
     const replacement = "$1/" + this.targetDir;
 
-    progressBar.init(this.commits.length);
+    this.progressBar.init(this.commits.length);
 
     async.series(this.commits.map((sha) => (done) => {
-      progressBar.tick(sha);
+      this.progressBar.tick(sha);
 
       // Create a patch file for this commit and prepend the target directory
       // to all affected files.  This moves the git history for the entire
@@ -117,7 +116,7 @@ export default class ImportCommand extends Command {
         done(err);
       }).stdin.end(patch);
     }), (err) => {
-      progressBar.terminate();
+      this.progressBar.terminate();
 
       if (!err) {
         this.logger.info("Import complete!");


### PR DESCRIPTION
Again, for consistency, let's make sure all the subcommands are accessing the logger and progress bar in the same way. Making as many as possible accessed via instance properties makes future mocking and/or test optimizations a lot easier.