### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -43,8 +43,19 @@
 
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
-| `lerna --version` |  |
-| `npm --version`  |  |
-| `yarn --version` |  |
-| `node --version` |  |
-| OS |  |
+
+| Executable | Version |
+| ---: | :--- |
+| `lerna --version` | VERSION |
+| `npm --version`  | VERSION |
+| `yarn --version` | VERSION |
+| `node --version` | VERSION |
+
+| OS | Version |
+| --- | --- |
+| NAME | VERSION |
+<!-- For example:
+| macOS Sierra | 10.12.3 |
+| Windows 10 | 1607 |
+| Ubuntu | 16.10 |
+-->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+<details><summary>lerna.json</summary><p>
+<!-- browsers demand the next line be empty -->
+
+```json
+<!-- Please paste your `lerna.json` here -->
+```
+</p></details>
+
+<details><summary>lerna-debug.log</summary><p>
+<!-- browsers demand the next line be empty -->
+
+```txt
+<!-- If you have a `lerna-debug.log` available, please paste it here -->
+<!-- Otherwise, feel free to delete this <details> block -->
+```
+</p></details>
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+| `lerna --version` |  |
+| `npm --version`  |  |
+| `yarn --version` |  |
+| `node --version` |  |
+| OS |  |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.


### PR DESCRIPTION
I used the delightful "choose your own adventure" [Open Source Templates](https://www.talater.com/open-source-templates/#/) generator, with some additional tweaks.

It just helped remind me to update the docs in another PR I was about to open. :D