### PR TITLE
Add script command

### DIFF
--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -35,6 +35,12 @@ export default class ChildProcessUtilities {
     );
   }
 
+  static execStreaming(command, opts, prefix, callback) {
+    opts = this.getStreamingOpts(opts);
+    const childProcess = this.exec(command, opts, callback);
+    this.streaming(childProcess, prefix);
+  }
+
   static execSync(command, opts) {
     const mergedOpts = Object.assign({
       encoding: "utf8",
@@ -63,12 +69,18 @@ export default class ChildProcessUtilities {
   }
 
   static spawnStreaming(command, args, opts, prefix, callback) {
-    opts = Object.assign({}, opts, {
+    opts = this.getStreamingOpts(opts);
+    const childProcess = _spawn(command, args, opts, callback);
+    this.streaming(childProcess, prefix);
+  }
+
+  static getStreamingOpts(opts) {
+    return Object.assign({}, opts, {
       stdio: ["ignore", "pipe", "pipe"],
     });
+  }
 
-    const childProcess = _spawn(command, args, opts, callback);
-
+  static streaming(childProcess, prefix) {
     ["stdout", "stderr"].forEach((stream) => {
       let partialLine = "";
       childProcess[stream].setEncoding("utf8")

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -54,6 +54,10 @@ export default class Repository {
     return this.lernaJson && this.lernaJson.bootstrapConfig || {};
   }
 
+  get scripts() {
+    return this.lernaJson && this.lernaJson.scripts || {};
+  }
+
   get nodeModulesLocation() {
     return path.join(this.rootPath, "node_modules");
   }

--- a/src/commands/ScriptCommand.js
+++ b/src/commands/ScriptCommand.js
@@ -1,0 +1,65 @@
+import ChildProcessUtilities from "../ChildProcessUtilities";
+import PackageUtilities from "../PackageUtilities";
+import Command from "../Command";
+
+export default class ScriptCommand extends Command {
+  initialize(callback) {
+    this.script = this.input[0];
+    this.args = this.input.slice(1);
+    
+    if (!this.script) {
+      callback(new Error("You must specify which lerna script to run."));
+      return;
+    }
+
+    this.batchedPackages = this.toposort
+      ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages, {logger: this.logger})
+      : [ this.filteredPackages ];
+
+    callback(null, true);
+  }
+
+  execute(callback) {
+    PackageUtilities.runParallelBatches(this.batchedPackages, (pkg) => (done) => {
+      this.runLernaLifecycleScriptInPackage(pkg, done);
+    }, this.concurrency, callback);
+  }
+
+  runLernaLifecycleScriptInPackage(pkg, callback) {
+    this.runLernaScriptInPackage({ pkg, prefix: "pre" }, (precode) => {
+      if (precode) callback(precode);
+      else this.runLernaScriptInPackage({ pkg }, (code) => {
+        if (code) callback(code);
+        else this.runLernaScriptInPackage({ pkg, prefix: "post" }, (postcode) => {
+          callback(postcode);
+        });
+      });
+    });
+  }
+
+  runLernaScriptInPackage({ pkg, prefix = "" }, callback) {
+    const script = `${prefix}${this.script}`;
+    const input = this.repository.scripts[script];
+    if (!input) {
+      callback(prefix ? null : new Error(`No lerna scripts found with '${script}'`));
+    } else {
+      const args = input.split(" ").concat(prefix ? [] : this.args);
+      const command = args.shift();
+      this.runCommandInPackage({ pkg, command, args }, callback);
+    }
+  }
+
+  runCommandInPackage({ pkg, command, args }, callback) {
+    ChildProcessUtilities.spawn(command, args, {
+      cwd: pkg.location,
+      env: process.env
+    }, (code) => {
+      if (code) {
+        this.logger.error(`Errored while running command '${command}' ` +
+                          `with arguments '${args.join(" ")}' in '${pkg.name}'`);
+      }
+      callback(code);
+    });
+  }
+
+}

--- a/src/commands/ScriptCommand.js
+++ b/src/commands/ScriptCommand.js
@@ -76,7 +76,7 @@ export default class ScriptCommand extends Command {
       this.logger.info(`${prefix}> ${command}`);
       this.logger.info(prefix);
       if (stdout)
-        this.logger.info(stdout.split("\n").map((line) => line).join("\n"));
+        this.logger.info(stdout.split("\n").map((line) => prefix + line).join("\n"));
     };
     const cb = (code, stdout) => {
       if (!stream)

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
 import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
+import ScriptCommand from "./commands/ScriptCommand";
 import {exposeCommands} from "./Command";
 
 export const __commands__ = exposeCommands([
@@ -21,6 +22,7 @@ export const __commands__ = exposeCommands([
   RunCommand,
   ExecCommand,
   LsCommand,
+  ScriptCommand,
 ]);
 
 import PackageUtilities from "./PackageUtilities";

--- a/test/ScriptCommand.js
+++ b/test/ScriptCommand.js
@@ -1,0 +1,241 @@
+import assert from "assert";
+import path from "path";
+
+import ChildProcessUtilities from "../src/ChildProcessUtilities";
+import exitWithCode from "./_exitWithCode";
+import initFixture from "./_initFixture";
+import ScriptCommand from "../src/commands/ScriptCommand";
+import stub from "./_stub";
+
+describe("ScriptCommand", () => {
+
+  describe("in a basic repo", () => {
+    let testDir;
+    beforeEach((done) => {
+      testDir = initFixture("ScriptCommand/basic", done);
+    });
+
+    it("should complain if invoked without command", (done) => {
+      const scriptCommand = new ScriptCommand([], {});
+
+      scriptCommand.runValidations();
+      scriptCommand.runPreparations();
+
+      scriptCommand.runCommand(exitWithCode(1, (err) => {
+        assert.ok(err instanceof Error);
+        done();
+      }));
+    });
+
+    it("should filter packages with `ignore`", (done) => {
+      const scriptCommand = new ScriptCommand(["ls"], { ignore: "package-1" });
+
+      scriptCommand.runValidations();
+      scriptCommand.runPreparations();
+
+      scriptCommand.initialize(function(error) {
+        assert.equal(error, null);
+      });
+
+      assert.equal(scriptCommand.filteredPackages.length, 1);
+      assert.equal(scriptCommand.filteredPackages[0].name, "package-2");
+
+      done();
+    });
+
+    it("should run a command", (done) => {
+      const scriptCommand = new ScriptCommand(["build"], {});
+
+      scriptCommand.runValidations();
+      scriptCommand.runPreparations();
+
+      let calls = 0;
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        assert.equal(command, "babel");
+
+        if (calls === 0) assert.deepEqual(options, {
+          cwd: path.join(testDir, "packages/package-1"),
+          env: Object.assign({}, process.env, { LERNA_SCRIPT_NESTED_PACKAGE: "package-1" }) });
+        if (calls === 1) assert.deepEqual(options, {
+          cwd: path.join(testDir, "packages/package-2"),
+          env: Object.assign({}, process.env, { LERNA_SCRIPT_NESTED_PACKAGE: "package-2" }) });
+
+        calls++;
+        callback();
+      });
+
+      scriptCommand.runCommand(exitWithCode(0, () => {
+        assert.equal(calls, 2);
+        done();
+      }));
+    });
+
+    it("should run a command with lifecycle pre/post", (done) => {
+      const scriptCommand = new ScriptCommand(["lifecycle"], {});
+
+      scriptCommand.runValidations();
+      scriptCommand.runPreparations();
+
+      let calls = [];
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        calls.push({ command, options });
+        callback();
+      });
+
+      scriptCommand.runCommand(exitWithCode(0, () => {
+        assert.equal(calls.length, 6);
+        calls.sort((a, b) => {
+          const aPackage = a.options.env.LERNA_SCRIPT_NESTED_PACKAGE;
+          const bPackage = b.options.env.LERNA_SCRIPT_NESTED_PACKAGE;
+          return aPackage > bPackage;
+        });
+        const packages = ["package-1", "package-2"];
+        const commands = ["echo pre", "echo main", "echo post"];
+        for (let i = 0; i < packages.length; i += 1) {
+          for (let j = 0; j < commands.length; j += 1) {
+            assert.deepEqual(calls.shift(), {
+              command: commands[j],
+              options: {
+                cwd: path.join(testDir, `packages/${packages[i]}`),
+                env: Object.assign({}, process.env, { LERNA_SCRIPT_NESTED_PACKAGE: packages[i] }) 
+              }
+            });
+          }
+        }
+        done();
+      }));
+    });
+
+    it("should run a command with parameters", (done) => {
+      const scriptCommand = new ScriptCommand(["build", "--out-dir", "lib"], {});
+
+      scriptCommand.runValidations();
+      scriptCommand.runPreparations();
+
+      let calls = 0;
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        assert.equal(command, "babel --out-dir lib");
+
+        if (calls === 0) assert.deepEqual(options, {
+          cwd: path.join(testDir, "packages/package-1"),
+          env: Object.assign({}, process.env, { LERNA_SCRIPT_NESTED_PACKAGE: "package-1" }) });
+        if (calls === 1) assert.deepEqual(options, {
+          cwd: path.join(testDir, "packages/package-2"),
+          env: Object.assign({}, process.env, { LERNA_SCRIPT_NESTED_PACKAGE: "package-2" }) });
+
+        calls++;
+        callback();
+      });
+
+      scriptCommand.runCommand(exitWithCode(0, () => {
+        assert.equal(calls, 2);
+        done();
+      }));
+    });
+    
+    it("should run with streaming enabled with --stream", (done) => {
+      const scriptCommand = new ScriptCommand(["build", "--watch"], {stream: true});
+
+      scriptCommand.runValidations();
+      scriptCommand.runPreparations();
+
+      let calls = 0;
+      stub(ChildProcessUtilities, "execStreaming", (command, options, prefix, callback) => {
+        const pkg = "package-" + ([1,2][calls]);
+
+        assert.equal(command, "babel --watch");
+        assert.deepEqual(options, {
+          cwd: path.join(testDir, "packages/" + pkg),
+          env: Object.assign({}, process.env, { LERNA_SCRIPT_NESTED_PACKAGE: pkg }),
+        });
+        assert.equal(prefix, pkg + ": ");
+
+        calls++;
+        callback();
+      });
+
+      scriptCommand.runCommand(exitWithCode(0, done));
+    });
+
+    // Both of these commands should result in the same outcome
+    const filters = [
+      { test: "should run a command for a given scope", flag: "scope", flagValue: "package-1"},
+      { test: "should not run a command for ignored packages", flag: "ignore", flagValue: "package-@(2|3|4)"},
+    ];
+    filters.forEach((filter) => {
+      it(filter.test, (done) => {
+        const scriptCommand = new ScriptCommand(["build"], {[filter.flag]: filter.flagValue});
+
+        scriptCommand.runValidations();
+        scriptCommand.runPreparations();
+
+        const ranInPackages = [];
+        stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+          ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+          callback();
+        });
+
+        scriptCommand.runCommand(exitWithCode(0, () => {
+          assert.deepEqual(ranInPackages, ["package-1"]);
+          done();
+        }));
+      });
+    });
+
+    it("should run a command in the package who executed the nested script", (done) => {
+      process.env.LERNA_SCRIPT_NESTED_PACKAGE = "package-2";
+
+      const scriptCommand = new ScriptCommand(["build"], {});
+
+      scriptCommand.runValidations();
+      scriptCommand.runPreparations();
+
+      let calls = 0;
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        assert.equal(command, "babel");
+        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-2"), env: process.env });
+
+        calls++;
+        callback();
+      });
+
+      scriptCommand.runCommand(exitWithCode(0, () => {
+        assert.equal(calls, 1);
+        delete process.env.LERNA_SCRIPT_NESTED_PACKAGE;
+        done();
+      }));
+    });
+
+  });
+
+  
+  describe("with --include-filtered-dependencies", () => {
+    let testDir;
+    beforeEach((done) => {
+      testDir = initFixture("ScriptCommand/include-filtered-dependencies", done);
+    });
+
+    it("should run a command for the given scope, including filtered deps", (done) => {
+      const scriptCommand = new ScriptCommand(["build"], {
+        scope: "@test/package-2",
+        includeFilteredDependencies: true
+      });
+
+      scriptCommand.runValidations();
+      scriptCommand.runPreparations();
+
+      const ranInPackages = [];
+      stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+        callback();
+      });
+
+      scriptCommand.runCommand(exitWithCode(0, () => {
+        const expected = ["package-1", "package-2"];
+        assert.deepEqual(ranInPackages.sort(), expected.sort());
+        done();
+      }));
+    });
+  });
+
+});

--- a/test/fixtures/ScriptCommand/basic/lerna.json
+++ b/test/fixtures/ScriptCommand/basic/lerna.json
@@ -1,0 +1,10 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "babel",
+    "prelifecycle": "echo pre",
+    "lifecycle": "echo main",
+    "postlifecycle": "echo post"
+  }
+}

--- a/test/fixtures/ScriptCommand/basic/package.json
+++ b/test/fixtures/ScriptCommand/basic/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/ScriptCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/ScriptCommand/basic/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ScriptCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/ScriptCommand/basic/packages/package-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-2",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ScriptCommand/include-filtered-dependencies/lerna.json
+++ b/test/fixtures/ScriptCommand/include-filtered-dependencies/lerna.json
@@ -1,0 +1,7 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "babel"
+  }
+}

--- a/test/fixtures/ScriptCommand/include-filtered-dependencies/package.json
+++ b/test/fixtures/ScriptCommand/include-filtered-dependencies/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/ScriptCommand/include-filtered-dependencies/packages/package-1/package.json
+++ b/test/fixtures/ScriptCommand/include-filtered-dependencies/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ScriptCommand/include-filtered-dependencies/packages/package-2/package.json
+++ b/test/fixtures/ScriptCommand/include-filtered-dependencies/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-2",
+  "version": "1.0.0",
+  "dependencies": {
+  	"@test/package-1": "1.0.0"
+  }
+}

--- a/test/fixtures/ScriptCommand/include-filtered-dependencies/packages/package-3/package.json
+++ b/test/fixtures/ScriptCommand/include-filtered-dependencies/packages/package-3/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-3",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Related #292

For me, this is a way to solve problem like this:

package.json

```sh
{
  "scripts": {
    "test": "lerna exec -- mocha ./lib/test/**/*.test.js"
  }
}
```

while using `npm run test`, I cannot pass any arguments to it, since it would be a wrong order.

For example:

```sh
npm run test -- --scope some-package
```

will be

```sh
lerna exec -- mocha ./lib/test/**/*.test.js --scope some-package
```

instead of

```sh
lerna exec --scope some-package -- mocha ./lib/test/**/*.test.js
```

Additionally, I think it would be better to have hook scripts (pre/post) and nested script, so I made this command.

This command is separated from original lerna lifecycle scripts (`./scripts/prepublish.js`, etc.), they won't affect each other.

## Command

```sh
lerna script <script-name> [-- <args>...]
```
Support flags

- `--stream`
- `--scope`
- `--ignore`
- `--include-filtered-dependencies`

## Configs

lerna.json
```json
{
  "scripts": {
    "prebuild": "rm -rf ./lib",
    "build": "babel",
    "postbuild": "lerna script test && lerna script lint",
    "build-watch": "lerna script build -- --watch",
    "test": "mocha",
    "lint": "eslint"
  }
}
```

Support nested scripts

- it will run a command in the package who executed the nested script.