### PR TITLE
Commands: pass execOpts to all utilities executions

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -48,6 +48,16 @@ export default class Command {
     return this.constructor.name;
   }
 
+  get execOpts() {
+    if (!this._execOpts) {
+      this._execOpts = {
+        cwd: this.repository.rootPath,
+      };
+    }
+
+    return this._execOpts;
+  }
+
   // Override this to inherit config from another command.
   // For example `updated` inherits config from `publish`.
   get otherCommandConfigs() {

--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -13,20 +13,21 @@ const CHANGELOG_HEADER = dedent(`# Change Log
 
 export default class ConventionalCommitUtilities {
   @logger.logifySync()
-  static recommendVersion(pkg) {
+  static recommendVersion(pkg, opts) {
     const name = pkg.name;
     const version = pkg.version;
     const pkgLocation = pkg.location;
 
     const recommendedBump = ChildProcessUtilities.execSync(
-      `${require.resolve("conventional-recommended-bump/cli.js")} -l ${name} --commit-path=${pkgLocation} -p angular`
+      `${require.resolve("conventional-recommended-bump/cli.js")} -l ${name} --commit-path=${pkgLocation} -p angular`,
+      opts
     );
 
     return semver.inc(version, recommendedBump);
   }
 
   @logger.logifySync()
-  static updateChangelog(pkg) {
+  static updateChangelog(pkg, opts) {
     const name = pkg.name;
     const pkgLocation = pkg.location;
     const changelogLocation = ConventionalCommitUtilities.changelogLocation(pkg);
@@ -39,7 +40,8 @@ export default class ConventionalCommitUtilities {
     // run conventional-changelog-cli to generate the markdown
     // for the upcoming release.
     const newEntry = ChildProcessUtilities.execSync(
-      `${require.resolve("conventional-changelog-cli/cli.js")} -l ${name} --commit-path=${pkgLocation} --pkg=${path.join(pkgLocation, "package.json")} -p angular`
+      `${require.resolve("conventional-changelog-cli/cli.js")} -l ${name} --commit-path=${pkgLocation} --pkg=${path.join(pkgLocation, "package.json")} -p angular`,
+      opts
     );
 
     // CHANGELOG entries start with <a name=, we remove

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -4,16 +4,18 @@ import escapeArgs from "command-join";
 
 export default class GitUtilities {
   @logger.logifySync()
-  static isDetachedHead() {
-    const branchName = GitUtilities.getCurrentBranch();
+  static isDetachedHead(opts) {
+    const branchName = GitUtilities.getCurrentBranch(opts);
     return branchName === "HEAD";
   }
 
   @logger.logifySync()
-  static isInitialized(cwd) {
+  static isInitialized(opts) {
     try {
       // we only want the return code, so ignore stdout/stderr
-      ChildProcessUtilities.execSync("git rev-parse", { cwd, stdio: "ignore" });
+      ChildProcessUtilities.execSync("git rev-parse", Object.assign({}, opts, {
+        stdio: "ignore"
+      }));
       return true;
     } catch (err) {
       return false;
@@ -21,92 +23,93 @@ export default class GitUtilities {
   }
 
   @logger.logifySync()
-  static addFile(file) {
-    ChildProcessUtilities.execSync("git add " + escapeArgs(file));
+  static addFile(file, opts) {
+    ChildProcessUtilities.execSync("git add " + escapeArgs(file), opts);
   }
 
   @logger.logifySync()
-  static commit(message) {
+  static commit(message, opts) {
     // Use echo to allow multi\nline strings.
-    ChildProcessUtilities.execSync("git commit -m \"$(echo \"" + message + "\")\"");
+    ChildProcessUtilities.execSync("git commit -m \"$(echo \"" + message + "\")\"", opts);
   }
 
   @logger.logifySync()
-  static addTag(tag) {
-    ChildProcessUtilities.execSync("git tag -a " + tag + " -m \"" + tag + "\"");
+  static addTag(tag, opts) {
+    ChildProcessUtilities.execSync("git tag -a " + tag + " -m \"" + tag + "\"", opts);
   }
 
   @logger.logifySync()
-  static removeTag(tag) {
-    ChildProcessUtilities.execSync("git tag -d " + tag);
+  static removeTag(tag, opts) {
+    ChildProcessUtilities.execSync("git tag -d " + tag, opts);
   }
 
   @logger.logifySync()
-  static hasTags() {
-    return !!ChildProcessUtilities.execSync("git tag");
+  static hasTags(opts) {
+    return !!ChildProcessUtilities.execSync("git tag", opts);
   }
 
   @logger.logifySync()
-  static getLastTaggedCommit() {
-    return ChildProcessUtilities.execSync("git rev-list --tags --max-count=1");
+  static getLastTaggedCommit(opts) {
+    return ChildProcessUtilities.execSync("git rev-list --tags --max-count=1", opts);
   }
 
   @logger.logifySync()
-  static getLastTaggedCommitInBranch() {
-    const tagName = GitUtilities.getLastTag();
-    return ChildProcessUtilities.execSync("git rev-list -n 1 " + tagName);
+  static getLastTaggedCommitInBranch(opts) {
+    const tagName = GitUtilities.getLastTag(opts);
+    return ChildProcessUtilities.execSync("git rev-list -n 1 " + tagName, opts);
   }
 
   @logger.logifySync()
-  static getFirstCommit() {
-    return ChildProcessUtilities.execSync("git rev-list --max-parents=0 HEAD");
+  static getFirstCommit(opts) {
+    return ChildProcessUtilities.execSync("git rev-list --max-parents=0 HEAD", opts);
   }
 
   @logger.logifySync()
-  static pushWithTags(remote, tags) {
-    ChildProcessUtilities.execSync(`git push ${remote} ${GitUtilities.getCurrentBranch()}`);
-    ChildProcessUtilities.execSync(`git push ${remote} ${tags.join(" ")}`);
+  static pushWithTags(remote, tags, opts) {
+    const branch = GitUtilities.getCurrentBranch(opts);
+    ChildProcessUtilities.execSync(`git push ${remote} ${branch}`, opts);
+    ChildProcessUtilities.execSync(`git push ${remote} ${tags.join(" ")}`, opts);
   }
 
   @logger.logifySync()
-  static getLastTag() {
-    return ChildProcessUtilities.execSync("git describe --tags --abbrev=0");
+  static getLastTag(opts) {
+    return ChildProcessUtilities.execSync("git describe --tags --abbrev=0", opts);
   }
 
   @logger.logifySync()
-  static describeTag(commit) {
-    return ChildProcessUtilities.execSync("git describe --tags " + commit);
+  static describeTag(commit, opts) {
+    return ChildProcessUtilities.execSync("git describe --tags " + commit, opts);
   }
 
   @logger.logifySync()
-  static diffSinceIn(since, location) {
-    return ChildProcessUtilities.execSync("git diff --name-only " + since + " -- " + escapeArgs(location));
+  static diffSinceIn(since, location, opts) {
+    return ChildProcessUtilities.execSync("git diff --name-only " + since + " -- " + escapeArgs(location), opts);
   }
 
   @logger.logifySync()
-  static getCurrentBranch() {
-    return ChildProcessUtilities.execSync("git rev-parse --abbrev-ref HEAD");
+  static getCurrentBranch(opts) {
+    return ChildProcessUtilities.execSync("git rev-parse --abbrev-ref HEAD", opts);
   }
 
   @logger.logifySync()
-  static getCurrentSHA() {
-    return ChildProcessUtilities.execSync("git rev-parse HEAD");
+  static getCurrentSHA(opts) {
+    return ChildProcessUtilities.execSync("git rev-parse HEAD", opts);
   }
 
   @logger.logifySync()
-  static checkoutChanges(changes) {
-    ChildProcessUtilities.execSync("git checkout -- " + changes);
+  static checkoutChanges(changes, opts) {
+    ChildProcessUtilities.execSync("git checkout -- " + changes, opts);
   }
 
   @logger.logifySync()
-  static init(cwd) {
-    return ChildProcessUtilities.execSync("git init", { cwd });
+  static init(opts) {
+    return ChildProcessUtilities.execSync("git init", opts);
   }
 
   @logger.logifySync()
-  static hasCommit() {
+  static hasCommit(opts) {
     try {
-      ChildProcessUtilities.execSync("git log");
+      ChildProcessUtilities.execSync("git log", opts);
       return true;
     } catch (e) {
       return false;

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -11,6 +11,7 @@ class Update {
 
 export default class UpdatedPackagesCollector {
   constructor(command) {
+    this.execOpts = command.execOpts;
     this.logger = command.logger;
     this.repository = command.repository;
     this.packages = command.filteredPackages;
@@ -28,10 +29,10 @@ export default class UpdatedPackagesCollector {
   collectUpdatedPackages() {
     this.logger.info("Checking for updated packages...");
 
-    const hasTags = GitUtilities.hasTags();
+    const hasTags = GitUtilities.hasTags(this.execOpts);
 
     if (hasTags) {
-      const tag = GitUtilities.getLastTag();
+      const tag = GitUtilities.getLastTag(this.execOpts);
       this.logger.info("Comparing with: " + tag);
     } else {
       this.logger.info("No tags found! Comparing with initial commit.");
@@ -47,12 +48,12 @@ export default class UpdatedPackagesCollector {
       if (this.flags.canary !== true) {
         currentSHA = this.flags.canary;
       } else {
-        currentSHA = GitUtilities.getCurrentSHA();
+        currentSHA = GitUtilities.getCurrentSHA(this.execOpts);
       }
 
       commits = this.getAssociatedCommits(currentSHA);
     } else if (hasTags) {
-      commits = GitUtilities.describeTag(GitUtilities.getLastTaggedCommitInBranch());
+      commits = GitUtilities.describeTag(GitUtilities.getLastTaggedCommitInBranch(this.execOpts), this.execOpts);
     }
 
     const updatedPackages = {};
@@ -145,7 +146,7 @@ export default class UpdatedPackagesCollector {
 
   hasDiffSinceThatIsntIgnored(pkg, commits) {
     const folder = path.relative(this.repository.rootPath, pkg.location);
-    const diff = GitUtilities.diffSinceIn(commits, pkg.location);
+    const diff = GitUtilities.diffSinceIn(commits, pkg.location, this.execOpts);
 
     if (diff === "") {
       return false;

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -3,12 +3,12 @@ import Command from "../Command";
 import ChildProcessUtilities from "../ChildProcessUtilities";
 import find from "lodash/find";
 
-function getLastCommit() {
-  if (GitUtilities.hasTags()) {
-    return GitUtilities.getLastTaggedCommit();
+function getLastCommit(execOpts) {
+  if (GitUtilities.hasTags(execOpts)) {
+    return GitUtilities.getLastTaggedCommit(execOpts);
   }
 
-  return GitUtilities.getFirstCommit();
+  return GitUtilities.getFirstCommit(execOpts);
 }
 
 export default class DiffCommand extends Command {
@@ -28,15 +28,12 @@ export default class DiffCommand extends Command {
       }
     }
 
-    if (!GitUtilities.hasCommit()) {
+    if (!GitUtilities.hasCommit(this.execOpts)) {
       callback(new Error("Can't diff. There are no commits in this repository, yet."));
       return;
     }
 
-    this.args = ["diff", getLastCommit(), "--color=auto"];
-    this.opts = {
-      cwd: this.repository.rootPath,
-    };
+    this.args = ["diff", getLastCommit(this.execOpts), "--color=auto"];
 
     if (targetPackage) {
       this.args.push("--", targetPackage.location);
@@ -46,7 +43,7 @@ export default class DiffCommand extends Command {
   }
 
   execute(callback) {
-    ChildProcessUtilities.spawn("git", this.args, this.opts, (code) => {
+    ChildProcessUtilities.spawn("git", this.args, this.execOpts, (code) => {
       if (code) {
         callback(new Error("Errored while spawning `git diff`."));
       } else {

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -11,9 +11,9 @@ export default class InitCommand extends Command {
   runPreparations() {}
 
   initialize(callback) {
-    if (!GitUtilities.isInitialized(this.repository.rootPath)) {
+    if (!GitUtilities.isInitialized(this.execOpts)) {
       this.logger.info("Initializing Git repository.");
-      GitUtilities.init(this.repository.rootPath);
+      GitUtilities.init(this.execOpts);
     }
 
     this.exact = this.getOptions().exact;

--- a/test/ConventionalCommitUtilities.js
+++ b/test/ConventionalCommitUtilities.js
@@ -18,15 +18,18 @@ describe("ConventionalCommitUtilities", () => {
     it("should invoke conventional-changelog-recommended bump to fetch next version", () => {
       ChildProcessUtilities.execSync = jest.fn(() => "major");
 
+      const opts = { cwd: "test" };
+
       const recommendVersion = ConventionalCommitUtilities.recommendVersion({
         name: "bar",
         version: "1.0.0",
         location: "/foo/bar",
-      });
+      }, opts);
 
       expect(recommendVersion).toBe("2.0.0");
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         `${require.resolve("conventional-recommended-bump/cli.js")} -l bar --commit-path=/foo/bar -p angular`,
+        opts,
       );
     });
   });
@@ -36,16 +39,19 @@ describe("ConventionalCommitUtilities", () => {
       FileSystemUtilities.existsSync = jest.fn(() => false);
       ChildProcessUtilities.execSync = jest.fn(() => "<a name='change' />feat: I should be placed in the CHANGELOG");
 
+      const opts = { cwd: "test" };
+
       ConventionalCommitUtilities.updateChangelog({
         name: "bar",
         location: "/foo/bar"
-      });
+      }, opts);
 
       expect(FileSystemUtilities.existsSync).lastCalledWith(
         path.normalize("/foo/bar/CHANGELOG.md")
       );
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         `${require.resolve("conventional-changelog-cli/cli.js")} -l bar --commit-path=/foo/bar --pkg=${path.normalize("/foo/bar/package.json")} -p angular`,
+        opts,
       );
       expect(FileSystemUtilities.writeFileSync).lastCalledWith(
         path.normalize("/foo/bar/CHANGELOG.md"),

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -46,7 +46,9 @@ describe("DiffCommand", () => {
             "beefcafe",
             "--color=auto",
           ],
-          { cwd: testDir },
+          expect.objectContaining({
+            cwd: testDir,
+          }),
           expect.any(Function)
         );
         done();
@@ -76,7 +78,9 @@ describe("DiffCommand", () => {
             "cafedead",
             "--color=auto",
           ],
-          { cwd: testDir },
+          expect.objectContaining({
+            cwd: testDir,
+          }),
           expect.any(Function)
         );
         done();
@@ -107,7 +111,9 @@ describe("DiffCommand", () => {
             "--",
             path.join(testDir, "packages/package-1"),
           ],
-          { cwd: testDir },
+          expect.objectContaining({
+            cwd: testDir,
+          }),
           expect.any(Function)
         );
         done();

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -26,11 +26,18 @@ describe("GitUtilities", () => {
       GitUtilities.getCurrentBranch = jest.fn(() => "master");
       expect(GitUtilities.isDetachedHead()).toBe(false);
     });
+
+    it("passes opts to getCurrentBranch()", () => {
+      GitUtilities.getCurrentBranch = jest.fn();
+      const opts = { cwd: "test" };
+      GitUtilities.isDetachedHead(opts);
+      expect(GitUtilities.getCurrentBranch).lastCalledWith(opts);
+    });
   });
 
   describe(".isInitialized()", () => {
     it("returns true when git command succeeds", () => {
-      expect(GitUtilities.isInitialized("test")).toBe(true);
+      expect(GitUtilities.isInitialized({ cwd: "test" })).toBe(true);
       expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse", { cwd: "test", stdio: "ignore" });
     });
 
@@ -45,42 +52,48 @@ describe("GitUtilities", () => {
 
   describe(".addFile()", () => {
     it("calls git add with file argument", () => {
-      GitUtilities.addFile("foo");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git add foo");
+      const opts = { cwd: "test" };
+      GitUtilities.addFile("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git add foo", opts);
     });
   });
 
   describe(".commit()", () => {
     it("calls git commit with message", () => {
-      GitUtilities.commit("foo");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git commit -m \"$(echo \"foo\")\"");
+      const opts = { cwd: "oneline" };
+      GitUtilities.commit("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git commit -m \"$(echo \"foo\")\"", opts);
     });
 
     it("allows multiline message", () => {
-      GitUtilities.commit(`foo${EOL}bar`);
-      expect(ChildProcessUtilities.execSync).lastCalledWith(`git commit -m "$(echo "foo${EOL}bar")"`);
+      const opts = { cwd: "multiline" };
+      GitUtilities.commit(`foo${EOL}bar`, opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(`git commit -m "$(echo "foo${EOL}bar")"`, opts);
     });
   });
 
   describe(".addTag()", () => {
     it("creates annotated git tag", () => {
-      GitUtilities.addTag("foo");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -a foo -m \"foo\"");
+      const opts = { cwd: "test" };
+      GitUtilities.addTag("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -a foo -m \"foo\"", opts);
     });
   });
 
   describe(".removeTag()", () => {
     it("deletes specified git tag", () => {
-      GitUtilities.removeTag("foo");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -d foo");
+      const opts = { cwd: "test" };
+      GitUtilities.removeTag("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -d foo", opts);
     });
   });
 
   describe(".hasTags()", () => {
     it("returns true when one or more git tags exist", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "v1.0.0");
-      expect(GitUtilities.hasTags()).toBe(true);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.hasTags(opts)).toBe(true);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag", opts);
     });
 
     it("returns false when no git tags exist", () => {
@@ -92,8 +105,9 @@ describe("GitUtilities", () => {
   describe(".getLastTaggedCommit()", () => {
     it("returns SHA of closest git tag", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "deadbeef");
-      expect(GitUtilities.getLastTaggedCommit()).toBe("deadbeef");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --tags --max-count=1");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getLastTaggedCommit(opts)).toBe("deadbeef");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --tags --max-count=1", opts);
     });
   });
 
@@ -106,16 +120,18 @@ describe("GitUtilities", () => {
     it("returns SHA of closest git tag in branch", () => {
       GitUtilities.getLastTag = jest.fn(() => "v1.0.0");
       ChildProcessUtilities.execSync.mockImplementation(() => "deadbeef");
-      expect(GitUtilities.getLastTaggedCommitInBranch()).toBe("deadbeef");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list -n 1 v1.0.0");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getLastTaggedCommitInBranch(opts)).toBe("deadbeef");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list -n 1 v1.0.0", opts);
     });
   });
 
   describe(".getFirstCommit()", () => {
     it("returns SHA of first commit", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "beefcafe");
-      expect(GitUtilities.getFirstCommit()).toBe("beefcafe");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --max-parents=0 HEAD");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getFirstCommit(opts)).toBe("beefcafe");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --max-parents=0 HEAD", opts);
     });
   });
 
@@ -127,71 +143,80 @@ describe("GitUtilities", () => {
 
     it("pushes current branch and specified tag(s) to origin", () => {
       GitUtilities.getCurrentBranch = jest.fn(() => "master");
-      GitUtilities.pushWithTags("origin", ["foo@1.0.1", "foo-bar@1.0.0"]);
-      expect(ChildProcessUtilities.execSync).toBeCalledWith("git push origin master");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git push origin foo@1.0.1 foo-bar@1.0.0");
+      const opts = { cwd: "test" };
+      GitUtilities.pushWithTags("origin", ["foo@1.0.1", "foo-bar@1.0.0"], opts);
+      expect(ChildProcessUtilities.execSync).toBeCalledWith("git push origin master", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git push origin foo@1.0.1 foo-bar@1.0.0", opts);
     });
   });
 
   describe(".getLastTag()", () => {
     it("returns the closest tag", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "v1.0.0");
-      expect(GitUtilities.getLastTag()).toBe("v1.0.0");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags --abbrev=0");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getLastTag(opts)).toBe("v1.0.0");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags --abbrev=0", opts);
     });
   });
 
   describe(".describeTag()", () => {
     it("returns description of specified tag", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "foo@1.0.0");
-      expect(GitUtilities.describeTag("deadbeef")).toBe("foo@1.0.0");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags deadbeef");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.describeTag("deadbeef", opts)).toBe("foo@1.0.0");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags deadbeef", opts);
     });
   });
 
   describe(".diffSinceIn()", () => {
     it("returns list of files changed since commit at location", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "files");
-      expect(GitUtilities.diffSinceIn("foo@1.0.0", "packages/foo")).toBe("files");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git diff --name-only foo@1.0.0 -- packages/foo");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.diffSinceIn("foo@1.0.0", "packages/foo", opts)).toBe("files");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git diff --name-only foo@1.0.0 -- packages/foo", opts);
     });
   });
 
   describe(".getCurrentBranch()", () => {
     it("calls `git rev-parse --abbrev-ref HEAD`", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "master");
-      expect(GitUtilities.getCurrentBranch()).toBe("master");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse --abbrev-ref HEAD");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getCurrentBranch(opts)).toBe("master");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse --abbrev-ref HEAD", opts);
     });
   });
 
   describe(".getCurrentSHA()", () => {
     it("returns SHA of current ref", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "deadcafe");
-      expect(GitUtilities.getCurrentSHA()).toBe("deadcafe");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse HEAD");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getCurrentSHA(opts)).toBe("deadcafe");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse HEAD", opts);
     });
   });
 
   describe(".checkoutChanges()", () => {
     it("calls git checkout with specified arg", () => {
-      GitUtilities.checkoutChanges("packages/*/package.json");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git checkout -- packages/*/package.json");
+      const opts = { cwd: "test" };
+      GitUtilities.checkoutChanges("packages/*/package.json", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git checkout -- packages/*/package.json", opts);
     });
   });
 
   describe(".init()", () => {
     it("calls git init", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "stdout for logger");
-      expect(GitUtilities.init("test")).toBe("stdout for logger");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git init", { cwd: "test" });
+      const opts = { cwd: "test" };
+      expect(GitUtilities.init(opts)).toBe("stdout for logger");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git init", opts);
     });
   });
 
   describe(".hasCommit()", () => {
     it("returns true when git command succeeds", () => {
-      expect(GitUtilities.hasCommit()).toBe(true);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git log");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.hasCommit(opts)).toBe(true);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git log", opts);
     });
 
     it("returns false when git command fails", () => {

--- a/test/InitCommand.js
+++ b/test/InitCommand.js
@@ -77,7 +77,11 @@ describe("InitCommand", () => {
         try {
           expect(code).toBe(0);
 
-          expect(GitUtilities.init).toBeCalled();
+          const execOpts = expect.objectContaining({
+            cwd: testDir,
+          });
+          expect(GitUtilities.isInitialized).lastCalledWith(execOpts);
+          expect(GitUtilities.init).lastCalledWith(execOpts);
 
           expect(writeJsonFile.sync).lastCalledWith(
             path.join(testDir, "lerna.json"),

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -85,18 +85,6 @@ exports[`[independent] git commit message 1`] = `
  - package-4@1.1.0"
 `;
 
-exports[`[independent] git push <remote> [tags] 1`] = `
-Array [
-  "origin",
-  Array [
-    "package-1@1.0.1",
-    "package-2@1.1.0",
-    "package-3@2.0.0",
-    "package-4@1.1.0",
-  ],
-]
-`;
-
 exports[`[independent] git tags added 1`] = `
 Array [
   "package-1@1.0.1",
@@ -218,15 +206,6 @@ Array [
   "packages/package-3/package.json",
   "packages/package-4/package.json",
   "packages/package-5/package.json",
-]
-`;
-
-exports[`[normal] git push <remote> [tags] 1`] = `
-Array [
-  "origin",
-  Array [
-    "v1.0.1",
-  ],
 ]
 `;
 


### PR DESCRIPTION
## Description
Pass `opts.cwd` to all utility executions (in addition to existing `opts`, if present).

## Motivation and Context
This aims to remove any implicit reliance on `process.cwd()`, improving consistency and laying more groundwork for concurrent unit tests.

This builds on the work done in #714.

## How Has This Been Tested?
Updated existing unit test suite.

## Types of changes
- [x] Internal

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
