### PR TITLE
Indent parsimonious stubbedCalls consistently

### DIFF
--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -161,13 +161,9 @@ describe("BootstrapCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install"], { cwd: testDir, stdio: STDIO_OPT }] }
-        ]],
-        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] }
-        ]],
-        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
+          { args: ["npm", ["install"], { cwd: testDir, stdio: STDIO_OPT }] },
+          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] },
+          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] },
         ]],
       ]);
 
@@ -273,10 +269,8 @@ describe("BootstrapCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages", "package-1"), stdio: STDIO_OPT }] }
-        ]],
-        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages", "package-2"), stdio: STDIO_OPT }] }
+          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages", "package-1"), stdio: STDIO_OPT }] },
+          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages", "package-2"), stdio: STDIO_OPT }] },
         ]]
       ]);
 
@@ -310,10 +304,8 @@ describe("BootstrapCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] }
-        ]],
-        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
+          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] },
+          { args: ["npm", ["install"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] },
         ]]
       ]);
 
@@ -395,16 +387,10 @@ describe("BootstrapCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-1"), stdio: STDIO_OPT }] }
-        ]],
-        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-2"), stdio: STDIO_OPT }] }
-        ]],
-        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "package-3"), stdio: STDIO_OPT }] }
-        ]],
-        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "@test/package-1@^0.0.0"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
+          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-1"), stdio: STDIO_OPT }] },
+          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-2"), stdio: STDIO_OPT }] },
+          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "package-3"), stdio: STDIO_OPT }] },
+          { args: ["npm", ["install", "@test/package-1@^0.0.0"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] },
         ]],
       ]);
 

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -998,49 +998,49 @@ describe("PublishCommand", () => {
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git tag"] }
         ]],
-       [PromptUtilities, "confirm", { valueCallback: true }, [
-         { args: ["Are you sure you want to publish the above changes?"], returns: true }
-       ]],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["git add " + escapeArgs(path.join(testDir, "lerna.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
-         { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
-         { args: ["git tag v1.0.1"] }
-       ]],
-       [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         // No package-5.  It's private.
-       ], true],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-1 lerna-temp"] },
-         { args: ["npm dist-tag add package-1@1.0.1 latest"] },
+        [PromptUtilities, "confirm", { valueCallback: true }, [
+          { args: ["Are you sure you want to publish the above changes?"], returns: true }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git add " + escapeArgs(path.join(testDir, "lerna.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
+          { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
+          { args: ["git tag v1.0.1"] }
+        ]],
+        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          // No package-5.  It's private.
+        ], true],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-1 lerna-temp"] },
+          { args: ["npm dist-tag add package-1@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-3 lerna-temp"] },
-         { args: ["npm dist-tag add package-3@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-3 lerna-temp"] },
+          { args: ["npm dist-tag add package-3@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-4 lerna-temp"] },
-         { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-4 lerna-temp"] },
+          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-2 lerna-temp"] },
-         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
-         // No package-5.  It's private.
+          // No package-5.  It's private.
 
-         { args: ["git symbolic-ref --short HEAD"], returns: "master" },
-         { args: ["git push origin master"] },
-         { args: ["git push origin v1.0.1"] }
-       ]],
+          { args: ["git symbolic-ref --short HEAD"], returns: "master" },
+          { args: ["git push origin master"] },
+          { args: ["git push origin v1.0.1"] }
+        ]],
       ]);
 
       publishCommand.runCommand(exitWithCode(0, (err) => {
@@ -1093,52 +1093,52 @@ describe("PublishCommand", () => {
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["git tag"] }
-       ]],
-       [PromptUtilities, "confirm", { valueCallback: true }, [
-         { args: ["Are you sure you want to publish the above changes?"], returns: true }
-       ]],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["git add " + escapeArgs(path.join(testDir, "lerna.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
-         { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
-         { args: ["git tag v1.0.1"] }
-       ]],
-       [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         // No package-5.  It's private.
-       ], true],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-1 lerna-temp"] },
-         { args: ["npm dist-tag add package-1@1.0.1 latest"] },
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git tag"] }
+        ]],
+        [PromptUtilities, "confirm", { valueCallback: true }, [
+          { args: ["Are you sure you want to publish the above changes?"], returns: true }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git add " + escapeArgs(path.join(testDir, "lerna.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
+          { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
+          { args: ["git tag v1.0.1"] }
+        ]],
+        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          // No package-5.  It's private.
+        ], true],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-1 lerna-temp"] },
+          { args: ["npm dist-tag add package-1@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-3 lerna-temp"] },
-         { args: ["npm dist-tag add package-3@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-3 lerna-temp"] },
+          { args: ["npm dist-tag add package-3@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-4 lerna-temp"] },
-         { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-4 lerna-temp"] },
+          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-2 lerna-temp"] },
-         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
-         // No package-5.  It's private.
+          // No package-5.  It's private.
 
-         { args: ["git symbolic-ref --short HEAD"], returns: "master" },
-         { args: ["git push origin master"] },
-         { args: ["git push origin v1.0.1"] }
-       ]],
+          { args: ["git symbolic-ref --short HEAD"], returns: "master" },
+          { args: ["git push origin master"] },
+          { args: ["git push origin v1.0.1"] }
+        ]],
       ]);
 
       publishCommand.runCommand(exitWithCode(0, (err) => {
@@ -1581,55 +1581,55 @@ describe("PublishCommand", () => {
         [ChildProcessUtilities, "execSync", {}, [
           { args: ["git symbolic-ref --short -q HEAD"] }
         ]],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["git tag"] }
-       ]],
-       [PromptUtilities, "select", { valueCallback: true }, [
-         { args: ["Select a new version (currently 1.0.0)"], returns: "1.0.1" }
-       ]],
-       [PromptUtilities, "confirm", { valueCallback: true }, [
-         { args: ["Are you sure you want to publish the above changes?"], returns: true }
-       ]],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["git add " + escapeArgs(path.join(testDir, "lerna.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
-         { args: ["git commit -m \"$(echo \"A custom publish message\")\""] },
-         { args: ["git tag v1.0.1"] }
-       ]],
-       [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         { args: ["npm publish --tag lerna-temp"] },
-         // No package-5.  It's private.
-       ], true],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-1 lerna-temp"] },
-         { args: ["npm dist-tag add package-1@1.0.1 latest"] },
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git tag"] }
+        ]],
+        [PromptUtilities, "select", { valueCallback: true }, [
+          { args: ["Select a new version (currently 1.0.0)"], returns: "1.0.1" }
+        ]],
+        [PromptUtilities, "confirm", { valueCallback: true }, [
+          { args: ["Are you sure you want to publish the above changes?"], returns: true }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git add " + escapeArgs(path.join(testDir, "lerna.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
+          { args: ["git commit -m \"$(echo \"A custom publish message\")\""] },
+          { args: ["git tag v1.0.1"] }
+        ]],
+        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          { args: ["npm publish --tag lerna-temp"] },
+          // No package-5.  It's private.
+        ], true],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["npm dist-tag ls package-1"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-1 lerna-temp"] },
+          { args: ["npm dist-tag add package-1@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-3 lerna-temp"] },
-         { args: ["npm dist-tag add package-3@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-3"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-3 lerna-temp"] },
+          { args: ["npm dist-tag add package-3@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-4 lerna-temp"] },
-         { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-4"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-4 lerna-temp"] },
+          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-2 lerna-temp"] },
-         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-2"], returns: "lerna-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
-         // No package-5.  It's private.
+          // No package-5.  It's private.
 
-         { args: ["git symbolic-ref --short HEAD"], returns: "master" },
-         { args: ["git push origin master"] },
-         { args: ["git push origin v1.0.1"] }
-       ]],
+          { args: ["git symbolic-ref --short HEAD"], returns: "master" },
+          { args: ["git push origin master"] },
+          { args: ["git push origin v1.0.1"] }
+        ]],
       ]);
 
       publishCommand.runCommand(exitWithCode(0, (err) => {

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -36,9 +36,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -136,9 +134,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -234,12 +230,9 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] },
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" }
         ]],
@@ -328,12 +321,9 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] },
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" },
           { args: ["git rev-parse HEAD"], returns: "81e3b44339e1403fe3d762e9435b7c9a155fdef7" }
         ]],
@@ -419,9 +409,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -500,9 +488,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -571,9 +557,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -630,9 +614,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -698,9 +680,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -993,9 +973,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "confirm", { valueCallback: true }, [
@@ -1191,9 +1169,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "confirm", { valueCallback: true }, [
@@ -1292,9 +1268,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "confirm", { valueCallback: true }, [
@@ -1386,9 +1360,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "confirm", { valueCallback: true }, [
@@ -1479,9 +1451,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -1680,9 +1650,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [PromptUtilities, "select", { valueCallback: true }, [
@@ -1780,9 +1748,7 @@ describe("PublishCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["git symbolic-ref --short -q HEAD"] }
-        ]],
-        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git symbolic-ref --short -q HEAD"] },
           { args: ["git tag"] }
         ]],
         [ConventionalCommitUtilities, "recommendVersion", {}, [


### PR DESCRIPTION
It's incredibly subtle, and paradoxically the linter does not complain about it.

Additionally, many `assertStubbedCalls` lists had repetitive object stubs, which are easier to read when condensed.