### PR TITLE
Use yargs to handle CLI args and subcommands

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -1,63 +1,27 @@
 #!/usr/bin/env node
 "use strict";
 
-/* eslint-disable max-len */
-// too many long lines in this file to bother
-
-const lerna = require("../lib/index");
+const globalOptions = require("../lib/Command").builder;
 const logger = require("../lib/logger");
-const chalk = require("chalk");
 const yargs = require("yargs");
-const _ = require("lodash");
+const path = require("path");
 
-yargs.epilogue("For more information, find our manual at https://github.com/lerna/lerna");
-yargs.usage("$ lerna [command] [flags]");
-yargs.wrap(yargs.terminalWidth());
+logger.setLogLevel(yargs.argv.loglevel);
+
 yargs
+  .epilogue("For more information, find our manual at https://github.com/lerna/lerna")
+  .usage("$ lerna [command] [flags]")
+  .wrap(yargs.terminalWidth())
   .option("loglevel", {
     default: "info",
     describe: "What level of logs to report. On failure, all logs are written to lerna-debug.log in the current working directory.",
     type: "string",
     global: true
-  });
+  })
+  .options(globalOptions).group(Object.keys(globalOptions), "Global Options:")
+  .commandDir(path.join(__dirname, "..", "lib", "commands"))
+  .demandCommand()
+  .help()
+  .argv;
 
 require("signal-exit").unload();
-
-logger.setLogLevel(yargs.argv.loglevel || "info");
-
-const commandName = yargs.argv._[0];
-const Command = lerna.__commands__[commandName];
-
-Object.keys(lerna.__commands__)
-  .forEach((commandName) => {
-    const cmd = lerna.__commands__[commandName];
-    const opts = cmd.getSupportedOptions();
-    yargs.command(commandName, cmd.describe, (yargs) => {
-      Object.keys(opts)
-        .forEach((optionName) => {
-          let kebabName = _.kebabCase(optionName);
-          yargs.option(kebabName, opts[optionName]);
-        });
-      return yargs;
-    });
-  });
-
-if (!Command) {
-
-  // Don't emit "Invalid lerna command: undefined" when run with no command.
-  if (commandName) {
-    console.log(chalk.red("Invalid lerna command: " + commandName));
-  }
-
-  yargs.showHelp();
-} else if (yargs.argv.help) {
-  yargs.showHelp();
-} else {
-  // camelCased properties will only be set when the user passed the flags in the CLI
-  // yargs seemingly does not provide a clean API which only returns flags given, so we should filter the flags for readability
-  const argsFiltered = _.omitBy(yargs.argv, (value, key) => {
-    return value === undefined || ["$0", "_"].indexOf(key) > -1 || key.indexOf("-") > -1;
-  });
-  const command = new Command(yargs.argv._.slice(1), argsFiltered);
-  command.run();
-}

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -14,8 +14,8 @@ yargs
   .wrap(yargs.terminalWidth())
   .option("loglevel", {
     default: "info",
-    describe: `What level of logs to report. On failure, all logs are written to lerna-debug.log in the 
-               current working directory.`,
+    describe: "What level of logs to report. On failure, all logs are written to lerna-debug.log in the"
+            + "current working directory.",
     type: "string",
     global: true
   })

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -64,6 +64,13 @@ logger.setLogLevel(cli.flags.loglevel);
 const commandName = cli.input[0];
 const Command = lerna.__commands__[commandName];
 
+console.log("Supported Flags for Commands:");
+Object.keys(lerna.__commands__)
+  .forEach((commandName) => {
+    // FIXME breaks...
+    console.log(lerna.__commands__[commandName].getSupportedOptions().toString());
+  });
+
 if (!Command) {
 
   // Don't emit "Invalid lerna command: undefined" when run with no command.

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -14,7 +14,8 @@ yargs
   .wrap(yargs.terminalWidth())
   .option("loglevel", {
     default: "info",
-    describe: "What level of logs to report. On failure, all logs are written to lerna-debug.log in the current working directory.",
+    describe: `What level of logs to report. On failure, all logs are written to lerna-debug.log in the 
+               current working directory.`,
     type: "string",
     global: true
   })

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -11,7 +11,7 @@ const yargs = require("yargs");
 const _ = require("lodash");
 
 yargs.epilogue("For more information, find our manual at https://github.com/lerna/lerna");
-yargs.usage("$ lerna [command]");
+yargs.usage("$ lerna [command] [flags]");
 yargs.wrap(yargs.terminalWidth());
 yargs
   .option("loglevel", {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "inquirer": "^3.0.6",
     "load-json-file": "^2.0.0",
     "lodash": "^4.17.4",
-    "meow": "^3.7.0",
     "minimatch": "^3.0.0",
     "path-exists": "^3.0.0",
     "progress": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "jest": "^19.0.2",
     "normalize-newline": "^3.0.0",
     "normalize-path": "^2.1.1",
-    "replacestream": "^4.0.2"
+    "replacestream": "^4.0.2",
+    "yargs": "^7.0.2"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "signal-exit": "^3.0.2",
     "tempy": "^0.1.0",
     "write-json-file": "^2.0.0",
-    "write-pkg": "^2.1.0"
+    "write-pkg": "^2.1.0",
+    "yargs": "^7.0.2"
   },
   "bin": {
     "lerna": "./bin/lerna.js"

--- a/package.json
+++ b/package.json
@@ -80,8 +80,7 @@
     "jest": "^19.0.2",
     "normalize-newline": "^3.0.0",
     "normalize-path": "^2.1.1",
-    "replacestream": "^4.0.2",
-    "yargs": "^7.0.2"
+    "replacestream": "^4.0.2"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/Command.js
+++ b/src/Command.js
@@ -18,20 +18,24 @@ export const builder = {
     coerce: (val) => Math.max(1, val)
   },
   "ignore": {
-    describe: "Ignores packages with names matching the given glob (Works only in combination with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
+    describe: `Ignores packages with names matching the given glob (Works only in combination with the 
+               'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).`,
     type: "string",
     requiresArg: true
   },
   "include-filtered-dependencies": {
-    describe: "Flag to force lerna to include all dependencies and transitive dependencies when running 'bootstrap', even if they should not be included by the scope or ignore flags"
+    describe: `Flag to force lerna to include all dependencies and transitive dependencies when running 
+               'bootstrap', even if they should not be included by the scope or ignore flags`
   },
   "registry": {
-    describe: "When run with this flag, forwarded npm commands will use the specified registry for your package(s).",
+    describe: `When run with this flag, forwarded npm commands will use the specified registry for your 
+               package(s).`,
     type: "string",
     requiresArg: true
   },
   "scope": {
-    describe: "Restricts the scope to package names matching the given glob (Works only in combination with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
+    describe: `Restricts the scope to package names matching the given glob (Works only in combination 
+               with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).`,
     type: "string",
     requiresArg: true
   },
@@ -138,7 +142,7 @@ export default class Command {
   }
 
   runValidations() {
-    const {independent, onlyExplicitUpdates} = this.getOptions();
+    const { independent, onlyExplicitUpdates } = this.getOptions();
     if (!GitUtilities.isInitialized(this.repository.rootPath)) {
       this.logger.warn("This is not a git repository, did you already run `git init` or `lerna init`?");
       this._complete(null, 1);

--- a/src/Command.js
+++ b/src/Command.js
@@ -9,6 +9,38 @@ import logger from "./logger";
 
 const DEFAULT_CONCURRENCY = 4;
 
+export const builder = {
+  "concurrency": {
+    describe: "How many threads to use if lerna parallelises the tasks.",
+    type: "number",
+    requiresArg: true,
+    default: DEFAULT_CONCURRENCY,
+    coerce: (val) => Math.max(1, val)
+  },
+  "ignore": {
+    describe: "Ignores packages with names matching the given glob (Works only in combination with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
+    type: "string",
+    requiresArg: true
+  },
+  "include-filtered-dependencies": {
+    describe: "Flag to force lerna to include all dependencies and transitive dependencies when running 'bootstrap', even if they should not be included by the scope or ignore flags"
+  },
+  "registry": {
+    describe: "When run with this flag, forwarded npm commands will use the specified registry for your package(s).",
+    type: "string",
+    requiresArg: true
+  },
+  "scope": {
+    describe: "Restricts the scope to package names matching the given glob (Works only in combination with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
+    type: "string",
+    requiresArg: true
+  },
+  "sort": {
+    describe: "Sort packages topologically",
+    default: true
+  }
+};
+
 export default class Command {
   constructor(input, flags, cwd) {
     this.input = input;
@@ -106,6 +138,7 @@ export default class Command {
   }
 
   runValidations() {
+    const {independent, onlyExplicitUpdates} = this.getOptions();
     if (!GitUtilities.isInitialized(this.repository.rootPath)) {
       this.logger.warn("This is not a git repository, did you already run `git init` or `lerna init`?");
       this._complete(null, 1);
@@ -124,7 +157,7 @@ export default class Command {
       return;
     }
 
-    if (this.flags.independent && !this.repository.isIndependent()) {
+    if (independent && !this.repository.isIndependent()) {
       this.logger.warn(
         "You ran lerna with `--independent` or `-i`, but the repository is not set to independent mode. " +
         "To use independent mode you need to set your `lerna.json` \"version\" to \"independent\". " +
@@ -167,7 +200,7 @@ export default class Command {
       return;
     }
 
-    if (this.flags.onlyExplicitUpdates) {
+    if (onlyExplicitUpdates) {
       this.logger.warn("`--only-explicit-updates` has been removed. This flag was only ever added for Babel and we never should have exposed it to everyone.");
       this._complete(null, 1);
       return;
@@ -286,21 +319,4 @@ export default class Command {
 
 export function commandNameFromClassName(className) {
   return className.replace(/Command$/, "").toLowerCase();
-}
-
-export function exposeCommands(commands) {
-  return commands.reduce((obj, cls) => {
-    const commandName = commandNameFromClassName(cls.name);
-    if (!cls.name.match(/Command$/)) {
-      throw new Error(`Invalid command class name "${cls.name}".  Must end with "Command".`);
-    }
-    if (obj[commandName]) {
-      throw new Error(`Duplicate command: "${commandName}"`);
-    }
-    if (!Command.isPrototypeOf(cls)) {
-      throw new Error(`Command does not extend Command: "${cls.name}"`);
-    }
-    obj[commandName] = cls;
-    return obj;
-  }, {});
 }

--- a/src/Command.js
+++ b/src/Command.js
@@ -18,24 +18,24 @@ export const builder = {
     coerce: (val) => Math.max(1, val)
   },
   "ignore": {
-    describe: `Ignores packages with names matching the given glob (Works only in combination with the 
-               'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).`,
+    describe: "Ignores packages with names matching the given glob (Works only in combination with the "
+            + "'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
     type: "string",
     requiresArg: true
   },
   "include-filtered-dependencies": {
-    describe: `Flag to force lerna to include all dependencies and transitive dependencies when running 
-               'bootstrap', even if they should not be included by the scope or ignore flags`
+    describe: "Flag to force lerna to include all dependencies and transitive dependencies when running "
+            + "'bootstrap', even if they should not be included by the scope or ignore flags."
   },
   "registry": {
-    describe: `When run with this flag, forwarded npm commands will use the specified registry for your 
-               package(s).`,
+    describe: "When run with this flag, forwarded npm commands will use the specified registry for your "
+            + "package(s).",
     type: "string",
     requiresArg: true
   },
   "scope": {
-    describe: `Restricts the scope to package names matching the given glob (Works only in combination 
-               with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).`,
+    describe: "Restricts the scope to package names matching the given glob (Works only in combination "
+            + "with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
     type: "string",
     requiresArg: true
   },

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -7,6 +7,30 @@ import find from "lodash/find";
 import path from "path";
 import semver from "semver";
 
+export function handler(argv) {
+  return new BootstrapCommand(argv._, argv).run();
+}
+
+export const command = "bootstrap";
+
+export const describe = "Link local packages together and install remaining package dependencies";
+
+export const builder = {
+  "hoist": {
+    describe: "Install external dependencies matching [glob] to the repo root.  Use with no glob for all.",
+    type: "string"
+  },
+  "nohoist": {
+    describe: "Don't hoist external dependencies matching [glob] to the repo root",
+    type: "string"
+  },
+  "npm-client": {
+    describe: "Executable used to install dependencies (npm, yarn, pnpm, ...)",
+    type: "string",
+    requiresArg: true
+  }
+};
+
 export default class BootstrapCommand extends Command {
   initialize(callback) {
     this.npmConfig = {

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -1,26 +1,11 @@
+import async from "async";
+import Command from "../Command";
 import FileSystemUtilities from "../FileSystemUtilities";
 import PromptUtilities from "../PromptUtilities";
-import Command from "../Command";
-import async from "async";
-
-const SUPPORTED_OPTS = {
-  yes: {
-    describe: "Skip all confirmation prompts"
-  }
-};
 
 export default class CleanCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions(), SUPPORTED_OPTS);
-  }
-
-  static get describe() {
-    return "Remove the node_modules directory from all packages.";
-  }
-
   initialize(callback) {
-    const {yes} = this.getAvailableOptions();
-    if (yes) {
+    if (this.flags.yes) {
       callback(null, true);
     } else {
       this.logger.info(`About to remove the following directories:\n${

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -1,11 +1,19 @@
-import async from "async";
-import Command from "../Command";
 import FileSystemUtilities from "../FileSystemUtilities";
 import PromptUtilities from "../PromptUtilities";
+import Command from "../Command";
+import {uniq} from "lodash";
+import async from "async";
+
+const SUPPORTED_OPTS = ["yes"];
 
 export default class CleanCommand extends Command {
+  static getSupportedOptions() {
+    return uniq(Command.getSupportedOptions().concat(SUPPORTED_OPTS));
+  }
+
   initialize(callback) {
-    if (this.flags.yes) {
+    const {yes} = this.getAvailableOptions();
+    if (yes) {
       callback(null, true);
     } else {
       this.logger.info(`About to remove the following directories:\n${

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -2,6 +2,7 @@ import async from "async";
 import Command from "../Command";
 import FileSystemUtilities from "../FileSystemUtilities";
 import PromptUtilities from "../PromptUtilities";
+
 export function handler(argv) {
   return new CleanCommand(argv._, argv).run();
 }

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -2,6 +2,19 @@ import async from "async";
 import Command from "../Command";
 import FileSystemUtilities from "../FileSystemUtilities";
 import PromptUtilities from "../PromptUtilities";
+export function handler(argv) {
+  return new CleanCommand(argv._, argv).run();
+}
+
+export const command = "clean";
+
+export const describe = "Remove the node_modules directory from all packages.";
+
+export const builder = {
+  "yes": {
+    describe: "Skip all confirmation prompts"
+  }
+};
 
 export default class CleanCommand extends Command {
   initialize(callback) {

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -1,14 +1,21 @@
 import FileSystemUtilities from "../FileSystemUtilities";
 import PromptUtilities from "../PromptUtilities";
 import Command from "../Command";
-import {uniq} from "lodash";
 import async from "async";
 
-const SUPPORTED_OPTS = ["yes"];
+const SUPPORTED_OPTS = {
+  yes: {
+    describe: "Skip all confirmation prompts"
+  }
+};
 
 export default class CleanCommand extends Command {
   static getSupportedOptions() {
-    return uniq(Command.getSupportedOptions().concat(SUPPORTED_OPTS));
+    return Object.assign({}, Command.getSupportedOptions(), SUPPORTED_OPTS);
+  }
+
+  static get describe() {
+    return "Remove the node_modules directory from all packages.";
   }
 
   initialize(callback) {

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -22,6 +22,14 @@ function getLastCommit(execOpts) {
 }
 
 export default class DiffCommand extends Command {
+  static getSupportedOptions() {
+    return Object.assign({}, Command.getSupportedOptions());
+  }
+
+  static get describe() {
+    return "Diff all packages or a single package since the last release.";
+  }
+
   initialize(callback) {
     const packageName = this.input[0];
 

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -4,10 +4,10 @@ import ChildProcessUtilities from "../ChildProcessUtilities";
 import find from "lodash/find";
 
 export function handler(argv) {
-  return new DiffCommand(argv._, argv).run();
+  return new DiffCommand([argv.pkg], argv).run();
 }
 
-export const command = "diff";
+export const command = "diff <pkg>";
 
 export const describe = "Diff all packages or a single package since the last release.";
 

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -12,6 +12,14 @@ function getLastCommit(execOpts) {
 }
 
 export default class DiffCommand extends Command {
+  static getSupportedOptions() {
+    return Object.assign({}, Command.getSupportedOptions());
+  }
+
+  static get describe() {
+    return "Diff all packages or a single package since the last release.";
+  }
+
   initialize(callback) {
     const packageName = this.input[0];
 

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -22,14 +22,6 @@ function getLastCommit(execOpts) {
 }
 
 export default class DiffCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions());
-  }
-
-  static get describe() {
-    return "Diff all packages or a single package since the last release.";
-  }
-
   initialize(callback) {
     const packageName = this.input[0];
 

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -3,6 +3,16 @@ import Command from "../Command";
 import ChildProcessUtilities from "../ChildProcessUtilities";
 import find from "lodash/find";
 
+export function handler(argv) {
+  return new DiffCommand(argv._, argv).run();
+}
+
+export const command = "diff";
+
+export const describe = "Diff all packages or a single package since the last release.";
+
+export const builder = {};
+
 function getLastCommit(execOpts) {
   if (GitUtilities.hasTags(execOpts)) {
     return GitUtilities.getLastTaggedCommit(execOpts);
@@ -12,14 +22,6 @@ function getLastCommit(execOpts) {
 }
 
 export default class DiffCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions());
-  }
-
-  static get describe() {
-    return "Diff all packages or a single package since the last release.";
-  }
-
   initialize(callback) {
     const packageName = this.input[0];
 

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -3,6 +3,14 @@ import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 
 export default class ExecCommand extends Command {
+  static getSupportedOptions() {
+    return Object.assign({}, Command.getSupportedOptions());
+  }
+
+  static get describe() {
+    return "Run an arbitrary command in each package.";
+  }
+
   initialize(callback) {
     this.command = this.input[0];
     this.args = this.input.slice(1);

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -13,14 +13,6 @@ export const describe = "Run an arbitrary command in each package.";
 export const builder = {};
 
 export default class ExecCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions());
-  }
-
-  static get describe() {
-    return "Run an arbitrary command in each package.";
-  }
-
   initialize(callback) {
     this.command = this.input[0];
     this.args = this.input.slice(1);

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -13,6 +13,14 @@ export const describe = "Run an arbitrary command in each package.";
 export const builder = {};
 
 export default class ExecCommand extends Command {
+  static getSupportedOptions() {
+    return Object.assign({}, Command.getSupportedOptions());
+  }
+
+  static get describe() {
+    return "Run an arbitrary command in each package.";
+  }
+
   initialize(callback) {
     this.command = this.input[0];
     this.args = this.input.slice(1);

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -2,15 +2,17 @@ import ChildProcessUtilities from "../ChildProcessUtilities";
 import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 
+export function handler(argv) {
+  return new ExecCommand(argv._, argv).run();
+}
+
+export const command = "exec";
+
+export const describe = "Run an arbitrary command in each package.";
+
+export const builder = {};
+
 export default class ExecCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions());
-  }
-
-  static get describe() {
-    return "Run an arbitrary command in each package.";
-  }
-
   initialize(callback) {
     this.command = this.input[0];
     this.args = this.input.slice(1);

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -7,13 +7,13 @@ import FileSystemUtilities from "../FileSystemUtilities";
 import GitUtilities from "../GitUtilities";
 
 export function handler(argv) {
-  return new ImportCommand(argv._, argv).run();
+  return new ImportCommand([argv.repo], argv).run();
 }
 
-export const command = "import";
+export const command = "import <repo>";
 
-export const describe = `Import the package at <path-to-external-repository>, with commit history, 
-                         into packages/<directory-name>.`;
+export const describe = "Import the package at <path-to-external-repository>, with commit history, "
+                      + "into packages/<directory-name>.";
 
 export const builder = {
   "yes": {

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -6,6 +6,20 @@ import ChildProcessUtilities from "../ChildProcessUtilities";
 import FileSystemUtilities from "../FileSystemUtilities";
 import GitUtilities from "../GitUtilities";
 
+export function handler(argv) {
+  return new ImportCommand(argv._, argv).run();
+}
+
+export const command = "import";
+
+export const describe = "Import the package at <path-to-external-repository>, with commit history, into packages/<directory-name>.";
+
+export const builder = {
+  "yes": {
+    describe: "Skip all confirmation prompts"
+  }
+};
+
 export default class ImportCommand extends Command {
   initialize(callback) {
     const inputPath = this.input[0];

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -12,7 +12,8 @@ export function handler(argv) {
 
 export const command = "import";
 
-export const describe = "Import the package at <path-to-external-repository>, with commit history, into packages/<directory-name>.";
+export const describe = `Import the package at <path-to-external-repository>, with commit history, 
+                         into packages/<directory-name>.`;
 
 export const builder = {
   "yes": {
@@ -22,6 +23,7 @@ export const builder = {
 
 export default class ImportCommand extends Command {
   initialize(callback) {
+    const {yes} = this.getOptions();
     const inputPath = this.input[0];
 
     if (!inputPath) {
@@ -77,7 +79,7 @@ export default class ImportCommand extends Command {
       `About to import ${this.commits.length} commits from ${inputPath} into ${this.targetDir}`
     );
 
-    if (this.flags.yes) {
+    if (yes) {
       callback(null, true);
     } else {
       const message = "Are you sure you want to import these commits onto the current branch?";

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -23,7 +23,7 @@ export const builder = {
 
 export default class ImportCommand extends Command {
   initialize(callback) {
-    const {yes} = this.getOptions();
+    const { yes } = this.getOptions();
     const inputPath = this.input[0];
 
     if (!inputPath) {

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -11,7 +11,8 @@ export function handler(argv) {
 
 export const command = "init";
 
-export const describe = "Create a new Lerna repo or upgrade an existing repo to the current version of Lerna.";
+export const describe = `Create a new Lerna repo or upgrade an existing repo to the current version 
+                         of Lerna.`;
 
 export const builder = {
   "exact": {
@@ -75,7 +76,7 @@ export default class InitCommand extends Command {
   }
 
   ensureLernaJson() {
-    const {independent} = this.getOptions();
+    const { independent } = this.getOptions();
 
     // lernaJson already defaulted to empty object in Repository constructor
     const lernaJson = this.repository.lernaJson;

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -11,8 +11,8 @@ export function handler(argv) {
 
 export const command = "init";
 
-export const describe = `Create a new Lerna repo or upgrade an existing repo to the current version 
-                         of Lerna.`;
+export const describe = "Create a new Lerna repo or upgrade an existing repo to the current version "
+                      + "of Lerna.";
 
 export const builder = {
   "exact": {

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -5,6 +5,24 @@ import FileSystemUtilities from "../FileSystemUtilities";
 import GitUtilities from "../GitUtilities";
 import Command from "../Command";
 
+export function handler(argv) {
+  return new InitCommand(argv._, argv).run();
+}
+
+export const command = "init";
+
+export const describe = "Create a new Lerna repo or upgrade an existing repo to the current version of Lerna.";
+
+export const builder = {
+  "exact": {
+    describe: "Specify lerna dependency version in package.json without a caret (^)"
+  },
+  "independent": {
+    describe: "Version packages independently",
+    alias: "i"
+  }
+};
+
 export default class InitCommand extends Command {
   // don't do any of this.
   runValidations() {}
@@ -57,12 +75,14 @@ export default class InitCommand extends Command {
   }
 
   ensureLernaJson() {
+    const {independent} = this.getOptions();
+
     // lernaJson already defaulted to empty object in Repository constructor
     const lernaJson = this.repository.lernaJson;
 
     let version;
 
-    if (this.flags.independent) {
+    if (independent) {
       version = "independent";
     } else if (FileSystemUtilities.existsSync(this.repository.versionLocation)) {
       version = FileSystemUtilities.readFileSync(this.repository.versionLocation);

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -3,6 +3,14 @@ import chalk from "chalk";
 import columnify from "columnify";
 
 export default class LsCommand extends Command {
+  static getSupportedOptions() {
+    return Object.assign({}, Command.getSupportedOptions());
+  }
+
+  static get describe() {
+    return "List all public packages";
+  }
+
   initialize(callback) {
     // Nothing to do...
     callback(null, true);

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -2,15 +2,17 @@ import Command from "../Command";
 import chalk from "chalk";
 import columnify from "columnify";
 
+export function handler(argv) {
+  return new LsCommand(argv._, argv).run();
+}
+
+export const command = "ls";
+
+export const describe = "List all public packages";
+
+export const builder = {};
+
 export default class LsCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions());
-  }
-
-  static get describe() {
-    return "List all public packages";
-  }
-
   initialize(callback) {
     // Nothing to do...
     callback(null, true);

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -13,14 +13,6 @@ export const describe = "List all public packages";
 export const builder = {};
 
 export default class LsCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions());
-  }
-
-  static get describe() {
-    return "List all public packages";
-  }
-
   initialize(callback) {
     // Nothing to do...
     callback(null, true);

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -13,6 +13,14 @@ export const describe = "List all public packages";
 export const builder = {};
 
 export default class LsCommand extends Command {
+  static getSupportedOptions() {
+    return Object.assign({}, Command.getSupportedOptions());
+  }
+
+  static get describe() {
+    return "List all public packages";
+  }
+
   initialize(callback) {
     // Nothing to do...
     callback(null, true);

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -28,8 +28,8 @@ export const builder = {
     alias: "c"
   },
   "cd-version": {
-    describe: `Skip the version selection prompt (in independent mode) and use the next specified semantic 
-               version.`
+    describe: "Skip the version selection prompt (in independent mode) and use the next specified semantic "
+            + "version."
   },
   "conventional-commits": {
     describe: "Use angular conventional-commit format to determine version bump and generate CHANGELOG."
@@ -68,8 +68,8 @@ export const builder = {
     describe: "Stop before actually publishing change to npm."
   },
   "skip-temp-tag": {
-    describe: `Do not create a temporary tag while publishing. In stead use the normal npm publish 
-               methodology.`
+    describe: "Do not create a temporary tag while publishing. In stead use the normal npm publish"
+            + "methodology."
   }
 };
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -14,6 +14,63 @@ import chalk from "chalk";
 import path from "path";
 import { EOL } from "os";
 
+export function handler(argv) {
+  return new PublishCommand(argv._, argv).run();
+}
+
+export const command = "publish";
+
+export const describe = "Publish packages in the current Lerna project.";
+
+export const builder = {
+  "canary": {
+    describe: "Publish packages after every successful merge using the sha as part of the tag.",
+    alias: "c"
+  },
+  "cd-version": {
+    describe: "Skip the version selection prompt (in independent mode) and use the next specified semantic version."
+  },
+  "conventional-commits": {
+    describe: "Use angular conventional-commit format to determine version bump and generate CHANGELOG."
+  },
+  "exact": {
+    describe: "Specify cross-dependency version numbers exactly rather than with a caret (^)."
+  },
+  "git-remote": {
+    describe: "Push git changes to the specified remote instead of 'origin'.",
+    type: "string",
+    requiresArg: true
+  },
+  "yes": {
+    describe: "Skip all confirmation prompts."
+  },
+  "message": {
+    describe: "Use a custom commit message when creating the publish commit.",
+    alias: "m",
+    type: "string",
+    requiresArg: true
+  },
+  "npm-tag": {
+    describe: "Publish packages with the specified npm dist-tag",
+    type: "string",
+    requiresArg: true
+  },
+  "repo-version": {
+    describe: "Specify repo version to publish.",
+    type: "string",
+    requiresArg: true
+  },
+  "skip-git": {
+    describe: "Skip commiting, tagging, and pushing git changes."
+  },
+  "skip-npm": {
+    describe: "Stop before actually publishing change to npm."
+  },
+  "skip-temp-tag": {
+    describe: "Do not create a temporary tag while publishing. In stead use the normal npm publish methodology."
+  }
+};
+
 export default class PublishCommand extends Command {
   initialize(callback) {
     this.gitEnabled = !(this.flags.canary || this.flags.skipGit);

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -28,7 +28,8 @@ export const builder = {
     alias: "c"
   },
   "cd-version": {
-    describe: "Skip the version selection prompt (in independent mode) and use the next specified semantic version."
+    describe: `Skip the version selection prompt (in independent mode) and use the next specified semantic 
+               version.`
   },
   "conventional-commits": {
     describe: "Use angular conventional-commit format to determine version bump and generate CHANGELOG."
@@ -67,7 +68,8 @@ export const builder = {
     describe: "Stop before actually publishing change to npm."
   },
   "skip-temp-tag": {
-    describe: "Do not create a temporary tag while publishing. In stead use the normal npm publish methodology."
+    describe: `Do not create a temporary tag while publishing. In stead use the normal npm publish 
+               methodology.`
   }
 };
 

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -3,10 +3,10 @@ import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 
 export function handler(argv) {
-  return new RunCommand(argv._, argv).run();
+  return new RunCommand([argv.script, ...argv.arguments], argv).run();
 }
 
-export const command = "run";
+export const command = "run <script> [arguments..]";
 
 export const describe = "Run an npm script in each package that contains that script.";
 

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -2,6 +2,20 @@ import NpmUtilities from "../NpmUtilities";
 import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 
+export function handler(argv) {
+  return new RunCommand(argv._, argv).run();
+}
+
+export const command = "run";
+
+export const describe = "Run an npm script in each package that contains that script.";
+
+export const builder = {
+  "stream": {
+    describe: "Stream output with lines prefixed by package."
+  }
+};
+
 export default class RunCommand extends Command {
   initialize(callback) {
     this.script = this.input[0];

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -1,13 +1,20 @@
 import PackageUtilities from "../PackageUtilities";
 import NpmUtilities from "../NpmUtilities";
 import Command from "../Command";
-import {uniq} from "lodash";
 
-const SUPPORTED_OPTS = ["stream"];
+const SUPPORTED_OPTS = {
+  stream: {
+    describe: "Stream output with lines prefixed by package."
+  }
+};
 
 export default class RunCommand extends Command {
   static getSupportedOptions() {
-    return uniq(Command.getSupportedOptions().concat(SUPPORTED_OPTS));
+    return Object.assign({}, Command.getSupportedOptions(), SUPPORTED_OPTS);
+  }
+
+  static get describe() {
+    return "Run an npm script in each package that contains that script.";
   }
 
   initialize(callback) {

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -1,8 +1,15 @@
-import NpmUtilities from "../NpmUtilities";
 import PackageUtilities from "../PackageUtilities";
+import NpmUtilities from "../NpmUtilities";
 import Command from "../Command";
+import {uniq} from "lodash";
+
+const SUPPORTED_OPTS = ["stream"];
 
 export default class RunCommand extends Command {
+  static getSupportedOptions() {
+    return uniq(Command.getSupportedOptions().concat(SUPPORTED_OPTS));
+  }
+
   initialize(callback) {
     this.script = this.input[0];
     this.args = this.input.slice(1);
@@ -50,7 +57,8 @@ export default class RunCommand extends Command {
   }
 
   runScriptInPackage(pkg, callback) {
-    if (this.getOptions().stream) {
+    const {stream} = this.getAvailableOptions();
+    if (stream) {
       this.runScriptInPackageStreaming(pkg, callback);
     } else {
       this.runScriptInPackageCapturing(pkg, callback);

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -1,22 +1,8 @@
-import PackageUtilities from "../PackageUtilities";
 import NpmUtilities from "../NpmUtilities";
+import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 
-const SUPPORTED_OPTS = {
-  stream: {
-    describe: "Stream output with lines prefixed by package."
-  }
-};
-
 export default class RunCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions(), SUPPORTED_OPTS);
-  }
-
-  static get describe() {
-    return "Run an npm script in each package that contains that script.";
-  }
-
   initialize(callback) {
     this.script = this.input[0];
     this.args = this.input.slice(1);
@@ -64,8 +50,7 @@ export default class RunCommand extends Command {
   }
 
   runScriptInPackage(pkg, callback) {
-    const {stream} = this.getAvailableOptions();
-    if (stream) {
+    if (this.getOptions().stream) {
       this.runScriptInPackageStreaming(pkg, callback);
     } else {
       this.runScriptInPackageCapturing(pkg, callback);

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -3,6 +3,14 @@ import Command from "../Command";
 import chalk from "chalk";
 
 export default class UpdatedCommand extends Command {
+  static getSupportedOptions() {
+    return Object.assign({}, Command.getSupportedOptions());
+  }
+
+  static get describe() {
+    return "Check which packages have changed since the last release (the last git tag).";
+  }
+
   initialize(callback) {
     const updatedPackagesCollector = new UpdatedPackagesCollector(this);
     this.updates = updatedPackagesCollector.getUpdates();

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -1,16 +1,19 @@
 import UpdatedPackagesCollector from "../UpdatedPackagesCollector";
+import { builder as publishOptions } from "./PublishCommand";
 import Command from "../Command";
 import chalk from "chalk";
 
+export function handler(argv) {
+  return new UpdatedCommand(argv._, argv).run();
+}
+
+export const command = "updated";
+
+export const describe = "Check which packages have changed since the last release (the last git tag).";
+
+export const builder = Object.assign({}, publishOptions);
+
 export default class UpdatedCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions());
-  }
-
-  static get describe() {
-    return "Check which packages have changed since the last release (the last git tag).";
-  }
-
   initialize(callback) {
     const updatedPackagesCollector = new UpdatedPackagesCollector(this);
     this.updates = updatedPackagesCollector.getUpdates();

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -14,6 +14,14 @@ export const describe = "Check which packages have changed since the last releas
 export const builder = Object.assign({}, publishOptions);
 
 export default class UpdatedCommand extends Command {
+  static getSupportedOptions() {
+    return Object.assign({}, Command.getSupportedOptions());
+  }
+
+  static get describe() {
+    return "Check which packages have changed since the last release (the last git tag).";
+  }
+
   initialize(callback) {
     const updatedPackagesCollector = new UpdatedPackagesCollector(this);
     this.updates = updatedPackagesCollector.getUpdates();

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -14,14 +14,6 @@ export const describe = "Check which packages have changed since the last releas
 export const builder = Object.assign({}, publishOptions);
 
 export default class UpdatedCommand extends Command {
-  static getSupportedOptions() {
-    return Object.assign({}, Command.getSupportedOptions());
-  }
-
-  static get describe() {
-    return "Check which packages have changed since the last release (the last git tag).";
-  }
-
   initialize(callback) {
     const updatedPackagesCollector = new UpdatedPackagesCollector(this);
     this.updates = updatedPackagesCollector.getUpdates();

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,8 @@ import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
 import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
-import { exposeCommands } from "./Command";
 
-export const __commands__ = exposeCommands([
+export default {
   BootstrapCommand,
   PublishCommand,
   UpdatedCommand,
@@ -20,5 +19,5 @@ export const __commands__ = exposeCommands([
   InitCommand,
   RunCommand,
   ExecCommand,
-  LsCommand,
-]);
+  LsCommand
+};

--- a/test/Command.js
+++ b/test/Command.js
@@ -10,7 +10,7 @@ import callsBack from "./helpers/callsBack";
 import initFixture from "./helpers/initFixture";
 
 // file under test
-import Command, { exposeCommands } from "../src/Command";
+import Command from "../src/Command";
 
 jest.mock("../src/ChildProcessUtilities");
 jest.mock("../src/FileSystemUtilities");
@@ -306,36 +306,6 @@ describe("Command", () => {
         const instance = new TestCommand([], {}, testDir);
         expect(instance.getOptions().ignore).toBe(undefined);
       });
-    });
-  });
-
-  describe("exposeCommands", () => {
-    class FooCommand extends Command {
-    }
-    class BarCommand extends Command {
-    }
-    class BadClassName extends Command {
-    }
-    class NonCommand {
-    }
-
-    it("makes a mapping from command names to classes", () => {
-      expect(exposeCommands([FooCommand, BarCommand])).toEqual({
-        foo: FooCommand,
-        bar: BarCommand,
-      });
-    });
-
-    it("fails on bad class name", () => {
-      expect(() => exposeCommands([BadClassName])).toThrow();
-    });
-
-    it("fails on duplicate class", () => {
-      expect(() => exposeCommands([FooCommand, FooCommand])).toThrow();
-    });
-
-    it("fails on class that doesn't extend Command", () => {
-      expect(() => exposeCommands([NonCommand])).toThrow();
     });
   });
 

--- a/test/fixtures/PublishCommand/integration/lerna.json
+++ b/test/fixtures/PublishCommand/integration/lerna.json
@@ -1,0 +1,7 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "packages": [
+    "package-*"
+  ],
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/integration/package-1/package.json
+++ b/test/fixtures/PublishCommand/integration/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@integration/package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/integration/package-2/package.json
+++ b/test/fixtures/PublishCommand/integration/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@integration/package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "@integration/package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/integration/package.json
+++ b/test/fixtures/PublishCommand/integration/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "integration",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "lp": "lerna publish --skip-npm --cd-version=major --yes"
+  },
+  "devDependencies": {
+    "lerna": "__TEST_PKG_URL__"
+  }
+}

--- a/test/fixtures/RunCommand/integration-lifecycle/lerna.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/RunCommand/integration-lifecycle/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "independent",
+  "scripts": {
+    "postinstall": "lerna run my-script --scope=package-1"
+  }
+}

--- a/test/fixtures/RunCommand/integration-lifecycle/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/package.json
@@ -1,6 +1,11 @@
 {
-  "name": "independent",
+  "name": "integration-lifecycle",
+  "version": "1.0.0",
+  "private": true,
   "scripts": {
-    "postinstall": "lerna run my-script --scope=package-1"
+    "test": "lerna run test --scope=package-1"
+  },
+  "devDependencies": {
+    "lerna": "__TEST_PKG_URL__"
   }
 }

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-1/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "scripts": {
+    "my-script": "echo package-1"
+  }
+}

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-1/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-1/package.json
@@ -2,6 +2,6 @@
   "name": "package-1",
   "version": "1.0.0",
   "scripts": {
-    "my-script": "echo package-1"
+    "test": "echo package-1"
   }
 }

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-2/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-3/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-3/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "devDependencies": {
+    "package-2": "^1.0.0"
+  },
+  "scripts": {
+    "my-script": "echo package-3"
+  }
+}

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-3/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-3/package.json
@@ -3,8 +3,5 @@
   "version": "1.0.0",
   "devDependencies": {
     "package-2": "^1.0.0"
-  },
-  "scripts": {
-    "my-script": "echo package-3"
   }
 }

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-4/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^0.0.0"
+  }
+}

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-4/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-4/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "dependencies": {
     "package-1": "^0.0.0"
+  },
+  "scripts": {
+    "test": "echo package-4"
   }
 }

--- a/test/helpers/packageTools.js
+++ b/test/helpers/packageTools.js
@@ -1,0 +1,21 @@
+import glob from "glob";
+import readPkg from "read-pkg";
+
+const parsePackageJson = (filePath) =>
+  readPkg(filePath, { normalize: false });
+
+export const loadAllPackages = (cwd) => {
+  return new Promise((resolve, reject) => {
+    glob("packages/*/package.json", {
+      absolute: true,
+      strict: true,
+      cwd,
+    }, (err, files) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(Promise.all(files.map(parsePackageJson)));
+      }
+    });
+  });
+};

--- a/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -31,6 +31,17 @@ Successfully bootstrapped 4 packages."
 
 exports[`stdout: simple 2`] = `
 "Lerna __TEST_VERSION__
+Ignoring packages that match '@integration/package-1'
+Bootstrapping 3 packages
+Preinstalling packages
+Symlinking packages and binaries
+Postinstalling packages
+Prepublishing packages
+Successfully bootstrapped 3 packages."
+`;
+
+exports[`stdout: simple 3`] = `
+"Lerna __TEST_VERSION__
 package-1
 
 package-2

--- a/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -20,6 +20,18 @@ Successfully ran npm script 'test' in packages:
 
 exports[`stdout: simple 1`] = `
 "Lerna __TEST_VERSION__
+Ignoring packages that match '@integration/package-1'
+Bootstrapping 3 packages
+Preinstalling packages
+Installing external dependencies
+Symlinking packages and binaries
+Postinstalling packages
+Prepublishing packages
+Successfully bootstrapped 3 packages."
+`;
+
+exports[`stdout: simple 2`] = `
+"Lerna __TEST_VERSION__
 Bootstrapping 4 packages
 Preinstalling packages
 Installing external dependencies
@@ -27,17 +39,6 @@ Symlinking packages and binaries
 Postinstalling packages
 Prepublishing packages
 Successfully bootstrapped 4 packages."
-`;
-
-exports[`stdout: simple 2`] = `
-"Lerna __TEST_VERSION__
-Ignoring packages that match '@integration/package-1'
-Bootstrapping 3 packages
-Preinstalling packages
-Symlinking packages and binaries
-Postinstalling packages
-Prepublishing packages
-Successfully bootstrapped 3 packages."
 `;
 
 exports[`stdout: simple 3`] = `

--- a/test/integration/__snapshots__/lerna-exec.test.js.snap
+++ b/test/integration/__snapshots__/lerna-exec.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`exec: with ignore 1`] = `
+"Lerna __TEST_VERSION__
+Ignoring packages that match 'package-1'
+package-2 v1.0.0 "
+`;

--- a/test/integration/__snapshots__/lerna-import.test.js.snap
+++ b/test/integration/__snapshots__/lerna-import.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`simple: import with argument 1`] = `
+Array [
+  Object {
+    "//": "Import should use _directory_ name, not package name",
+    "name": "external-name",
+  },
+]
+`;

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -68,6 +68,23 @@ Array [
 ]
 `;
 
+exports[`packages: updates independent versions by npm 1`] = `
+"
+> integration@0.0.0 lp /tmp/05424c5c2996a34cdbc603dc0ea49797
+> lerna publish --skip-npm --cd-version=major --yes
+
+Lerna __TEST_VERSION__
+Current version: 1.0.0
+Checking for updated packages...
+No tags found! Comparing with initial commit.
+
+Changes:
+- @integration/package-1: 1.0.0 => 2.0.0
+- @integration/package-2: 1.0.0 => 2.0.0
+
+Assuming confirmation."
+`;
+
 exports[`stdout: updates fixed versions 1`] = `
 "Lerna __TEST_VERSION__
 Current version: 1.0.0

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -69,11 +69,7 @@ Array [
 `;
 
 exports[`packages: updates independent versions by npm 1`] = `
-"
-> integration@0.0.0 lp /tmp/0bf080d532373b601b8a7cd4835db6c5
-> lerna publish --skip-npm --cd-version=major --yes
-
-Lerna __TEST_VERSION__
+"Lerna __TEST_VERSION__
 Current version: 1.0.0
 Checking for updated packages...
 No tags found! Comparing with initial commit.

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -70,7 +70,7 @@ Array [
 
 exports[`packages: updates independent versions by npm 1`] = `
 "
-> integration@0.0.0 lp /tmp/05424c5c2996a34cdbc603dc0ea49797
+> integration@0.0.0 lp /tmp/0bf080d532373b601b8a7cd4835db6c5
 > lerna publish --skip-npm --cd-version=major --yes
 
 Lerna __TEST_VERSION__

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -3,10 +3,6 @@
 exports[`stdout: simple 1`] = `
 "Lerna __TEST_VERSION__
 Scoping to packages that match 'package-1'
-
-> package-1@1.0.0 my-script /tmp/adedbf29bf6edb284695f2cb2ba09d5b/packages/package-1
-> echo package-1
-
 package-1
 
 Successfully ran npm script 'my-script' in packages:

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`stdout: simple 1`] = `
+"Lerna __TEST_VERSION__
+Scoping to packages that match 'package-1'
+
+> package-1@1.0.0 my-script /tmp/adedbf29bf6edb284695f2cb2ba09d5b/packages/package-1
+> echo package-1
+
+package-1
+
+Successfully ran npm script 'my-script' in packages:
+- package-1"
+`;

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -8,3 +8,12 @@ package-1
 Successfully ran npm script 'my-script' in packages:
 - package-1"
 `;
+
+exports[`stdout: simple-npm 1`] = `
+"Lerna __TEST_VERSION__
+Scoping to packages that match 'package-1'
+package-1
+
+Successfully ran npm script 'my-script' in packages:
+- package-1"
+`;

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -14,6 +14,6 @@ exports[`stdout: simple-npm 1`] = `
 Scoping to packages that match 'package-1'
 package-1
 
-Successfully ran npm script 'my-script' in packages:
+Successfully ran npm script 'test' in packages:
 - package-1"
 `;

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -21,11 +21,16 @@ describe("lerna bootstrap", () => {
           .then((result) => {
             expect(result.stdout).toMatchSnapshot("stdout: simple");
           })
-          .then(() => execa(LERNA_BIN, ["bootstrap", "--ignore", "@integration/package-1"], { cwd }))
+          .then(() => execa(LERNA_BIN, ["run", "test", "--", "--silent"], { cwd }))
           .then((result) => {
             expect(result.stdout).toMatchSnapshot("stdout: simple");
-          })
-          .then(() => execa(LERNA_BIN, ["run", "test", "--", "--silent"], { cwd }))
+          });
+      });
+    });
+    test.concurrent("respects ignore flag", () => {
+      return initFixture("BootstrapCommand/integration").then((cwd) => {
+        return Promise.resolve()
+          .then(() => execa(LERNA_BIN, ["bootstrap", "--ignore", "@integration/package-1"], { cwd }))
           .then((result) => {
             expect(result.stdout).toMatchSnapshot("stdout: simple");
           });

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -21,6 +21,10 @@ describe("lerna bootstrap", () => {
           .then((result) => {
             expect(result.stdout).toMatchSnapshot("stdout: simple");
           })
+          .then(() => execa(LERNA_BIN, ["bootstrap", "--ignore", "@integration/package-1"], { cwd }))
+          .then((result) => {
+            expect(result.stdout).toMatchSnapshot("stdout: simple");
+          })
           .then(() => execa(LERNA_BIN, ["run", "test", "--", "--silent"], { cwd }))
           .then((result) => {
             expect(result.stdout).toMatchSnapshot("stdout: simple");

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -1,0 +1,19 @@
+import execa from "execa";
+import initFixture from "../helpers/initFixture";
+import { LERNA_BIN } from "../helpers/constants";
+
+describe("lerna exec", () => {
+  test.concurrent("works with ignore flag", () => {
+    return initFixture("ExecCommand/basic").then((cwd) => {
+      const args = [
+        "ls",
+        "--ignore=package-1"
+      ];
+      return Promise.resolve()
+        .then(() => execa(LERNA_BIN, args, { cwd: cwd }))
+        .then((result) => {
+          expect(result.stdout).toMatchSnapshot("exec: with ignore");
+        });
+    });
+  });
+});

--- a/test/integration/lerna-import.test.js
+++ b/test/integration/lerna-import.test.js
@@ -1,0 +1,28 @@
+import execa from "execa";
+import initFixture from "../helpers/initFixture";
+import { loadAllPackages } from "../helpers/packageTools";
+import { LERNA_BIN } from "../helpers/constants";
+
+describe("lerna import", () => {
+  test.concurrent("works with argument provided", () => {
+    return Promise
+      .all([
+        initFixture("ImportCommand/external", "Init external commit"),
+        initFixture("ImportCommand/basic"),
+      ])
+      .then(([externalPath, basicPath]) => {
+        const args = [
+          "import",
+          externalPath,
+          "--yes"
+        ];
+        return Promise.resolve()
+          .then(() => execa(LERNA_BIN, args, { cwd: basicPath }))
+          .then(() => {
+            return loadAllPackages(basicPath).then((allPackageJsons) => {
+              expect(allPackageJsons).toMatchSnapshot("simple: import with argument");
+            });
+          });
+      });
+  });
+});

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -63,9 +63,14 @@ describe("lerna publish", () => {
 
   test("updates independent versions by npm", () => {
     return initFixture("PublishCommand/integration").then((cwd) => {
+      const args = [
+        "run",
+        "lp",
+        "--silent"
+      ];
       return Promise.resolve()
         .then(() => installInDir(cwd))
-        .then(() => execa("npm", ["run", "lp"], { cwd }))
+        .then(() => execa("npm", args, { cwd }))
         .then((result) => {
           expect(result.stdout).toMatchSnapshot("packages: updates independent versions by npm");
         });

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -1,30 +1,10 @@
-import glob from "glob";
 import execa from "execa";
-import readPkg from "read-pkg";
 import initFixture from "../helpers/initFixture";
+import { loadAllPackages } from "../helpers/packageTools";
 import { LERNA_BIN } from "../helpers/constants";
 
 const installInDir = (cwd) =>
   execa("npm", ["install", "--cache-min=99999"], { cwd });
-
-const parsePackageJson = (filePath) =>
-  readPkg(filePath, { normalize: false });
-
-const loadAllPackages = (cwd) => {
-  return new Promise((resolve, reject) => {
-    glob("packages/*/package.json", {
-      absolute: true,
-      strict: true,
-      cwd,
-    }, (err, files) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(Promise.all(files.map(parsePackageJson)));
-      }
-    });
-  });
-};
 
 describe("lerna publish", () => {
   test.concurrent("updates fixed versions", () => initFixture("PublishCommand/normal").then((cwd) => {

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -4,6 +4,9 @@ import readPkg from "read-pkg";
 import initFixture from "../helpers/initFixture";
 import { LERNA_BIN } from "../helpers/constants";
 
+const installInDir = (cwd) =>
+  execa("npm", ["install", "--cache-min=99999"], { cwd });
+
 const parsePackageJson = (filePath) =>
   readPkg(filePath, { normalize: false });
 
@@ -57,4 +60,15 @@ describe("lerna publish", () => {
       });
     });
   }));
+
+  test("updates independent versions by npm", () => {
+    return initFixture("PublishCommand/integration").then((cwd) => {
+      return Promise.resolve()
+        .then(() => installInDir(cwd))
+        .then(() => execa("npm", ["run", "lp"], { cwd }))
+        .then((result) => {
+          expect(result.stdout).toMatchSnapshot("packages: updates independent versions by npm");
+        });
+    });
+  });
 });

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -7,7 +7,7 @@ const installInDir = (cwd) =>
 
 describe("lerna run", () => {
 
-  test.concurrent("can run script in packages", () => {
+  test("can run script in packages", () => {
     return initFixture("RunCommand/basic").then((cwd) => {
       const args = [
         "run",
@@ -25,7 +25,7 @@ describe("lerna run", () => {
     });
   });
 
-  test.concurrent("can run script in packages through npm lifecycle hook", () => {
+  test("can run script in packages through npm lifecycle hook", () => {
     return initFixture("RunCommand/integration-lifecycle").then((cwd) => {
       return Promise.resolve()
         .then(() => installInDir(cwd))

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -9,9 +9,16 @@ describe("lerna run", () => {
 
   test.concurrent("can run script in packages", () => {
     return initFixture("RunCommand/basic").then((cwd) => {
+      const args = [
+        "run",
+        "my-script",
+        "--scope=package-1",
+        "--",
+        "--silent"
+      ];
       return Promise.resolve()
         .then(() => installInDir(cwd))
-        .then(() => execa(LERNA_BIN, ["run", "my-script", "--scope=package-1"], { cwd }))
+        .then(() => execa(LERNA_BIN, args, { cwd }))
         .then((result) => {
           expect(result.stdout).toMatchSnapshot("stdout: simple");
         });

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -1,0 +1,20 @@
+import execa from "execa";
+import initFixture from "../helpers/initFixture";
+import { LERNA_BIN } from "../helpers/constants";
+
+const installInDir = (cwd) =>
+  execa("npm", ["install", "--cache-min=99999"], { cwd });
+
+describe("lerna run", () => {
+
+  test.concurrent("can run script in packages", () => {
+    return initFixture("RunCommand/basic").then((cwd) => {
+      return Promise.resolve()
+        .then(() => installInDir(cwd))
+        .then(() => execa(LERNA_BIN, ["run", "my-script", "--scope=package-1"], { cwd }))
+        .then((result) => {
+          expect(result.stdout).toMatchSnapshot("stdout: simple");
+        });
+    });
+  });
+});

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -25,7 +25,7 @@ describe("lerna run", () => {
     });
   });
 
-  test.concurrent("can run script in packages through npm", () => {
+  test.concurrent("can run script in packages through npm lifecycle hook", () => {
     return initFixture("RunCommand/integration-lifecycle").then((cwd) => {
       return Promise.resolve()
         .then(() => installInDir(cwd))

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -3,7 +3,7 @@ import initFixture from "../helpers/initFixture";
 import { LERNA_BIN } from "../helpers/constants";
 
 const installInDir = (cwd) =>
-  execa("npm", ["install", "--cache-min=99999"], { cwd });
+  execa("npm", ["install", "--cache-min=99999", "--silent"], { cwd });
 
 describe("lerna run", () => {
 
@@ -21,6 +21,16 @@ describe("lerna run", () => {
         .then(() => execa(LERNA_BIN, args, { cwd }))
         .then((result) => {
           expect(result.stdout).toMatchSnapshot("stdout: simple");
+        });
+    });
+  });
+
+  test.concurrent("can run script in packages through npm", () => {
+    return initFixture("RunCommand/integration-lifecycle").then((cwd) => {
+      return Promise.resolve()
+        .then(() => installInDir(cwd))
+        .then((result) => {
+          expect(result.stdout).toMatchSnapshot("stdout: simple-npm");
         });
     });
   });

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -3,11 +3,14 @@ import initFixture from "../helpers/initFixture";
 import { LERNA_BIN } from "../helpers/constants";
 
 const installInDir = (cwd) =>
-  execa("npm", ["install", "--cache-min=99999", "--silent"], { cwd });
+  execa("npm", ["install", "--cache-min=99999"], { cwd });
+
+const npmTestInDir = (cwd) =>
+  execa("npm", ["test", "--silent"], { cwd });
 
 describe("lerna run", () => {
 
-  test("can run script in packages", () => {
+  test.concurrent("can run script in packages", () => {
     return initFixture("RunCommand/basic").then((cwd) => {
       const args = [
         "run",
@@ -25,10 +28,11 @@ describe("lerna run", () => {
     });
   });
 
-  test("can run script in packages through npm lifecycle hook", () => {
+  test.concurrent("can run script in packages through npm lifecycle hook", () => {
     return initFixture("RunCommand/integration-lifecycle").then((cwd) => {
       return Promise.resolve()
         .then(() => installInDir(cwd))
+        .then(() => npmTestInDir(cwd))
         .then((result) => {
           expect(result.stdout).toMatchSnapshot("stdout: simple-npm");
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3930,6 +3930,12 @@ yargs-parser@^4.2.0:
   dependencies:
     camelcase "^3.0.0"
 
+yargs-parser@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
+  dependencies:
+    camelcase "^3.0.0"
+
 yargs@^6.3.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
@@ -3947,6 +3953,24 @@ yargs@^6.3.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
+
+yargs@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.0.2.tgz#115b97df1321823e8b8648e8968c782521221f67"
+  dependencies:
+    camelcase "^3.0.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.2"
+    which-module "^1.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^5.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
## Description
I'm proposing this PR as a possible solution to the problem of the lerna cli tool help maintenance hassle, and the Command options handling in Lerna.

The current implementation should be considered as a draft, or a conversation starter. It could be changed, redesigned, or used as a starting point!

## Motivation and Context
I found it really hard to maintain the list of flags and when to use them in the README.md file manually. I also found the allocation of said flags problematic in the Command implementations as a contributor.

My main goals were the following:
- Provide an in-place configuration for each Command were developers can find and define all the flags they want to provide for each Command.
- Make the Commands and their respective options descriptors available statically so e.g. [yargs](https://github.com/yargs/yargs) or any other cli util could access them without the need of instantiation.
- Provide an API method in the `Command.js` class besides `.getOptions()` called `.getAvailableOptions()` which filters all the options present in the system, and only returns the flags which are applicable to the Command it is called on (this IMHO should not replace the existing `getOptions()` method, because we might need it for flexibility).

All child Commands inherit options defined on the base `Comand` class.

## How Has This Been Tested?
Anyone can test how the new help system works by using the already familiar `--help` flag on the `lerna` command it self, or now with any Lerna command, e.g.:
```
$ lerna bootstrap --help
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
