### PR TITLE
Make tmpdir resolution more robust in tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,6 @@ before_test:
   - git config --global user.name "Tester McPerson"
 
 test_script:
-  - yarn run ci -- --runInBand
+  - yarn run ci
 
 build: off

--- a/package.json
+++ b/package.json
@@ -67,14 +67,14 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
+    "cpr": "^2.0.2",
     "eslint": "^2.3.0",
     "eslint-config-babel": "^1.0.1",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flow-vars": "^0.5.0",
     "jest": "^19.0.2",
     "normalize-newline": "^2.1.0",
-    "pify": "^2.3.0",
-    "recursive-copy": "^2.0.6"
+    "pify": "^2.3.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/test/CleanCommand.js
+++ b/test/CleanCommand.js
@@ -89,8 +89,13 @@ describe("CleanCommand", () => {
 
         cleanCommand.runCommand(exitWithCode(0, (err) => {
           if (err) return done.fail(err);
-          assert.deepEqual(ranInPackages, ["package-1", "package-2"]);
-          done();
+
+          try {
+            assert.deepEqual(ranInPackages, ["package-1", "package-2"]);
+            done();
+          } catch (ex) {
+            done.fail(ex);
+          }
         }));
       });
     });
@@ -126,9 +131,14 @@ describe("CleanCommand", () => {
 
       cleanCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
-        const expected = ["package-1", "package-2"].map((pkg) => path.join(testDir, "packages", pkg, "node_modules"));
-        assert.deepEqual(ranInPackages.sort(), expected.sort());
-        done();
+
+        try {
+          const expected = ["package-1", "package-2"].map((pkg) => path.join(testDir, "packages", pkg, "node_modules"));
+          assert.deepEqual(ranInPackages.sort(), expected.sort());
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       }));
     });
 

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -36,8 +36,13 @@ describe("FileSystemUtilities", () => {
       const dirPath = path.join(testDir, "mkdirp/test");
       FileSystemUtilities.mkdirp(dirPath, (err) => {
         if (err) return done.fail(err);
-        assert.ok(pathExists.sync(dirPath));
-        done();
+
+        try {
+          assert.ok(pathExists.sync(dirPath));
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });
@@ -64,9 +69,14 @@ describe("FileSystemUtilities", () => {
       const filePath = path.join(testDir, "writeFile-test");
       FileSystemUtilities.writeFile(filePath, "contents", (err) => {
         if (err) return done.fail(err);
-        assert.ok(pathExists.sync(filePath));
-        assert.equal(fs.readFileSync(filePath).toString(), "contents\n");
-        done();
+
+        try {
+          assert.ok(pathExists.sync(filePath));
+          assert.equal(fs.readFileSync(filePath).toString(), "contents\n");
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });
@@ -93,8 +103,13 @@ describe("FileSystemUtilities", () => {
       mkdirp.sync(dirPath);
       FileSystemUtilities.rimraf(dirPath, (err) => {
         if (err) return done.fail(err);
-        assert.ok(!pathExists.sync(dirPath));
-        done();
+
+        try {
+          assert.ok(!pathExists.sync(dirPath));
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });
@@ -106,10 +121,15 @@ describe("FileSystemUtilities", () => {
       fs.writeFileSync(srcPath, "contents");
       FileSystemUtilities.rename(srcPath, dstPath, (err) => {
         if (err) return done.fail(err);
-        assert.ok(pathExists.sync(dstPath));
-        assert.ok(!pathExists.sync(srcPath));
-        assert.equal(fs.readFileSync(dstPath).toString(), "contents");
-        done();
+
+        try {
+          assert.ok(pathExists.sync(dstPath));
+          assert.ok(!pathExists.sync(srcPath));
+          assert.equal(fs.readFileSync(dstPath).toString(), "contents");
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
       });
     });
   });

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -7,21 +7,18 @@ import path from "path";
 import {
   fixtureNamer,
   getTempDir,
-  mkdirpAsync,
   rimrafAsync,
 } from "./helpers/fixtureUtils";
 
 import FileSystemUtilities from "../src/FileSystemUtilities";
 
-const pTmpDir = getTempDir();
-const getFixtureName = fixtureNamer();
-
 describe("FileSystemUtilities", () => {
+  const getFixtureName = fixtureNamer();
+
   let testDir;
 
-  beforeEach(() => pTmpDir.then((tmpDir) => {
-    testDir = path.resolve(tmpDir, getFixtureName("FileSystemUtilities"));
-    return mkdirpAsync(testDir);
+  beforeEach(() => getTempDir(getFixtureName("FileSystemUtilities")).then((dir) => {
+    testDir = dir;
   }));
 
   afterEach(() => rimrafAsync(testDir));

--- a/test/helpers/fixtureUtils.js
+++ b/test/helpers/fixtureUtils.js
@@ -8,11 +8,6 @@ import mkdirp from "mkdirp";
 import pify from "pify";
 import rimraf from "rimraf";
 
-const CURRENT_SHA = child.execSync("git rev-parse --short HEAD", {
-  cwd: __dirname,
-  encoding: "utf8",
-}).trim();
-
 const execAsync = pify(child.exec);
 const realpathAsync = pify(fs.realpath);
 
@@ -25,20 +20,16 @@ const { unlink, chmod, stat, lstat, rmdir, readdir } = fs;
 export const mkdirpAsync = (fp) => _mkdirpAsync(fp, { fs });
 export const rimrafAsync = (fp) => _rimrafAsync(fp, { unlink, chmod, stat, lstat, rmdir, readdir });
 
-export function getTempDir(suffix) {
-  // e.g., "lerna-12345-deadbeef"
+export function getTempDir(fixtureName) {
+  // e.g., "lerna-1490053388515-663678-BootstrapCommand_01_basic"
   const prefix = [
     "lerna",
-    process.pid,
-    CURRENT_SHA,
+    Date.now(),
+    Math.floor(Math.random() * 1e6),
+    fixtureName,
   ];
 
-  if (suffix) {
-    // e.g., "lerna-12345-deadbeef-external"
-    prefix.push(suffix);
-  }
-
-  const tmpDir = path.join(os.tmpdir() || "/tmp", prefix.join("-"));
+  const tmpDir = path.join(os.tmpdir(), prefix.join("-"));
 
   // We realpath because OS X symlinks /var -> /private/var
   // and require() also calls realpath on its argument.

--- a/test/helpers/fixtureUtils.js
+++ b/test/helpers/fixtureUtils.js
@@ -7,16 +7,19 @@ import { padStart } from "lodash";
 import mkdirp from "mkdirp";
 import pify from "pify";
 import rimraf from "rimraf";
+import cpr from "cpr";
 
 const execAsync = pify(child.exec);
 const realpathAsync = pify(fs.realpath);
 
+const _cpr = pify(cpr);
 const _mkdirpAsync = pify(mkdirp);
 const _rimrafAsync = pify(rimraf);
 
 // graceful-fs overrides for rimraf
 const { unlink, chmod, stat, lstat, rmdir, readdir } = fs;
 
+export const cp = (from, to) => _cpr(from, to, { overwrite: true });
 export const mkdirpAsync = (fp) => _mkdirpAsync(fp, { fs });
 export const rimrafAsync = (fp) => _rimrafAsync(fp, { unlink, chmod, stat, lstat, rmdir, readdir });
 

--- a/test/helpers/initExternalFixture.js
+++ b/test/helpers/initExternalFixture.js
@@ -7,7 +7,6 @@ import {
   removeAll,
 } from "./fixtureUtils";
 
-const pTmpDir = getTempDir("external");
 const getFixtureName = fixtureNamer();
 
 const createdDirectories = [];
@@ -17,9 +16,7 @@ export default function initExternalFixture(fixturePath) {
   const fixtureDir = path.resolve(__dirname, `../fixtures/${fixturePath}`);
   const fixtureName = getFixtureName(fixturePath);
 
-  return pTmpDir.then((tmpDir) => {
-    const testDir = path.join(tmpDir, fixtureName);
-
+  return getTempDir(fixtureName).then((testDir) => {
     createdDirectories.push(testDir);
 
     return cp(fixtureDir, testDir)

--- a/test/helpers/initExternalFixture.js
+++ b/test/helpers/initExternalFixture.js
@@ -1,6 +1,6 @@
 import path from "path";
-import cp from "recursive-copy";
 import {
+  cp,
   fixtureNamer,
   getTempDir,
   gitInit,

--- a/test/helpers/initFixture.js
+++ b/test/helpers/initFixture.js
@@ -7,7 +7,6 @@ import {
   removeAll,
 } from "./fixtureUtils";
 
-const pTmpDir = getTempDir();
 const getFixtureName = fixtureNamer();
 
 const createdDirectories = [];
@@ -23,9 +22,7 @@ export default function initFixture(fixturePath) {
   const fixtureDir = path.resolve(__dirname, `../fixtures/${fixturePath}`);
   const fixtureName = getFixtureName(fixturePath);
 
-  return pTmpDir.then((tmpDir) => {
-    const testDir = path.join(tmpDir, fixtureName);
-
+  return getTempDir(fixtureName).then((testDir) => {
     createdDirectories.push(testDir);
 
     return cp(fixtureDir, testDir)

--- a/test/helpers/initFixture.js
+++ b/test/helpers/initFixture.js
@@ -1,6 +1,6 @@
 import path from "path";
-import cp from "recursive-copy";
 import {
+  cp,
   fixtureNamer,
   getTempDir,
   gitInit,

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,10 +122,6 @@ arr-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
 
-array-differ@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
-
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
@@ -155,10 +151,6 @@ array-unique@^0.2.1:
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-
-asap@~2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
 
 asn1@~0.2.3:
   version "0.2.3"
@@ -1093,6 +1085,15 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cpr@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/cpr/-/cpr-2.0.2.tgz#9e44be91101f644a3e1f8c908712b70cdd547056"
+  dependencies:
+    graceful-fs "^4.1.5"
+    minimist "^1.2.0"
+    mkdirp "~0.5.1"
+    rimraf "^2.5.4"
+
 cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -1187,7 +1188,7 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-del@^2.0.2, del@^2.2.0:
+del@^2.0.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
   dependencies:
@@ -1236,11 +1237,7 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-emitter-mixin@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/emitter-mixin/-/emitter-mixin-0.0.3.tgz#5948cb286f2e48edc3b251a7cfc1f7883396d65c"
-
-"errno@>=0.1.1 <0.2.0-0", errno@^0.1.2:
+"errno@>=0.1.1 <0.2.0-0":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -1726,7 +1723,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.5, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2404,10 +2401,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-junk@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
-
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
@@ -2523,15 +2516,6 @@ makeerror@1.0.x:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-
-maximatch@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/maximatch/-/maximatch-0.1.0.tgz#86cd8d6b04c9f307c05a6b9419906d0360fb13a2"
-  dependencies:
-    array-differ "^1.0.0"
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    minimatch "^3.0.0"
 
 meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
@@ -2889,12 +2873,6 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-promise@^7.0.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
-  dependencies:
-    asap "~2.0.3"
-
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -2992,21 +2970,6 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
-
-recursive-copy@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/recursive-copy/-/recursive-copy-2.0.6.tgz#d590f9eb5f165b96a1b80bc8f9cbcb5c6f9c89e9"
-  dependencies:
-    del "^2.2.0"
-    emitter-mixin "0.0.3"
-    errno "^0.1.2"
-    graceful-fs "^4.1.4"
-    junk "^1.0.1"
-    maximatch "^0.1.0"
-    mkdirp "^0.5.1"
-    pify "^2.3.0"
-    promise "^7.0.1"
-    slash "^1.0.0"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -3144,7 +3107,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Switching the crash-prone `lerna-<process.pid>-<SHA>/<fixtureDir>_<index>_<fixtureName>` temp directory naming scheme to a more robust `lerna-<Date.now()>-<random 6 digits>-<fixtureDir>_<index>_<fixtureName>` directory-per-test.
2. Removes overcomplicated `recursive-copy` dev dependency in favor of simpler `cpr`.
3. Runs windows tests on AppVeyor the same way as Travis, removing the `--runInBand` option.

## Motivation and Context
Several flapping tests in both AppVeyor and Travis.

## How Has This Been Tested?
Merciless test repetitions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
