### PR TITLE
expose getUpdatedPackages for programmatic API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ import RunCommand from "./commands/RunCommand";
 import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
 import {exposeCommands} from "./Command";
+import UpdatedPackagesCollector from "./UpdatedPackagesCollector.js";
+import logger from "./logger";
 
 export const __commands__ = exposeCommands([
   BootstrapCommand,
@@ -30,3 +32,9 @@ export const getPackagePath = PackageUtilities.getPackagePath;
 export const getPackageConfigPath = PackageUtilities.getPackageConfigPath;
 export const getPackageConfig = PackageUtilities.getPackageConfig;
 export const getPackages = PackageUtilities.getPackages;
+export const getUpdatedPackages = (flags = {}) => {
+  logger.setLogLevel(flags.loglevel);
+  const command = new UpdatedCommand([], flags);
+  const updatedPackagesCollector = new UpdatedPackagesCollector(command);
+  return updatedPackagesCollector.getUpdates();
+};


### PR DESCRIPTION
I have a need to generate zip files (from Jenkins) for each updated package after they are published, but in order to do that, I need to know which packages have been updated.

This quick and dirty change makes this possible. Instead of trying to parse the list of packages from the updated command (which is made for human, not machine consumption), I can just create a script that calls the getUpdatedPackages function and puts the resulting list somewhere (maybe a file or env var). Then I'll run lerna publish. After a successful publish, I'll create a zip file for each package in the env var.

I assume you'll want some changes to this, if you don't just reject it outright, but thought I'd go ahead and create the PR to get the conversation started.