### PR TITLE
Fix #677, possible approach for transitive deps during hoist

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -377,14 +377,56 @@ export default class BootstrapCommand extends Command {
         // If we have any unsatisfied deps then we need to install everything.
         // This is important for consistent behavior across npm clients.
         if (deps.some(({isSatisfied}) => !isSatisfied)) {
-          actions.push(
-            (cb) => NpmUtilities.installInDir(
-              pkg.location, deps.map(({dependency}) => dependency), this.npmConfig, (err) => {
-                this.progressBar.tick(pkg.name);
-                cb(err);
-              }
-            )
-          );
+          if (root.length === 0) {
+            actions.push(
+              (cb) => NpmUtilities.installInDir(
+                pkg.location, deps.map(({dependency}) => dependency), this.npmConfig, (err) => {
+                  this.progressBar.tick(pkg.name);
+                  cb(err);
+                }
+              )
+            );
+          } else {
+            const targetLocation = path.join(pkg.location, "node_modules", "_node_modules");
+            const depNames = deps.map(({ dependency }) => dependency.match(/(.*)@/)[1]);
+            actions.push(
+              (cb) => async.series([
+                (cb) => FileSystemUtilities.mkdirp(targetLocation, cb),
+                (cb) => FileSystemUtilities.writeFile(
+                  path.join(targetLocation, "package.json"),
+                  FileSystemUtilities.readFileSync(path.join(pkg.location, "package.json")),
+                  cb
+                ),
+                (cb) => NpmUtilities.installInDir(
+                  targetLocation, deps.map(({dependency}) => dependency), this.npmConfig, (err) => {
+                    this.progressBar.tick(pkg.name);
+                    cb(err);
+                  }
+                ),
+                (cb) => async.parallel(
+                  depNames.map((dependency) =>
+                    (cb) => FileSystemUtilities.rename(
+                      path.join(targetLocation, "node_modules", dependency),
+                      path.join(pkg.location, "node_modules", dependency),
+                      cb
+                    )
+                  ),
+                  cb
+                ),
+                (cb) => async.parallel(
+                  depNames.map((dependency) =>
+                    (cb) => FileSystemUtilities.symlink(
+                      path.join(targetLocation, "node_modules"),
+                      path.join(pkg.location, "node_modules", dependency, "node_modules"),
+                      "dir",
+                      cb
+                    )
+                  ),
+                  cb
+                ),
+              ], cb)
+            );
+          }
         }
       });
 


### PR DESCRIPTION
Here's a possible approach to fixing #677.  Instead of installing the leaf dependencies directly, we install them in a "shadow" directory `package-name/node_modules/_node_modules`.  Once all the leaves for `package-name` are installed, we go back and move each dep from `package-name/node_modules/_node_modules/dep` to `package-name/node_modules/dep` and symlink the shadow modules back into dep (`package-name/node_modules/dep/node_modules` -> `package-name/node_modules/_node_modules`).  This approach should work for both npm and yarn clients.

This isn't ready to be merged - tests are failing and more complex cases need to be addressed (version collisions in the flattened shadow dir, for example).  Just wanted to get some feedback on the approach to see if this is worth pursuing.