### PR TITLE
fix(BootstrapCommand): symlink binaries of scoped packages correctly

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -104,17 +104,20 @@ export default class BootstrapCommand extends Command {
    * @param {Function} callback
    */
   createBinaryLink(src, dest, name, bin, callback) {
+    const safeName = name[0] === "@"
+      ? name.substring(name.indexOf("/") + 1)
+      : name;
     const destBinFolder = path.join(dest, ".bin");
     // The `bin` in a package.json may be either a string or an object.
     // Normalize to an object.
     const bins = typeof bin === "string"
-      ? { [name]: bin }
+      ? { [safeName]: bin }
       : bin;
     const srcBinFiles = [];
     const destBinFiles = [];
-    Object.keys(bins).forEach((name) => {
-      srcBinFiles.push(path.join(src, bins[name]));
-      destBinFiles.push(path.join(destBinFolder, name));
+    Object.keys(bins).forEach((binName) => {
+      srcBinFiles.push(path.join(src, bins[binName]));
+      destBinFiles.push(path.join(destBinFolder, binName));
     });
     // make sure when have a destination folder (node_modules/.bin)
     const actions = [(cb) => FileSystemUtilities.mkdirp(destBinFolder, cb)];

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -235,7 +235,7 @@ describe("BootstrapCommand", () => {
             "package-1 should be symlinked to package-3"
           );
           assert.equal(
-            normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "package-2"))),
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "@test", "package-2"))),
             normalize(path.join(testDir, "packages", "package-2")),
             "package-2 should be symlinked to package-3"
           );
@@ -342,7 +342,7 @@ describe("BootstrapCommand", () => {
             "package-1 should be symlinked to package-3"
           );
           assert.equal(
-            normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "package-2"))),
+            normalize(resolveSymlink(path.join(testDir, "packages", "package-3", "node_modules", "@test", "package-2"))),
             normalize(path.join(testDir, "packages", "package-2")),
             "package-2 should be symlinked to package-3"
           );

--- a/test/fixtures/BootstrapCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "package-2",
+  "name": "@test/package-2",
   "version": "1.0.0",
   "bin": "cli.js",
   "dependencies": {

--- a/test/fixtures/BootstrapCommand/basic/packages/package-3/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-3/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@test/package-1": "^1.0.0",
-    "package-2": "^1.0.0",
+    "@test/package-2": "^1.0.0",
     "foo": "0.1.12"
   }
 }


### PR DESCRIPTION
## Description
While working on #714, I found that binaries from scoped packages weren't being made correctly.

## Motivation and Context
When `npm` makes a symlink to `@foo/bar`'s CLI, it is available at `./node_modules/.bin/bar`.
Prior to this PR, `lerna` was making the equivalent symlink at `./node_modules/.bin/@foo/bar`.

## How Has This Been Tested?
Updated existing test cases.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
