### PR TITLE
Re-wrap async done() in try-catch

### DIFF
--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -36,12 +36,16 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.ok(pathExists.sync(path.join(testDir, "packages", "package-preinstall", "did-preinstall")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages", "package-postinstall", "did-postinstall")));
-        assert.ok(pathExists.sync(path.join(testDir, "packages", "package-prepublish", "did-prepublish")));
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-preinstall", "did-preinstall")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-postinstall", "did-postinstall")));
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-prepublish", "did-prepublish")));
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -120,10 +124,14 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.deepEqual(gotPackage, wantPackage, "Installed the right deps");
-        assert.deepEqual(gotRimraf, wantRimraf, "Removed the right stuff");
+        try {
+          assert.deepEqual(gotPackage, wantPackage, "Installed the right deps");
+          assert.deepEqual(gotRimraf, wantRimraf, "Removed the right stuff");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -174,10 +182,14 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.deepEqual(gotPackage, wantPackage, "Installed the right deps");
-        assert.deepEqual(gotRimraf, wantRimraf, "Removed the right stuff");
+        try {
+          assert.deepEqual(gotPackage, wantPackage, "Installed the right deps");
+          assert.deepEqual(gotRimraf, wantRimraf, "Removed the right stuff");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -202,57 +214,61 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        // package-1 should not have any packages symlinked
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-2")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-3")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-4")));
-        // package-2 package dependencies are symlinked
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "packages", "package-2", "node_modules", "@test", "package-1"))),
-          normalize(path.join(testDir, "packages", "package-1")),
-          "package-1 should be symlinked to package-2"
-        );
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-3")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-4")));
-        // package-3 package dependencies are symlinked
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "@test", "package-1"))),
-          normalize(path.join(testDir, "packages", "package-1")),
-          "package-1 should be symlinked to package-3"
-        );
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "package-2"))),
-          normalize(path.join(testDir, "packages", "package-2")),
-          "package-2 should be symlinked to package-3"
-        );
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "package-4")));
-        // package-4 package dependencies are symlinked
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-1")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-2")));
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "packages", "package-4", "node_modules", "package-3"))),
-          normalize(path.join(testDir, "packages", "package-3")),
-          "package-3 should be symlinked to package-4"
-        );
-        // package binaries are symlinked
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-3", "node_modules", ".bin", "package-2"))),
-          normalize(path.join(testDir, "packages", "package-2", "cli.js")),
-          "package-2 binary should be symlinked in package-3"
-        );
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
-          normalize(path.join(testDir, "packages", "package-3", "cli1.js")),
-          "package-3 binary should be symlinked in package-4"
-        );
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
-          normalize(path.join(testDir, "packages", "package-3", "cli2.js")),
-          "package-3 binary should be symlinked in package-4"
-        );
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          // package-1 should not have any packages symlinked
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-2")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-3")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-4")));
+          // package-2 package dependencies are symlinked
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-2", "node_modules", "@test", "package-1"))),
+            normalize(path.join(testDir, "packages", "package-1")),
+            "package-1 should be symlinked to package-2"
+          );
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-3")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-4")));
+          // package-3 package dependencies are symlinked
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "@test", "package-1"))),
+            normalize(path.join(testDir, "packages", "package-1")),
+            "package-1 should be symlinked to package-3"
+          );
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "package-2"))),
+            normalize(path.join(testDir, "packages", "package-2")),
+            "package-2 should be symlinked to package-3"
+          );
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "package-4")));
+          // package-4 package dependencies are symlinked
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-1")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-2")));
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-4", "node_modules", "package-3"))),
+            normalize(path.join(testDir, "packages", "package-3")),
+            "package-3 should be symlinked to package-4"
+          );
+          // package binaries are symlinked
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-3", "node_modules", ".bin", "package-2"))),
+            normalize(path.join(testDir, "packages", "package-2", "cli.js")),
+            "package-2 binary should be symlinked in package-3"
+          );
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
+            normalize(path.join(testDir, "packages", "package-3", "cli1.js")),
+            "package-3 binary should be symlinked in package-4"
+          );
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
+            normalize(path.join(testDir, "packages", "package-3", "cli2.js")),
+            "package-3 binary should be symlinked in package-4"
+          );
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -280,10 +296,14 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.deepEqual(installed, [0,1,1], "Did all our installs");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.deepEqual(installed, [0,1,1], "Did all our installs");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -311,47 +331,51 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.deepEqual(installed, [0,0,0,1,1], "Did all our installs");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.deepEqual(installed, [0,0,0,1,1], "Did all our installs");
 
-        // package-3 package dependencies are symlinked
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "@test", "package-1"))),
-          normalize(path.join(testDir, "packages", "package-1")),
-          "package-1 should be symlinked to package-3"
-        );
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "package-2"))),
-          normalize(path.join(testDir, "packages", "package-2")),
-          "package-2 should be symlinked to package-3"
-        );
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "package-4")));
-        // package-4 package dependencies are symlinked
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-1")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-2")));
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "packages", "package-4", "node_modules", "package-3"))),
-          normalize(path.join(testDir, "packages", "package-3")),
-          "package-3 should be symlinked to package-4"
-        );
-        // package binaries are symlinked
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-3", "node_modules", ".bin", "package-2"))),
-          normalize(path.join(testDir, "packages", "package-2", "cli.js")),
-          "package-2 binary should be symlinked in package-3"
-        );
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
-          normalize(path.join(testDir, "packages", "package-3", "cli1.js")),
-          "package-3 binary should be symlinked in package-4"
-        );
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
-          normalize(path.join(testDir, "packages", "package-3", "cli2.js")),
-          "package-3 binary should be symlinked in package-4"
-        );
+          // package-3 package dependencies are symlinked
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "@test", "package-1"))),
+            normalize(path.join(testDir, "packages", "package-1")),
+            "package-1 should be symlinked to package-3"
+          );
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "package-2"))),
+            normalize(path.join(testDir, "packages", "package-2")),
+            "package-2 should be symlinked to package-3"
+          );
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-3", "node_modules", "package-4")));
+          // package-4 package dependencies are symlinked
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-1")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-2")));
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-4", "node_modules", "package-3"))),
+            normalize(path.join(testDir, "packages", "package-3")),
+            "package-3 should be symlinked to package-4"
+          );
+          // package binaries are symlinked
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-3", "node_modules", ".bin", "package-2"))),
+            normalize(path.join(testDir, "packages", "package-2", "cli.js")),
+            "package-2 binary should be symlinked in package-3"
+          );
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
+            normalize(path.join(testDir, "packages", "package-3", "cli1.js")),
+            "package-3 binary should be symlinked in package-4"
+          );
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
+            normalize(path.join(testDir, "packages", "package-3", "cli2.js")),
+            "package-3 binary should be symlinked in package-4"
+          );
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -393,61 +417,65 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.deepEqual(want, got, "Installed everywhere");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.deepEqual(want, got, "Installed everywhere");
 
-        // Make sure the `prepublish` script got run (index.js got created).
-        assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
-        // package-1 should not have any packages symlinked
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-2")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-3")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-4")));
-        // package-2 package dependencies are symlinked
-        assert.equal(
-          path.resolve(resolveSymlink(path.join(testDir, "packages", "package-2", "node_modules", "@test", "package-1"))),
-          path.resolve(path.join(testDir, "packages", "package-1")),
-          "package-1 should be symlinked to package-2"
-        );
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-3")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-4")));
-        // package-3 package dependencies are symlinked
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "package-3", "node_modules", "@test", "package-1"))),
-          normalize(path.join(testDir, "packages", "package-1")),
-          "package-1 should be symlinked to package-3"
-        );
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "package-3", "node_modules", "package-2"))),
-          normalize(path.join(testDir, "packages", "package-2")),
-          "package-2 should be symlinked to package-3"
-        );
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "package-3", "node_modules", "package-4")));
-        // package-4 package dependencies are symlinked
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-1")));
-        assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-2")));
-        assert.equal(
-          normalize(resolveSymlink(path.join(testDir, "packages", "package-4", "node_modules", "package-3"))),
-          normalize(path.join(testDir, "package-3")),
-          "package-3 should be symlinked to package-4"
-        );
-        // package binaries are symlinked
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "package-3", "node_modules", ".bin", "package-2"))),
-          normalize(path.join(testDir, "packages", "package-2", "cli.js")),
-          "package-2 binary should be symlinked in package-3"
-        );
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
-          normalize(path.join(testDir, "package-3", "cli1.js")),
-          "package-3 binary should be symlinked in package-4"
-        );
-        assert.equal(
-          normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
-          normalize(path.join(testDir, "package-3", "cli2.js")),
-          "package-3 binary should be symlinked in package-4"
-        );
+          // Make sure the `prepublish` script got run (index.js got created).
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
+          // package-1 should not have any packages symlinked
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-2")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-3")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-1", "node_modules", "package-4")));
+          // package-2 package dependencies are symlinked
+          assert.equal(
+            path.resolve(resolveSymlink(path.join(testDir, "packages", "package-2", "node_modules", "@test", "package-1"))),
+            path.resolve(path.join(testDir, "packages", "package-1")),
+            "package-1 should be symlinked to package-2"
+          );
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-3")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-2", "node_modules", "package-4")));
+          // package-3 package dependencies are symlinked
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "package-3", "node_modules", "@test", "package-1"))),
+            normalize(path.join(testDir, "packages", "package-1")),
+            "package-1 should be symlinked to package-3"
+          );
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "package-3", "node_modules", "package-2"))),
+            normalize(path.join(testDir, "packages", "package-2")),
+            "package-2 should be symlinked to package-3"
+          );
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "package-3", "node_modules", "package-4")));
+          // package-4 package dependencies are symlinked
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-1")));
+          assert.throws(() => fs.readlinkSync(path.join(testDir, "packages", "package-4", "node_modules", "package-2")));
+          assert.equal(
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-4", "node_modules", "package-3"))),
+            normalize(path.join(testDir, "package-3")),
+            "package-3 should be symlinked to package-4"
+          );
+          // package binaries are symlinked
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "package-3", "node_modules", ".bin", "package-2"))),
+            normalize(path.join(testDir, "packages", "package-2", "cli.js")),
+            "package-2 binary should be symlinked in package-3"
+          );
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli1"))),
+            normalize(path.join(testDir, "package-3", "cli1.js")),
+            "package-3 binary should be symlinked in package-4"
+          );
+          assert.equal(
+            normalize(FileSystemUtilities.isSymlink(path.join(testDir, "packages", "package-4", "node_modules", ".bin", "package3cli2"))),
+            normalize(path.join(testDir, "package-3", "cli2.js")),
+            "package-3 binary should be symlinked in package-4"
+          );
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -468,9 +496,13 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -493,13 +525,17 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.deepEqual(installed, [0,1,1], "Did all our installs");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.deepEqual(installed, [0,1,1], "Did all our installs");
 
-        // Make sure the `prepublish` script got run (index.js got created)
-        assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
+          // Make sure the `prepublish` script got run (index.js got created)
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -522,13 +558,17 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.deepEqual(installed, [0,1,1], "Did all our installs");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.deepEqual(installed, [0,1,1], "Did all our installs");
 
-        // Make sure the `prepublish` script got run (index.js got created), even though we --ignored package-1
-        assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
+          // Make sure the `prepublish` script got run (index.js got created), even though we --ignored package-1
+          assert.ok(pathExists.sync(path.join(testDir, "packages", "package-1", "index.js")));
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -570,9 +610,13 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -599,10 +643,14 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.ok(!installed, "The external dependency was not installed");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.ok(!installed, "The external dependency was not installed");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -633,15 +681,19 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.deepEqual(got, {
-          dependencies: {
-            "external-1": "^1.0.0",
-            "external-2": "^1.0.0",
-          }
-        });
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.deepEqual(got, {
+            dependencies: {
+              "external-1": "^1.0.0",
+              "external-2": "^1.0.0",
+            }
+          });
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -673,11 +725,15 @@ describe("BootstrapCommand", () => {
       bootstrapCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
-        assert.ok(!pathExists.sync(path.join(testDir, "packages/package-1/node_modules/package-2")), "The linkable peer dependency should not be installed");
-        assert.ok(!installed, "The external peer dependency should not be installed");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")), "lerna-debug.log should not exist");
+          assert.ok(!pathExists.sync(path.join(testDir, "packages/package-1/node_modules/package-2")), "The linkable peer dependency should not be installed");
+          assert.ok(!installed, "The external peer dependency should not be installed");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -62,8 +62,13 @@ describe("ExecCommand", () => {
 
       execCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
-        assert.equal(calls, 2);
-        done();
+
+        try {
+          assert.equal(calls, 2);
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -92,8 +97,13 @@ describe("ExecCommand", () => {
 
       execCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
-        assert.equal(calls, 2);
-        done();
+
+        try {
+          assert.equal(calls, 2);
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -117,8 +127,13 @@ describe("ExecCommand", () => {
 
         execCommand.runCommand(exitWithCode(0, (err) => {
           if (err) return done.fail(err);
-          assert.deepEqual(ranInPackages, ["package-1"]);
-          done();
+
+          try {
+            assert.deepEqual(ranInPackages, ["package-1"]);
+            done();
+          } catch (ex) {
+            done.fail(ex);
+          }
         }));
       });
     });

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -45,15 +45,19 @@ describe("ImportCommand", () => {
       importCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
 
-        const lastCommit = ChildProcessUtilities.execSync("git log -1 --format=\"%s\"", { cwd: testDir });
-        assert.equal(lastCommit, "Init external commit");
+          const lastCommit = ChildProcessUtilities.execSync("git log -1 --format=\"%s\"", { cwd: testDir });
+          assert.equal(lastCommit, "Init external commit");
 
-        const packageJson = path.join(testDir, "packages", path.basename(externalDir), "package.json");
-        assert.ok(pathExists.sync(packageJson));
+          const packageJson = path.join(testDir, "packages", path.basename(externalDir), "package.json");
+          assert.ok(pathExists.sync(packageJson));
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 
@@ -75,13 +79,17 @@ describe("ImportCommand", () => {
       importCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        const lastCommit = ChildProcessUtilities.execSync("git log -1 --format=\"%s\"", { cwd: testDir });
-        assert.equal(lastCommit, "Moved old-file to new-file");
+        try {
+          const lastCommit = ChildProcessUtilities.execSync("git log -1 --format=\"%s\"", { cwd: testDir });
+          assert.equal(lastCommit, "Moved old-file to new-file");
 
-        const newFilePath = path.join(testDir, "packages", path.basename(externalDir), "new-file");
-        assert.ok(pathExists.sync(newFilePath));
+          const newFilePath = path.join(testDir, "packages", path.basename(externalDir), "new-file");
+          assert.ok(pathExists.sync(newFilePath));
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 

--- a/test/InitCommand.js
+++ b/test/InitCommand.js
@@ -27,29 +27,34 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        expect(fs.readdirSync(testDir)).toEqual([
-          ".git",
-          "lerna.json",
-          "package.json",
-        ]);
+        try {
+          expect(code).toBe(0);
 
-        const lernaJson = require(path.join(testDir, "lerna.json"));
-        expect(lernaJson).toEqual({
-          lerna: instance.lernaVersion,
-          packages: ["packages/*"],
-          version: "0.0.0",
-        });
+          expect(fs.readdirSync(testDir)).toEqual([
+            ".git",
+            "lerna.json",
+            "package.json",
+          ]);
 
-        const packageJson = require(path.join(testDir, "package.json"));
-        expect(packageJson).toEqual({
-          devDependencies: {
+          const lernaJson = require(path.join(testDir, "lerna.json"));
+          expect(lernaJson).toEqual({
             lerna: instance.lernaVersion,
-          },
-        });
+            packages: ["packages/*"],
+            version: "0.0.0",
+          });
 
-        done();
+          const packageJson = require(path.join(testDir, "package.json"));
+          expect(packageJson).toEqual({
+            devDependencies: {
+              lerna: instance.lernaVersion,
+            },
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
 
@@ -60,18 +65,23 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        expect(fs.readdirSync(testDir)).toEqual([
-          ".git",
-          "lerna.json",
-          "package.json",
-        ]);
+        try {
+          expect(code).toBe(0);
 
-        const lernaJson = require(path.join(testDir, "lerna.json"));
-        expect(lernaJson.version).toBe("independent");
+          expect(fs.readdirSync(testDir)).toEqual([
+            ".git",
+            "lerna.json",
+            "package.json",
+          ]);
 
-        done();
+          const lernaJson = require(path.join(testDir, "lerna.json"));
+          expect(lernaJson.version).toBe("independent");
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });
@@ -93,28 +103,33 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        expect(fs.readdirSync(testDir)).toEqual([
-          "lerna.json",
-          "package.json",
-        ]);
+        try {
+          expect(code).toBe(0);
 
-        const lernaJson = require(path.join(testDir, "lerna.json"));
-        expect(lernaJson).toEqual({
-          lerna: instance.lernaVersion,
-          packages: ["packages/*"],
-          version: "0.0.0",
-        });
+          expect(fs.readdirSync(testDir)).toEqual([
+            "lerna.json",
+            "package.json",
+          ]);
 
-        const packageJson = require(path.join(testDir, "package.json"));
-        expect(packageJson).toEqual({
-          devDependencies: {
+          const lernaJson = require(path.join(testDir, "lerna.json"));
+          expect(lernaJson).toEqual({
             lerna: instance.lernaVersion,
-          },
-        });
+            packages: ["packages/*"],
+            version: "0.0.0",
+          });
 
-        done();
+          const packageJson = require(path.join(testDir, "package.json"));
+          expect(packageJson).toEqual({
+            devDependencies: {
+              lerna: instance.lernaVersion,
+            },
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });
@@ -139,19 +154,24 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        const packageJson = require(packageJsonLocation);
-        expect(packageJson).toEqual({
-          name: "repo-root",
-          devDependencies: {
-            alpha: "first",
-            lerna: instance.lernaVersion,
-            omega: "last",
-          },
-        });
+        try {
+          expect(code).toBe(0);
 
-        done();
+          const packageJson = require(packageJsonLocation);
+          expect(packageJson).toEqual({
+            name: "repo-root",
+            devDependencies: {
+              alpha: "first",
+              lerna: instance.lernaVersion,
+              omega: "last",
+            },
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
 
@@ -171,21 +191,26 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        const packageJson = require(packageJsonLocation);
-        expect(packageJson).toEqual({
-          name: "repo-root",
-          dependencies: {
-            alpha: "first",
-            omega: "last",
-          },
-          devDependencies: {
-            lerna: instance.lernaVersion,
-          },
-        });
+        try {
+          expect(code).toBe(0);
 
-        done();
+          const packageJson = require(packageJsonLocation);
+          expect(packageJson).toEqual({
+            name: "repo-root",
+            dependencies: {
+              alpha: "first",
+              omega: "last",
+            },
+            devDependencies: {
+              lerna: instance.lernaVersion,
+            },
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
 
@@ -203,19 +228,24 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        const packageJson = require(packageJsonLocation);
-        expect(packageJson).toEqual({
-          name: "repo-root",
-          dependencies: {
-            alpha: "first",
-            lerna: instance.lernaVersion,
-            omega: "last",
-          },
-        });
+        try {
+          expect(code).toBe(0);
 
-        done();
+          const packageJson = require(packageJsonLocation);
+          expect(packageJson).toEqual({
+            name: "repo-root",
+            dependencies: {
+              alpha: "first",
+              lerna: instance.lernaVersion,
+              omega: "last",
+            },
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });
@@ -239,17 +269,22 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        const lernaJson = require(lernaJsonLocation);
-        expect(lernaJson).toEqual({
-          lerna: instance.lernaVersion,
-          packages: ["foo/*"],
-          version: "1.2.3",
-          hoist: true,
-        });
+        try {
+          expect(code).toBe(0);
 
-        done();
+          const lernaJson = require(lernaJsonLocation);
+          expect(lernaJson).toEqual({
+            lerna: instance.lernaVersion,
+            packages: ["foo/*"],
+            version: "1.2.3",
+            hoist: true,
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
 
@@ -267,17 +302,22 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        const lernaJson = require(lernaJsonLocation);
-        expect(lernaJson).toEqual({
-          lerna: instance.lernaVersion,
-          packages: ["bar/*"],
-          version: "independent",
-          hoist: true,
-        });
+        try {
+          expect(code).toBe(0);
 
-        done();
+          const lernaJson = require(lernaJsonLocation);
+          expect(lernaJson).toEqual({
+            lerna: instance.lernaVersion,
+            packages: ["bar/*"],
+            version: "independent",
+            hoist: true,
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });
@@ -294,15 +334,20 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        expect(fs.readdirSync(testDir)).toEqual([
-          ".git",
-          "lerna.json",
-          "package.json",
-        ]);
+        try {
+          expect(code).toBe(0);
 
-        done();
+          expect(fs.readdirSync(testDir)).toEqual([
+            ".git",
+            "lerna.json",
+            "package.json",
+          ]);
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
 
@@ -318,11 +363,16 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        expect(instance.logger.info).toBeCalledWith("Removing old VERSION file.");
+        try {
+          expect(code).toBe(0);
 
-        done();
+          expect(instance.logger.info).toBeCalledWith("Removing old VERSION file.");
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
 
@@ -331,12 +381,17 @@ describe("InitCommand", () => {
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
-        expect(code).toBe(0);
 
-        const lernaJson = require(path.join(testDir, "lerna.json"));
-        expect(lernaJson).toHaveProperty("version", "1.2.3");
+        try {
+          expect(code).toBe(0);
 
-        done();
+          const lernaJson = require(path.join(testDir, "lerna.json"));
+          expect(lernaJson).toHaveProperty("version", "1.2.3");
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -89,21 +89,25 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -184,18 +188,22 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "2.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "2.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -264,23 +272,27 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.0\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.0\"\n}\n");
 
-        // The following wouldn't be the actual results of a canary release
-        // because `git checkout --` would have removed the file changes.
-        // However, this is what would've been published to npm so it's
-        // useful to test.
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.0-alpha.81e3b443");
+          // The following wouldn't be the actual results of a canary release
+          // because `git checkout --` would have removed the file changes.
+          // However, this is what would've been published to npm so it's
+          // useful to test.
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.0-alpha.81e3b443");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -350,22 +362,26 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
 
-        // The following wouldn't be the actual results of a canary release
-        // because `git checkout --` would have removed the file changes.
-        // However, this is what would've been published to npm so it's
-        // useful to test.
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "2.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "3.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "4.0.0-alpha.81e3b443");
+          // The following wouldn't be the actual results of a canary release
+          // because `git checkout --` would have removed the file changes.
+          // However, this is what would've been published to npm so it's
+          // useful to test.
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "2.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "3.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "4.0.0-alpha.81e3b443");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^2.0.0-alpha.81e3b443");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^2.0.0-alpha.81e3b443");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -428,19 +444,23 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -490,21 +510,25 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -545,19 +569,23 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -619,10 +647,7 @@ describe("PublishCommand", () => {
         ]],
       ]);
 
-      publishCommand.runCommand(exitWithCode(0, (err) => {
-        if (err) return done.fail(err);
-        done();
-      }));
+      publishCommand.runCommand(exitWithCode(0, done));
     });
   });
 
@@ -701,21 +726,25 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -819,21 +848,25 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -979,21 +1012,25 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -1071,24 +1108,28 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "1.0.1");
-        // remains semver because it is a diverged version,
-        // (different from the release version) and is specified
-        // as semver in the package-4's package.json
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "1.0.1");
+          // remains semver because it is a diverged version,
+          // (different from the release version) and is specified
+          // as semver in the package-4's package.json
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -1165,25 +1206,29 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")),
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")),
           "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\",\n  \"exact\": true\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "1.0.1");
-        // remains semver because it is a diverged version,
-        // (different from the release version) and is specified
-        // as semver in the package-4's package.json
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "1.0.1");
+          // remains semver because it is a diverged version,
+          // (different from the release version) and is specified
+          // as semver in the package-4's package.json
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -1257,20 +1302,24 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.1.0\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.1.0\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "lerna.json")).version, "1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "lerna.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -1346,19 +1395,23 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"independent\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"independent\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "2.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "3.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "4.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "2.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "3.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "4.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^2.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^2.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -1438,21 +1491,25 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -1532,21 +1589,25 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
-        assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+          assert.equal(normalizeNewline(fs.readFileSync(path.join(testDir, "lerna.json"), "utf-8")), "{\n  \"lerna\": \"__TEST_VERSION__\",\n  \"version\": \"1.0.1\"\n}\n");
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).version, "1.0.1");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-5/package.json")).dependencies["package-1"], "^1.0.1");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -1628,18 +1689,22 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "2.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "2.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });
@@ -1732,18 +1797,22 @@ describe("PublishCommand", () => {
       publishCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
 
-        assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "lerna-debug.log")));
 
-        assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "2.0.0");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-1/package.json")).version, "1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).version, "1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).version, "2.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).version, "1.1.0");
 
-        assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
-        assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
-        assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
+          assert.equal(require(path.join(testDir, "packages/package-2/package.json")).dependencies["package-1"], "^1.0.1");
+          assert.equal(require(path.join(testDir, "packages/package-3/package.json")).devDependencies["package-2"], "^1.1.0");
+          assert.equal(require(path.join(testDir, "packages/package-4/package.json")).dependencies["package-1"], "^0.0.0");
 
-        done();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -81,8 +81,13 @@ describe("RunCommand", () => {
 
         runCommand.runCommand(exitWithCode(0, (err) => {
           if (err) return done.fail(err);
-          assert.equal(4, calls);
-          done();
+
+          try {
+            assert.equal(4, calls);
+            done();
+          } catch (ex) {
+            done.fail(ex);
+          }
         }));
       });
     });
@@ -107,8 +112,13 @@ describe("RunCommand", () => {
 
         runCommand.runCommand(exitWithCode(0, (err) => {
           if (err) return done.fail(err);
-          assert.deepEqual(ranInPackages, ["package-1"]);
-          done();
+
+          try {
+            assert.deepEqual(ranInPackages, ["package-1"]);
+            done();
+          } catch (ex) {
+            done.fail(ex);
+          }
         }));
       });
     });
@@ -132,9 +142,14 @@ describe("RunCommand", () => {
       let haveExited = false;
       runCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
-        assert.equal(lastInfo, "Waiting for 2 child processes to exit. CTRL-C to exit immediately.");
-        haveExited = true;
-        done();
+
+        try {
+          assert.equal(lastInfo, "Waiting for 2 child processes to exit. CTRL-C to exit immediately.");
+          haveExited = true;
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
 
       assert.equal(haveExited, false);
@@ -167,9 +182,14 @@ describe("RunCommand", () => {
 
       runCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
-        const expected = ["package-1", "package-2"];
-        assert.deepEqual(ranInPackages.sort(), expected.sort());
-        done();
+
+        try {
+          const expected = ["package-1", "package-2"];
+          assert.deepEqual(ranInPackages.sort(), expected.sort());
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
   });


### PR DESCRIPTION


## Description
Due to https://github.com/facebook/jest/issues/2059, turns out we need
those try/catch blocks I tried to remove in the previous PR.

## Motivation and Context
Async test cases (calling `done()`, basically) will cause timeout errors when one of the preceding assertions throws an error. I misread the docs that implied this wasn't the case.

This partially reverts #682

## How Has This Been Tested?
Multiple AppVeyor failures due to jasmine timeouts today have provided evidence that this is needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
