### PR TITLE
fix: ignore flag handling in Publish Command

### DIFF
--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -13,7 +13,7 @@ export default class UpdatedPackagesCollector {
   constructor(command) {
     this.logger = command.logger;
     this.repository = command.repository;
-    this.packages = command.repository.packages;
+    this.packages = command.filteredPackages;
     this.packageGraph = command.repository.packageGraph;
     this.progressBar = command.progressBar;
     this.flags = command.getOptions();


### PR DESCRIPTION
Fix for #715 

## Description
Publish command used the wrong Command attribute for packages.

## How Has This Been Tested?
Added new unit test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
