### PR TITLE
Fix cli compat check

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -126,7 +126,7 @@ export default class Command {
 
     if (
       process.env.NODE_ENV !== "lerna-test" &&
-      !this.repository.isCompatibleLerna(this.lernaVersion, this.getOptions())
+      !this.repository.isCompatibleLerna(this.lernaVersion)
     ) {
       this.logger.warn(
         `Lerna major version mismatch: The current version of lerna is ${this.lernaVersion}, ` +

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -90,9 +90,8 @@ export default class Repository {
     return path.join(this.rootPath, "VERSION");
   }
 
-  isCompatibleLerna(cliVersion, { exact }) {
-    const needVersion = exact ? cliVersion : `^${semver.major(cliVersion)}`;
-    return semver.satisfies(this.initVersion, needVersion);
+  isCompatibleLerna(cliVersion) {
+    return semver.satisfies(cliVersion, `^${this.initVersion}`);
   }
 
   isIndependent() {

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import FileSystemUtilities from "../FileSystemUtilities";
 import GitUtilities from "../GitUtilities";
 import Command from "../Command";
@@ -14,6 +15,8 @@ export default class InitCommand extends Command {
       GitUtilities.init();
     }
 
+    this.exact = this.getOptions().exact;
+
     callback(null, true);
   }
 
@@ -21,7 +24,7 @@ export default class InitCommand extends Command {
     this.ensurePackageJSON();
     this.ensureLernaJson();
     this.ensureNoVersionFile();
-    this.logger.success("Successfully created Lerna files");
+    this.logger.success("Successfully initialized Lerna files");
     callback(null, true);
   }
 
@@ -45,7 +48,7 @@ export default class InitCommand extends Command {
       targetDependencies = packageJson.devDependencies;
     }
 
-    const dependencyVersion = this.getOptions().exact
+    const dependencyVersion = this.exact
       ? this.lernaVersion
       : `^${this.lernaVersion}`;
 
@@ -88,6 +91,12 @@ export default class InitCommand extends Command {
       packages: packageConfigs,
       version: version
     });
+
+    if (this.exact) {
+      // ensure --exact is preserved for future init commands
+      const configKey = lernaJson.commands ? "commands" : "command";
+      _.set(lernaJson, `${configKey}.init.exact`, true);
+    }
 
     FileSystemUtilities.writeFileSync(lernaJsonLocation, JSON.stringify(lernaJson, null, 2));
   }

--- a/test/Repository.js
+++ b/test/Repository.js
@@ -197,40 +197,19 @@ describe("Repository", () => {
   });
 
   describe("isCompatibleLerna()", () => {
-    it("returns true when lerna major version matches initVersion", () => {
+    it("returns true when lerna CLI version satisfies initVersion range", () => {
       const repo = new Repository();
-      const opts = {};
-      expect(repo.isCompatibleLerna("500.250.0", opts)).toBe(true);
+      expect(repo.isCompatibleLerna("500.250.0")).toBe(true);
     });
 
     it("returns true when lerna version is identical to initVersion", () => {
       const repo = new Repository();
-      const opts = {};
-      expect(repo.isCompatibleLerna("500.0.0", opts)).toBe(true);
+      expect(repo.isCompatibleLerna("500.0.0")).toBe(true);
     });
 
-    it("returns false when lerna major version does not match initVersion", () => {
+    it("returns false when lerna CLI version does not satisfy initVersion range", () => {
       const repo = new Repository();
-      const opts = {};
-      expect(repo.isCompatibleLerna("1000.0.0", opts)).toBe(false);
-    });
-
-    describe("with --exact", () => {
-      it("returns true when lerna version is identical to initVersion", () => {
-        const repo = new Repository();
-        const opts = {
-          exact: true,
-        };
-        expect(repo.isCompatibleLerna("500.0.0", opts)).toBe(true);
-      });
-
-      it("returns false when lerna version does not exactly match initVersion", () => {
-        const repo = new Repository();
-        const opts = {
-          exact: true,
-        };
-        expect(repo.isCompatibleLerna("1000.0.0", opts)).toBe(false);
-      });
+      expect(repo.isCompatibleLerna("1000.0.0")).toBe(false);
     });
   });
 

--- a/test/fixtures/InitCommand/updates/lerna.json
+++ b/test/fixtures/InitCommand/updates/lerna.json
@@ -1,4 +1,9 @@
 {
   "lerna": "__TEST_VERSION__",
+  "commands": {
+    "bootstrap": {
+      "hoist": true
+    }
+  },
   "version": "1.0.0"
 }


### PR DESCRIPTION
## Description
We should always allow semver-compatible CLI versions to operate on a given lerna monorepo, even pre-releases.

Currently, this will fail:
```
$ npm i -g lerna@canary
$ npm i -D lerna@canary
$ lerna init
$ lerna diff
# ^ fails due to validation error
```

## Motivation and Context
The canary releases I've been doing recently were pointed out as failing with the latest changes from #694. Turns out I reversed the order of arguments to `semver.satisfies()` in that PR, and inadvertently conflated `--exact` dependency versioning with CLI version validation.

This fixes #702.

## How Has This Been Tested?
Improved the quality and coverage of the existing InitCommand and Repository tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
