### PR TITLE
fix(PackageUtilities): remove public API, it's broken anyway

### DIFF
--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -7,28 +7,6 @@ import minimatch from "minimatch";
 import async from "async";
 
 export default class PackageUtilities {
-  static getGlobalVersion(versionPath) {
-    if (FileSystemUtilities.existsSync(versionPath)) {
-      return FileSystemUtilities.readFileSync(versionPath);
-    }
-  }
-
-  static getPackagesPath(rootPath) {
-    return path.join(rootPath, "packages");
-  }
-
-  static getPackagePath(packagesPath, name) {
-    return path.join(packagesPath, name);
-  }
-
-  static getPackageConfigPath(packagesPath, name) {
-    return path.join(PackageUtilities.getPackagePath(packagesPath, name), "package.json");
-  }
-
-  static getPackageConfig(packagesPath, name) {
-    return require(PackageUtilities.getPackageConfigPath(packagesPath, name));
-  }
-
   static getPackages({
     packageConfigs,
     rootPath,

--- a/src/index.js
+++ b/src/index.js
@@ -22,11 +22,3 @@ export const __commands__ = exposeCommands([
   ExecCommand,
   LsCommand,
 ]);
-
-import PackageUtilities from "./PackageUtilities";
-
-export const getPackagesPath = PackageUtilities.getPackagesPath;
-export const getPackagePath = PackageUtilities.getPackagePath;
-export const getPackageConfigPath = PackageUtilities.getPackageConfigPath;
-export const getPackageConfig = PackageUtilities.getPackageConfig;
-export const getPackages = PackageUtilities.getPackages;

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -7,65 +7,21 @@ import Repository from "../src/Repository";
 import initFixture from "./helpers/initFixture";
 
 describe("PackageUtilities", () => {
-  describe("public API", () => {
+  describe(".getPackages()", () => {
     let testDir;
 
     beforeEach(() => initFixture("PackageUtilities/basic").then((dir) => {
       testDir = dir;
     }));
 
-    describe(".getPackagesPath()", () => {
-      it("should append the packages path to the repo path given", () => {
-        assert.equal(
-          PackageUtilities.getPackagesPath("/path/to/repo"),
-          path.join("/path/to/repo/packages")
-        );
-      });
-    });
+    it("should collect all the packages from the given packages directory", () => {
+      const result = PackageUtilities.getPackages(new Repository());
 
-    describe(".getPackagePath()", () => {
-      it("should append the package path to the packages path given", () => {
-        assert.equal(
-          PackageUtilities.getPackagePath("/path/to/repo/packages", "my-package"),
-          path.join("/path/to/repo/packages/my-package")
-        );
-      });
-    });
-
-    describe(".getPackageConfigPath()", () => {
-      it("should append the package config path to the packages path given", () => {
-        assert.equal(
-          PackageUtilities.getPackageConfigPath("/path/to/repo/packages", "my-package"),
-          path.join("/path/to/repo/packages/my-package/package.json")
-        );
-      });
-    });
-
-    describe(".getPackageConfig()", () => {
-      it("should get the config file for the given package in the given packages directory", () => {
-        const fixture = path.join(testDir, "packages");
-
-        assert.deepEqual(
-          PackageUtilities.getPackageConfig(fixture, "package-1"),
-          {
-            name: "package-1",
-            version: "1.0.0"
-          }
-        );
-      });
-    });
-
-    describe(".getPackages()", () => {
-      it("should collect all the packages from the given packages directory", () => {
-        const fixture = path.join(testDir, "packages");
-        const result = PackageUtilities.getPackages(new Repository);
-
-        assert.equal(result.length, 4);
-        assert(result[0] instanceof Package);
-        assert.equal(result[0].name, "package-1");
-        assert.equal(result[0].version, "1.0.0");
-        assert.equal(result[0].location, path.join(fixture, "package-1"));
-      });
+      assert.equal(result.length, 4);
+      assert(result[0] instanceof Package);
+      assert.equal(result[0].name, "package-1");
+      assert.equal(result[0].version, "1.0.0");
+      assert.equal(result[0].location, path.join(testDir, "packages", "package-1"));
     });
   });
 


### PR DESCRIPTION
## Description
Remove the public exports of various unused/broken `PackageUtilities` methods. Additionally, completely remove the unused `PackageUtilities.getGlobalVersion()` method.

## Motivation and Context
This was broken anyway, and we can provide better interaction through `--json` output (and the like) for various interrogative subcommands (`ls`, `updated`, etc).

These were discovered while working on #714.

## How Has This Been Tested?
N/A

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
