### PR TITLE
Add --include-peer-dependencies option

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -18,12 +18,14 @@ export default class Command {
     this.repository = new Repository();
     this.progressBar = progressBar;
 
-    const {sort, concurrency} = this.getOptions();
+    const {sort, concurrency, includePeerDependencies} = this.getOptions();
 
     this.concurrency = Math.max(1, +concurrency || DEFAULT_CONCURRENCY);
 
     // If the option isn't present then the default is to sort.
     this.toposort = sort == null || sort;
+
+    process.env.LERNA_INCLUDE_PEER_DEPENDENCIES = includePeerDependencies;
   }
 
   get name() {

--- a/src/Package.js
+++ b/src/Package.js
@@ -46,8 +46,12 @@ export default class Package {
   }
 
   get allDependencies() {
+    const allDependencies = {};
+    if (process.env.LERNA_INCLUDE_PEER_DEPENDENCIES === "true") {
+      Object.assign(allDependencies, this.peerDependencies);
+    }
     return Object.assign(
-      {},
+      allDependencies,
       this.devDependencies,
       this.dependencies
     );


### PR DESCRIPTION
Related #375

This PR adds a `--include-peer-dependencies` option that will affect the value from `Package#allDependencies`.

```sh
lerna bootstrap --include-peer-dependencies
```

Though it was implemented with `process.env`, but I think it's ok since it just use for `lerna bootstrap`, which is equivalent to the following code while running `lerna bootstrap --include-peer-dependencies`.

```js
get allDependencies() {
    return Object.assign(
      {},
      this.peerDependencies,
      this.devDependencies,
      this.dependencies
    );
  }
```