### PR TITLE
chore(ci): use yarn instead of npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,24 @@ git:
   depth: 1
 sudo: false
 language: node_js
-install: npm install
 cache:
+  yarn: true
   directories:
   - node_modules
 
 node_js:
- - '4'
- - '6'
  - '7'
+ - '6'
+ - '4'
 
 before_script:
   - git config --global user.email test@example.com
   - git config --global user.name "Tester McPerson"
-script: npm run ci
+
+script: yarn run ci
+
+matrix:
+  fast_finish: true
 
 notifications:
   slack: lernajs:qHyrojRoqBBu7OhDyX1OMiHQ

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,29 @@
 # Test against this version of Node.js
 environment:
   matrix:
-    - nodejs_version: "4"
-    - nodejs_version: "6"
     - nodejs_version: "7"
+    - nodejs_version: "6"
+    - nodejs_version: "4"
 
 init:
   - git config --global user.email test@example.com
   - git config --global user.name "Tester McPerson"
 
+cache:
+  - "%LOCALAPPDATA%\\Yarn"
+
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install
+  - yarn
+
+matrix:
+  fast_finish: true
 
 test_script:
   - node --version
   - npm --version
-  - npm run ci
+  - yarn --version
+  - yarn run ci
 
 # Don't actually build.
 build: off


### PR DESCRIPTION
Mostly copied from https://github.com/babel/babel/blob/7.0/.travis.yml, it should help ease the pain of non-parallel AppVeyor somewhat.