### PR TITLE
fix: always honour env vars in spawned processes

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -126,11 +126,10 @@ export default class NpmUtilities {
     const opts = {
       cwd: directory,
     };
+    opts.env = Object.assign({}, process.env);
 
     if (registry) {
-      opts.env = Object.assign({}, process.env, {
-        npm_config_registry: registry,
-      });
+      opts.env.npm_config_registry = registry;
     }
 
     return opts;

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -46,7 +46,7 @@ describe("NpmUtilities", () => {
 
     it("should handle missing environment variables", () => {
       process.env = mockEnv;
-      const want = { cwd: "test_dir" };
+      const want = { cwd: "test_dir", env: mockEnv };
       assert.deepEqual(NpmUtilities.getExecOpts("test_dir"), want);
     });
   });

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -1236,6 +1236,10 @@ describe("PublishCommand", () => {
       const publishCommand = new PublishCommand([], {
         cdVersion: "minor"
       });
+      const wantOptsPkg1 = { cwd: path.join(testDir,"packages/package-1"), env: process.env };
+      const wantOptsPkg2 = { cwd: path.join(testDir,"packages/package-2"), env: process.env };
+      const wantOptsPkg3 = { cwd: path.join(testDir,"packages/package-3"), env: process.env };
+      const wantOptsPkg4 = { cwd: path.join(testDir,"packages/package-4"), env: process.env };
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -1259,27 +1263,27 @@ describe("PublishCommand", () => {
           { args: ["git tag -a v1.1.0 -m \"v1.1.0\""] }
         ]],
         [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-          { args: ["npm publish --tag lerna-temp", { cwd: path.join(testDir,"packages/package-1") }] },
-          { args: ["npm publish --tag lerna-temp", { cwd: path.join(testDir,"packages/package-3") }] },
-          { args: ["npm publish --tag lerna-temp", { cwd: path.join(testDir,"packages/package-4") }] },
-          { args: ["npm publish --tag lerna-temp", { cwd: path.join(testDir,"packages/package-2") }] }
+          { args: ["npm publish --tag lerna-temp", wantOptsPkg1] },
+          { args: ["npm publish --tag lerna-temp", wantOptsPkg3] },
+          { args: ["npm publish --tag lerna-temp", wantOptsPkg4] },
+          { args: ["npm publish --tag lerna-temp", wantOptsPkg2] }
         ]],
         [ChildProcessUtilities, "execSync", {}, [
-          { args: ["npm dist-tag ls package-1", { cwd: path.join(testDir,"packages/package-1") }], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
-          { args: ["npm dist-tag rm package-1 lerna-temp", { cwd: path.join(testDir,"packages/package-1") }] },
-          { args: ["npm dist-tag add package-1@1.1.0 latest", { cwd: path.join(testDir,"packages/package-1") }] },
+          { args: ["npm dist-tag ls package-1", wantOptsPkg1], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-1 lerna-temp", wantOptsPkg1] },
+          { args: ["npm dist-tag add package-1@1.1.0 latest", wantOptsPkg1] },
 
-          { args: ["npm dist-tag ls package-3", { cwd: path.join(testDir,"packages/package-3") }], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
-          { args: ["npm dist-tag rm package-3 lerna-temp", { cwd: path.join(testDir,"packages/package-3") }] },
-          { args: ["npm dist-tag add package-3@1.1.0 latest", { cwd: path.join(testDir,"packages/package-3") }] },
+          { args: ["npm dist-tag ls package-3", wantOptsPkg3], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-3 lerna-temp", wantOptsPkg3] },
+          { args: ["npm dist-tag add package-3@1.1.0 latest", wantOptsPkg3] },
 
-          { args: ["npm dist-tag ls package-4", { cwd: path.join(testDir,"packages/package-4") }], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
-          { args: ["npm dist-tag rm package-4 lerna-temp", { cwd: path.join(testDir,"packages/package-4") }] },
-          { args: ["npm dist-tag add package-4@1.1.0 latest", { cwd: path.join(testDir,"packages/package-4") }] },
+          { args: ["npm dist-tag ls package-4", wantOptsPkg4], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-4 lerna-temp", wantOptsPkg4] },
+          { args: ["npm dist-tag add package-4@1.1.0 latest", wantOptsPkg4] },
 
-          { args: ["npm dist-tag ls package-2", { cwd: path.join(testDir,"packages/package-2") }], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
-          { args: ["npm dist-tag rm package-2 lerna-temp", { cwd: path.join(testDir,"packages/package-2") }] },
-          { args: ["npm dist-tag add package-2@1.1.0 latest", { cwd: path.join(testDir,"packages/package-2") }] },
+          { args: ["npm dist-tag ls package-2", wantOptsPkg2], returns: "lerna-temp: 1.1.0\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 lerna-temp", wantOptsPkg2] },
+          { args: ["npm dist-tag add package-2@1.1.0 latest", wantOptsPkg2] },
 
           { args: ["git rev-parse --abbrev-ref HEAD"], returns: "master" },
           { args: ["git push origin master"] },


### PR DESCRIPTION
Environment variables are only passed down to spawned processes when someone provides a registry flag. This is problematic (e.g. #721). I'm trying to fix this problem in this PR.

If this is totally not the right way to solve it please let me know!

## Description
`.getExecOpts()` has been modified to always pass down env vars.

## How Has This Been Tested?
Unit tests are updated, and an additional test has been added as well for the Bootstrap Command ("should always honour env vars").

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
