### PR TITLE
chore: whitelist files included in package tarball [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0-beta.38",
   "description": "Tool for managing JavaScript projects with multiple packages",
   "main": "lib/index.js",
+  "files": [
+    "bin",
+    "lib"
+  ],
   "scripts": {
     "build": "babel src -d lib",
     "coverage": "jest --coverage",


### PR DESCRIPTION
Tested with `npm pack && tar tf lerna-2.0.0-beta.38.tgz`:

```diff
package/package.json
package/README.md
package/LICENSE
package/CHANGELOG.md
-package/CONTRIBUTING.md
-package/FAQ.md
-package/.eslintcache
package/bin/lerna.js
package/lib/ChildProcessUtilities.js
package/lib/FileSystemUtilities.js
package/lib/GitUtilities.js
package/lib/NpmUtilities.js
package/lib/Package.js
package/lib/ExitHandler.js
package/lib/PackageUtilities.js
package/lib/PromptUtilities.js
package/lib/Repository.js
package/lib/UpdatedPackagesCollector.js
package/lib/logger.js
package/lib/ConventionalCommitUtilities.js
package/lib/index.js
package/lib/Command.js
package/lib/progressBar.js
package/lib/PackageGraph.js
package/lib/commands/BootstrapCommand.js
package/lib/commands/CleanCommand.js
package/lib/commands/DiffCommand.js
package/lib/commands/ExecCommand.js
package/lib/commands/ImportCommand.js
package/lib/commands/InitCommand.js
package/lib/commands/LsCommand.js
package/lib/commands/PublishCommand.js
package/lib/commands/RunCommand.js
package/lib/commands/UpdatedCommand.js
```

48k before, 46k after. 🤣 

It's small, but at least we can forget about including the `.eslintcache` file...