### PR TITLE
Use `yarn --frozen-lockfile` in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   directories:
   - node_modules
 
-install: yarn
+install: yarn --frozen-lockfile
 
 before_script:
   - git config --global user.email test@example.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ cache:
   directories:
   - node_modules
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 install: yarn --frozen-lockfile
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,26 @@ git:
   depth: 1
 sudo: false
 language: node_js
+node_js:
+ - '7'
+ - '6'
+ - '4'
+
+matrix:
+  fast_finish: true
+
 cache:
   yarn: true
   directories:
   - node_modules
 
-node_js:
- - '7'
- - '6'
- - '4'
+install: yarn
 
 before_script:
   - git config --global user.email test@example.com
   - git config --global user.name "Tester McPerson"
 
 script: yarn run ci
-
-matrix:
-  fast_finish: true
 
 notifications:
   slack: lernajs:qHyrojRoqBBu7OhDyX1OMiHQ

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ cache:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - yarn
+  - yarn --frozen-lockfile
 
 before_test:
   - git config --global user.email test@example.com

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,27 @@
-# Test against this version of Node.js
+clone_depth: 1
+
 environment:
   matrix:
     - nodejs_version: "7"
     - nodejs_version: "6"
     - nodejs_version: "4"
 
-init:
-  - git config --global user.email test@example.com
-  - git config --global user.name "Tester McPerson"
+matrix:
+  fast_finish: true
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"
+  - node_modules -> yarn.lock
 
 install:
   - ps: Install-Product node $env:nodejs_version
   - yarn
 
-matrix:
-  fast_finish: true
+before_test:
+  - git config --global user.email test@example.com
+  - git config --global user.name "Tester McPerson"
 
 test_script:
-  - node --version
-  - npm --version
-  - yarn --version
   - yarn run ci
 
-# Don't actually build.
 build: off


### PR DESCRIPTION
This is one way we can avoid PRs that update dependencies without committing `yarn.lock` (another is improving our contributing docs, also on my todo list). I've also harmonized the two CI config files as much as possible, with improved caching for AppVeyor.