### PR TITLE
Support lerna execution from subdirectories of repo root

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "glob": "^7.0.6",
     "graceful-fs": "^4.1.11",
     "inquirer": "^3.0.1",
+    "load-json-file": "^2.0.0",
     "lodash": "^4.17.4",
     "meow": "^3.7.0",
     "minimatch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "conventional-recommended-bump": "^1.0.0",
     "cross-spawn": "^4.0.0",
     "dedent": "^0.7.0",
+    "find-up": "^2.1.0",
     "glob": "^7.0.6",
     "graceful-fs": "^4.1.11",
     "inquirer": "^3.0.1",

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -40,7 +40,15 @@ export default class ChildProcessUtilities {
       encoding: "utf8",
       maxBuffer: MAX_BUFFER
     }, opts);
-    return child.execSync(command, mergedOpts).trim();
+
+    let stdout = child.execSync(command, mergedOpts);
+    if (stdout) {
+      // stdout is undefined when stdio[1] is anything other than "pipe"
+      // and there's no point trimming an empty string (no piped stdout)
+      stdout = stdout.trim();
+    }
+
+    return stdout;
   }
 
   static spawn(command, args, opts, callback) {

--- a/src/Command.js
+++ b/src/Command.js
@@ -17,13 +17,25 @@ export default class Command {
     this.logger = logger;
     this.repository = new Repository();
     this.progressBar = progressBar;
+  }
 
-    const {sort, concurrency} = this.getOptions();
+  get concurrency() {
+    if (!this._concurrency) {
+      const { concurrency } = this.getOptions();
+      this._concurrency = Math.max(1, +concurrency || DEFAULT_CONCURRENCY);
+    }
 
-    this.concurrency = Math.max(1, +concurrency || DEFAULT_CONCURRENCY);
+    return this._concurrency;
+  }
 
-    // If the option isn't present then the default is to sort.
-    this.toposort = sort == null || sort;
+  get toposort() {
+    if (!this._toposort) {
+      const { sort } = this.getOptions();
+      // If the option isn't present then the default is to sort.
+      this._toposort = sort == null || sort;
+    }
+
+    return this._toposort;
   }
 
   get name() {
@@ -83,12 +95,6 @@ export default class Command {
   }
 
   runValidations() {
-    if (this.concurrency < 1) {
-      this.logger.warn("command must be run with at least one thread.");
-      this._complete(null, 1);
-      return;
-    }
-
     if (!FileSystemUtilities.existsSync(this.repository.packageJsonLocation)) {
       this.logger.warn("`package.json` does not exist, have you run `lerna init`?");
       this._complete(null, 1);

--- a/src/Command.js
+++ b/src/Command.js
@@ -125,7 +125,7 @@ export default class Command {
     }
 
     if (FileSystemUtilities.existsSync(this.repository.versionLocation)) {
-      this.logger.warn("You have a `VERSION` file in your repository, this is leftover from a previous ");
+      this.logger.warn("You have a `VERSION` file in your repository, this is leftover from a previous version. Please run `lerna init` to update.");
       this._complete(null, 1);
       return;
     }

--- a/src/Command.js
+++ b/src/Command.js
@@ -1,5 +1,6 @@
 import ChildProcessUtilities from "./ChildProcessUtilities";
 import FileSystemUtilities from "./FileSystemUtilities";
+import GitUtilities from "./GitUtilities";
 import ExitHandler from "./ExitHandler";
 import progressBar from "./progressBar";
 import Repository from "./Repository";
@@ -95,6 +96,12 @@ export default class Command {
   }
 
   runValidations() {
+    if (!GitUtilities.isInitialized()) {
+      this.logger.warn("This is not a git repository, did you already run `git init` or `lerna init`?");
+      this._complete(null, 1);
+      return;
+    }
+
     if (!FileSystemUtilities.existsSync(this.repository.packageJsonLocation)) {
       this.logger.warn("`package.json` does not exist, have you run `lerna init`?");
       this._complete(null, 1);

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -29,12 +29,15 @@ export default class PackageUtilities {
     return require(PackageUtilities.getPackageConfigPath(packagesPath, name));
   }
 
-  static getPackages(repository) {
+  static getPackages({
+    packageConfigs,
+    rootPath,
+  }) {
     const packages = [];
 
-    repository.packageConfigs.forEach((globPath) => {
+    packageConfigs.forEach((globPath) => {
 
-      globSync(path.join(repository.rootPath, globPath, "package.json"))
+      globSync(path.join(rootPath, globPath, "package.json"))
         .map((fn) => path.resolve(fn))
         .forEach((packageConfigPath) => {
           const packagePath = path.dirname(packageConfigPath);

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -1,6 +1,5 @@
 import path from "path";
 import findUp from "find-up";
-import GitUtilities from "./GitUtilities";
 import loadJsonFile from "load-json-file";
 import PackageUtilities from "./PackageUtilities";
 import Package from "./Package";
@@ -10,11 +9,6 @@ const DEFAULT_PACKAGE_GLOB = "packages/*";
 
 export default class Repository {
   constructor() {
-    if (!GitUtilities.isInitialized()) {
-      logger.info("Initializing Git repository.");
-      GitUtilities.init();
-    }
-
     // findUp returns null when not found, and path.resolve starts from process.cwd()
     const lernaJsonLocation = findUp.sync("lerna.json") || path.resolve("lerna.json");
 

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -1,10 +1,10 @@
+import path from "path";
+import findUp from "find-up";
 import GitUtilities from "./GitUtilities";
 import FileSystemUtilities from "./FileSystemUtilities";
 import PackageUtilities from "./PackageUtilities";
 import Package from "./Package";
 import NpmUtilities from "./NpmUtilities";
-import path from "path";
-import logger from "./logger";
 
 const DEFAULT_PACKAGE_GLOB = "packages/*";
 
@@ -15,10 +15,12 @@ export default class Repository {
       GitUtilities.init();
     }
 
-    this.rootPath = path.resolve(GitUtilities.getTopLevelDirectory());
-    this.lernaJsonLocation = path.join(this.rootPath, "lerna.json");
+    // findUp returns null when not found, and path.resolve starts from process.cwd()
+    const lernaJsonLocation = findUp.sync("lerna.json") || path.resolve("lerna.json");
+
+    this.rootPath = path.dirname(lernaJsonLocation);
+    this.lernaJsonLocation = lernaJsonLocation;
     this.packageJsonLocation = path.join(this.rootPath, "package.json");
-    this.packagesLocation = path.join(this.rootPath, "packages"); // TODO: Kill this.
 
     // Legacy
     this.versionLocation = path.join(this.rootPath, "VERSION");

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -46,14 +46,6 @@ export default class Repository {
     return this.lernaJson && this.lernaJson.version;
   }
 
-  get publishConfig() {
-    return this.lernaJson && this.lernaJson.publishConfig || {};
-  }
-
-  get bootstrapConfig() {
-    return this.lernaJson && this.lernaJson.bootstrapConfig || {};
-  }
-
   get nodeModulesLocation() {
     return path.join(this.rootPath, "node_modules");
   }

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -2,6 +2,7 @@ import path from "path";
 import findUp from "find-up";
 import GitUtilities from "./GitUtilities";
 import FileSystemUtilities from "./FileSystemUtilities";
+import loadJsonFile from "load-json-file";
 import PackageUtilities from "./PackageUtilities";
 import Package from "./Package";
 import NpmUtilities from "./NpmUtilities";
@@ -23,7 +24,7 @@ export default class Repository {
     this.packageJsonLocation = path.join(this.rootPath, "package.json");
 
     if (FileSystemUtilities.existsSync(this.lernaJsonLocation)) {
-      this.lernaJson = JSON.parse(FileSystemUtilities.readFileSync(this.lernaJsonLocation));
+      this.lernaJson = loadJsonFile.sync(this.lernaJsonLocation);
     } else {
       // No need to distinguish between missing and empty.
       // This saves us a lot of guards.
@@ -31,7 +32,7 @@ export default class Repository {
     }
 
     if (FileSystemUtilities.existsSync(this.packageJsonLocation)) {
-      this.packageJson = JSON.parse(FileSystemUtilities.readFileSync(this.packageJsonLocation));
+      this.packageJson = loadJsonFile.sync(this.packageJsonLocation);
     }
 
     this.package = new Package(this.packageJson, this.rootPath);

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -22,9 +22,6 @@ export default class Repository {
     this.lernaJsonLocation = lernaJsonLocation;
     this.packageJsonLocation = path.join(this.rootPath, "package.json");
 
-    // Legacy
-    this.versionLocation = path.join(this.rootPath, "VERSION");
-
     if (FileSystemUtilities.existsSync(this.lernaJsonLocation)) {
       this.lernaJson = JSON.parse(FileSystemUtilities.readFileSync(this.lernaJsonLocation));
     } else {
@@ -76,6 +73,11 @@ export default class Repository {
       this.buildPackageGraph();
     }
     return this._packageGraph;
+  }
+
+  // Legacy
+  get versionLocation() {
+    return path.join(this.rootPath, "VERSION");
   }
 
   isIndependent() {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -9,7 +9,6 @@ import semver from "semver";
 
 export default class BootstrapCommand extends Command {
   initialize(callback) {
-    this.configFlags = this.repository.bootstrapConfig;
     this.npmConfig = {
       registry: this.npmRegistry,
       client: this.getOptions().npmClient,

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -45,7 +45,7 @@ export default class InitCommand extends Command {
       lerna: this.lernaVersion
     });
 
-    FileSystemUtilities.writeFileSync(packageJsonLocation, JSON.stringify(packageJson, null, "  "));
+    FileSystemUtilities.writeFileSync(packageJsonLocation, JSON.stringify(packageJson, null, 2));
   }
 
   ensureLernaJson() {

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -1,4 +1,5 @@
 import FileSystemUtilities from "../FileSystemUtilities";
+import GitUtilities from "../GitUtilities";
 import Command from "../Command";
 import objectAssignSorted from "object-assign-sorted";
 
@@ -8,7 +9,11 @@ export default class InitCommand extends Command {
   runPreparations() {}
 
   initialize(callback) {
-    // Nothing to do...
+    if (!GitUtilities.isInitialized()) {
+      this.logger.info("Initializing Git repository.");
+      GitUtilities.init();
+    }
+
     callback(null, true);
   }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -337,6 +337,7 @@ export default class PublishCommand extends Command {
   }
 
   updateUpdatedPackages() {
+    const { exact } = this.getOptions();
     const changedFiles = [];
 
     this.updates.forEach((update) => {
@@ -348,9 +349,9 @@ export default class PublishCommand extends Command {
       pkg.version = this.updatesVersions[pkg.name] || pkg.version;
 
       // update pkg dependencies
-      this.updatePackageDepsObject(pkg, "dependencies");
-      this.updatePackageDepsObject(pkg, "devDependencies");
-      this.updatePackageDepsObject(pkg, "peerDependencies");
+      this.updatePackageDepsObject(pkg, "dependencies", exact);
+      this.updatePackageDepsObject(pkg, "devDependencies", exact);
+      this.updatePackageDepsObject(pkg, "peerDependencies", exact);
 
       // write new package
       FileSystemUtilities.writeFileSync(packageJsonLocation, pkg.toJsonString());
@@ -374,9 +375,8 @@ export default class PublishCommand extends Command {
     }
   }
 
-  updatePackageDepsObject(pkg, depsKey) {
+  updatePackageDepsObject(pkg, depsKey, exact) {
     const deps = pkg[depsKey];
-    const {exact} = this.getOptions();
 
     if (!deps) {
       return;

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -140,7 +140,7 @@ export default class PublishCommand extends Command {
         if (!(this.flags.canary || this.flags.skipGit)) {
           this.logger.info("Pushing tags to git...");
           this.logger.newLine();
-          GitUtilities.pushWithTags(this.flags.gitRemote || this.repository.publishConfig.gitRemote || "origin", this.tags);
+          GitUtilities.pushWithTags(this.getOptions().gitRemote || "origin", this.tags);
         }
 
         let message = "Successfully published:";

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -330,7 +330,7 @@ export default class PublishCommand extends Command {
 
   updateVersionInLernaJson() {
     this.repository.lernaJson.version = this.masterVersion;
-    FileSystemUtilities.writeFileSync(this.repository.lernaJsonLocation, JSON.stringify(this.repository.lernaJson, null, "  "));
+    FileSystemUtilities.writeFileSync(this.repository.lernaJsonLocation, JSON.stringify(this.repository.lernaJson, null, 2));
     if (!this.flags.skipGit) {
       GitUtilities.addFile(this.repository.lernaJsonLocation);
     }

--- a/test/ChildProcessUtilities.js
+++ b/test/ChildProcessUtilities.js
@@ -8,6 +8,10 @@ describe("ChildProcessUtilities", () => {
     it("should execute a command in a child process and return the result", () => {
       assert.equal(ChildProcessUtilities.execSync("echo foo"), "foo");
     });
+
+    it("does not error when stdout is ignored", () => {
+      expect(() => ChildProcessUtilities.execSync("echo foo", { stdio: "ignore" })).not.toThrow();
+    });
   });
 
   describe(".exec()", () => {

--- a/test/Command.js
+++ b/test/Command.js
@@ -63,6 +63,23 @@ describe("Command", () => {
     });
   });
 
+  describe(".toposort", () => {
+    it("is enabled by default", () => {
+      const command = new Command([], {});
+      assert.equal(command.toposort, true);
+    });
+
+    it("is enabled when sort config is null", () => {
+      const command = new Command([], {sort: null});
+      assert.equal(command.toposort, true);
+    });
+
+    it("is disabled when sort config is explicitly false (--no-sort)", () => {
+      const command = new Command([], {sort: false});
+      assert.equal(command.toposort, false);
+    });
+  });
+
   describe(".run()", () => {
     it("should exist", (done) => {
       class TestCommand extends Command {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,6 +2445,15 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -3135,15 +3144,15 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@~2.5.1, rimraf@~2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
+rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+rimraf@~2.5.1, rimraf@~2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
     glob "^7.0.5"
 
@@ -3327,7 +3336,7 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-bom@3.0.0:
+strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 


### PR DESCRIPTION
A few high-level goals, here:

* `lerna init` should be the only time we (maybe) run `git init`.
* `lerna` commands should ensure they are run in a git repo during the validation phase, not instantiation.
* Use more "lazy" getters to avoid wasted work and streamline the command startup path.
* Use high-quality libraries ([find-up][], [load-json-file][]) instead of rolling our own.

fixes #645, #555

[find-up]: https://www.npmjs.com/package/find-up
[load-json-file]: https://www.npmjs.com/package/load-json-file