### PR TITLE
Command: pass explicit CWD to Repository constructor

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -10,13 +10,13 @@ import logger from "./logger";
 const DEFAULT_CONCURRENCY = 4;
 
 export default class Command {
-  constructor(input, flags) {
+  constructor(input, flags, cwd) {
     this.input = input;
     this.flags = flags;
 
     this.lernaVersion = require("../package.json").version;
     this.logger = logger;
-    this.repository = new Repository();
+    this.repository = new Repository(cwd);
     this.progressBar = progressBar;
   }
 

--- a/src/Command.js
+++ b/src/Command.js
@@ -233,7 +233,7 @@ export default class Command {
 
   _complete(err, code, callback) {
     if (code !== 0) {
-      const exitHandler = new ExitHandler();
+      const exitHandler = new ExitHandler(this.repository.rootPath);
       exitHandler.writeLogs(this.logger);
     }
 

--- a/src/Command.js
+++ b/src/Command.js
@@ -48,6 +48,16 @@ export default class Command {
     return this.constructor.name;
   }
 
+  get execOpts() {
+    if (!this._execOpts) {
+      this._execOpts = {
+        cwd: this.repository.rootPath,
+      };
+    }
+
+    return this._execOpts;
+  }
+
   // Override this to inherit config from another command.
   // For example `updated` inherits config from `publish`.
   get otherCommandConfigs() {

--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -13,20 +13,21 @@ const CHANGELOG_HEADER = dedent(`# Change Log
 
 export default class ConventionalCommitUtilities {
   @logger.logifySync()
-  static recommendVersion(pkg) {
+  static recommendVersion(pkg, opts) {
     const name = pkg.name;
     const version = pkg.version;
     const pkgLocation = pkg.location;
 
     const recommendedBump = ChildProcessUtilities.execSync(
-      `${require.resolve("conventional-recommended-bump/cli.js")} -l ${name} --commit-path=${pkgLocation} -p angular`
+      `${require.resolve("conventional-recommended-bump/cli.js")} -l ${name} --commit-path=${pkgLocation} -p angular`,
+      opts
     );
 
     return semver.inc(version, recommendedBump);
   }
 
   @logger.logifySync()
-  static updateChangelog(pkg) {
+  static updateChangelog(pkg, opts) {
     const name = pkg.name;
     const pkgLocation = pkg.location;
     const changelogLocation = ConventionalCommitUtilities.changelogLocation(pkg);
@@ -39,7 +40,8 @@ export default class ConventionalCommitUtilities {
     // run conventional-changelog-cli to generate the markdown
     // for the upcoming release.
     const newEntry = ChildProcessUtilities.execSync(
-      `${require.resolve("conventional-changelog-cli/cli.js")} -l ${name} --commit-path=${pkgLocation} --pkg=${path.join(pkgLocation, "package.json")} -p angular`
+      `${require.resolve("conventional-changelog-cli/cli.js")} -l ${name} --commit-path=${pkgLocation} --pkg=${path.join(pkgLocation, "package.json")} -p angular`,
+      opts
     );
 
     // CHANGELOG entries start with <a name=, we remove

--- a/src/ExitHandler.js
+++ b/src/ExitHandler.js
@@ -3,12 +3,13 @@ import path from "path";
 import padEnd from "lodash/padEnd";
 
 export default class ExitHandler {
-  constructor() {
+  constructor(cwd) {
+    this.cwd = cwd;
     this.errorsSeen = {};
   }
 
   writeLogs(logger) {
-    const filePath = path.join(process.cwd(), "lerna-debug.log");
+    const filePath = path.join(this.cwd, "lerna-debug.log");
     const fileContent = this._formatLogs(logger.logs);
 
     FileSystemUtilities.writeFileSync(filePath, fileContent);

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -4,16 +4,18 @@ import escapeArgs from "command-join";
 
 export default class GitUtilities {
   @logger.logifySync()
-  static isDetachedHead() {
-    const branchName = GitUtilities.getCurrentBranch();
+  static isDetachedHead(opts) {
+    const branchName = GitUtilities.getCurrentBranch(opts);
     return branchName === "HEAD";
   }
 
   @logger.logifySync()
-  static isInitialized(cwd) {
+  static isInitialized(opts) {
     try {
       // we only want the return code, so ignore stdout/stderr
-      ChildProcessUtilities.execSync("git rev-parse", { cwd, stdio: "ignore" });
+      ChildProcessUtilities.execSync("git rev-parse", Object.assign({}, opts, {
+        stdio: "ignore"
+      }));
       return true;
     } catch (err) {
       return false;
@@ -21,92 +23,93 @@ export default class GitUtilities {
   }
 
   @logger.logifySync()
-  static addFile(file) {
-    ChildProcessUtilities.execSync("git add " + escapeArgs(file));
+  static addFile(file, opts) {
+    ChildProcessUtilities.execSync("git add " + escapeArgs(file), opts);
   }
 
   @logger.logifySync()
-  static commit(message) {
+  static commit(message, opts) {
     // Use echo to allow multi\nline strings.
-    ChildProcessUtilities.execSync("git commit -m \"$(echo \"" + message + "\")\"");
+    ChildProcessUtilities.execSync("git commit -m \"$(echo \"" + message + "\")\"", opts);
   }
 
   @logger.logifySync()
-  static addTag(tag) {
-    ChildProcessUtilities.execSync("git tag -a " + tag + " -m \"" + tag + "\"");
+  static addTag(tag, opts) {
+    ChildProcessUtilities.execSync("git tag -a " + tag + " -m \"" + tag + "\"", opts);
   }
 
   @logger.logifySync()
-  static removeTag(tag) {
-    ChildProcessUtilities.execSync("git tag -d " + tag);
+  static removeTag(tag, opts) {
+    ChildProcessUtilities.execSync("git tag -d " + tag, opts);
   }
 
   @logger.logifySync()
-  static hasTags() {
-    return !!ChildProcessUtilities.execSync("git tag");
+  static hasTags(opts) {
+    return !!ChildProcessUtilities.execSync("git tag", opts);
   }
 
   @logger.logifySync()
-  static getLastTaggedCommit() {
-    return ChildProcessUtilities.execSync("git rev-list --tags --max-count=1");
+  static getLastTaggedCommit(opts) {
+    return ChildProcessUtilities.execSync("git rev-list --tags --max-count=1", opts);
   }
 
   @logger.logifySync()
-  static getLastTaggedCommitInBranch() {
-    const tagName = GitUtilities.getLastTag();
-    return ChildProcessUtilities.execSync("git rev-list -n 1 " + tagName);
+  static getLastTaggedCommitInBranch(opts) {
+    const tagName = GitUtilities.getLastTag(opts);
+    return ChildProcessUtilities.execSync("git rev-list -n 1 " + tagName, opts);
   }
 
   @logger.logifySync()
-  static getFirstCommit() {
-    return ChildProcessUtilities.execSync("git rev-list --max-parents=0 HEAD");
+  static getFirstCommit(opts) {
+    return ChildProcessUtilities.execSync("git rev-list --max-parents=0 HEAD", opts);
   }
 
   @logger.logifySync()
-  static pushWithTags(remote, tags) {
-    ChildProcessUtilities.execSync(`git push ${remote} ${GitUtilities.getCurrentBranch()}`);
-    ChildProcessUtilities.execSync(`git push ${remote} ${tags.join(" ")}`);
+  static pushWithTags(remote, tags, opts) {
+    const branch = GitUtilities.getCurrentBranch(opts);
+    ChildProcessUtilities.execSync(`git push ${remote} ${branch}`, opts);
+    ChildProcessUtilities.execSync(`git push ${remote} ${tags.join(" ")}`, opts);
   }
 
   @logger.logifySync()
-  static getLastTag() {
-    return ChildProcessUtilities.execSync("git describe --tags --abbrev=0");
+  static getLastTag(opts) {
+    return ChildProcessUtilities.execSync("git describe --tags --abbrev=0", opts);
   }
 
   @logger.logifySync()
-  static describeTag(commit) {
-    return ChildProcessUtilities.execSync("git describe --tags " + commit);
+  static describeTag(commit, opts) {
+    return ChildProcessUtilities.execSync("git describe --tags " + commit, opts);
   }
 
   @logger.logifySync()
-  static diffSinceIn(since, location) {
-    return ChildProcessUtilities.execSync("git diff --name-only " + since + " -- " + escapeArgs(location));
+  static diffSinceIn(since, location, opts) {
+    return ChildProcessUtilities.execSync("git diff --name-only " + since + " -- " + escapeArgs(location), opts);
   }
 
   @logger.logifySync()
-  static getCurrentBranch() {
-    return ChildProcessUtilities.execSync("git rev-parse --abbrev-ref HEAD");
+  static getCurrentBranch(opts) {
+    return ChildProcessUtilities.execSync("git rev-parse --abbrev-ref HEAD", opts);
   }
 
   @logger.logifySync()
-  static getCurrentSHA() {
-    return ChildProcessUtilities.execSync("git rev-parse HEAD");
+  static getCurrentSHA(opts) {
+    return ChildProcessUtilities.execSync("git rev-parse HEAD", opts);
   }
 
   @logger.logifySync()
-  static checkoutChanges(changes) {
-    ChildProcessUtilities.execSync("git checkout -- " + changes);
+  static checkoutChanges(changes, opts) {
+    ChildProcessUtilities.execSync("git checkout -- " + changes, opts);
   }
 
   @logger.logifySync()
-  static init(cwd) {
-    return ChildProcessUtilities.execSync("git init", { cwd });
+  static init(opts) {
+    return ChildProcessUtilities.execSync("git init", opts);
   }
 
   @logger.logifySync()
-  static hasCommit() {
+  static hasCommit(opts) {
     try {
-      ChildProcessUtilities.execSync("git log");
+      ChildProcessUtilities.execSync("git log", opts);
       return true;
     } catch (e) {
       return false;

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -10,9 +10,14 @@ import dependencyIsSatisfied from "./utils/dependencyIsSatisfied";
 const DEFAULT_PACKAGE_GLOB = "packages/*";
 
 export default class Repository {
-  constructor() {
-    // findUp returns null when not found, and path.resolve starts from process.cwd()
-    const lernaJsonLocation = findUp.sync("lerna.json") || path.resolve("lerna.json");
+  constructor(cwd) {
+    const lernaJsonLocation = (
+      // findUp returns null when not found
+      findUp.sync("lerna.json", { cwd }) ||
+
+      // path.resolve(".", ...) starts from process.cwd()
+      path.resolve((cwd || "."), "lerna.json")
+    );
 
     this.rootPath = path.dirname(lernaJsonLocation);
     this.lernaJsonLocation = lernaJsonLocation;

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -11,6 +11,7 @@ class Update {
 
 export default class UpdatedPackagesCollector {
   constructor(command) {
+    this.execOpts = command.execOpts;
     this.logger = command.logger;
     this.repository = command.repository;
     this.packages = command.filteredPackages;
@@ -28,10 +29,10 @@ export default class UpdatedPackagesCollector {
   collectUpdatedPackages() {
     this.logger.info("Checking for updated packages...");
 
-    const hasTags = GitUtilities.hasTags();
+    const hasTags = GitUtilities.hasTags(this.execOpts);
 
     if (hasTags) {
-      const tag = GitUtilities.getLastTag();
+      const tag = GitUtilities.getLastTag(this.execOpts);
       this.logger.info("Comparing with: " + tag);
     } else {
       this.logger.info("No tags found! Comparing with initial commit.");
@@ -47,12 +48,12 @@ export default class UpdatedPackagesCollector {
       if (this.flags.canary !== true) {
         currentSHA = this.flags.canary;
       } else {
-        currentSHA = GitUtilities.getCurrentSHA();
+        currentSHA = GitUtilities.getCurrentSHA(this.execOpts);
       }
 
       commits = this.getAssociatedCommits(currentSHA);
     } else if (hasTags) {
-      commits = GitUtilities.describeTag(GitUtilities.getLastTaggedCommitInBranch());
+      commits = GitUtilities.describeTag(GitUtilities.getLastTaggedCommitInBranch(this.execOpts), this.execOpts);
     }
 
     const updatedPackages = {};
@@ -145,7 +146,7 @@ export default class UpdatedPackagesCollector {
 
   hasDiffSinceThatIsntIgnored(pkg, commits) {
     const folder = path.relative(this.repository.rootPath, pkg.location);
-    const diff = GitUtilities.diffSinceIn(commits, pkg.location);
+    const diff = GitUtilities.diffSinceIn(commits, pkg.location, this.execOpts);
 
     if (diff === "") {
       return false;

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -3,12 +3,12 @@ import Command from "../Command";
 import ChildProcessUtilities from "../ChildProcessUtilities";
 import find from "lodash/find";
 
-function getLastCommit() {
-  if (GitUtilities.hasTags()) {
-    return GitUtilities.getLastTaggedCommit();
+function getLastCommit(execOpts) {
+  if (GitUtilities.hasTags(execOpts)) {
+    return GitUtilities.getLastTaggedCommit(execOpts);
   }
 
-  return GitUtilities.getFirstCommit();
+  return GitUtilities.getFirstCommit(execOpts);
 }
 
 export default class DiffCommand extends Command {
@@ -28,15 +28,12 @@ export default class DiffCommand extends Command {
       }
     }
 
-    if (!GitUtilities.hasCommit()) {
+    if (!GitUtilities.hasCommit(this.execOpts)) {
       callback(new Error("Can't diff. There are no commits in this repository, yet."));
       return;
     }
 
-    this.args = ["diff", getLastCommit(), "--color=auto"];
-    this.opts = {
-      cwd: this.repository.rootPath,
-    };
+    this.args = ["diff", getLastCommit(this.execOpts), "--color=auto"];
 
     if (targetPackage) {
       this.args.push("--", targetPackage.location);
@@ -46,7 +43,7 @@ export default class DiffCommand extends Command {
   }
 
   execute(callback) {
-    ChildProcessUtilities.spawn("git", this.args, this.opts, (code) => {
+    ChildProcessUtilities.spawn("git", this.args, this.execOpts, (code) => {
       if (code) {
         callback(new Error("Errored while spawning `git diff`."));
       } else {

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -11,9 +11,9 @@ export default class InitCommand extends Command {
   runPreparations() {}
 
   initialize(callback) {
-    if (!GitUtilities.isInitialized(this.repository.rootPath)) {
+    if (!GitUtilities.isInitialized(this.execOpts)) {
       this.logger.info("Initializing Git repository.");
-      GitUtilities.init(this.repository.rootPath);
+      GitUtilities.init(this.execOpts);
     }
 
     this.exact = this.getOptions().exact;

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -88,7 +88,7 @@ describe("BootstrapCommand", () => {
     }));
 
     it("should run preinstall, postinstall and prepublish scripts", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -121,7 +121,7 @@ describe("BootstrapCommand", () => {
     it("should hoist", (done) => {
       const bootstrapCommand = new BootstrapCommand([], {
         hoist: true
-      });
+      }, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -144,7 +144,7 @@ describe("BootstrapCommand", () => {
       const bootstrapCommand = new BootstrapCommand([], {
         hoist: true,
         nohoist: "@test/package-1"
-      });
+      }, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -175,7 +175,7 @@ describe("BootstrapCommand", () => {
     afterEach(resetSymlink);
 
     it("should bootstrap packages", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -197,7 +197,7 @@ describe("BootstrapCommand", () => {
     it("should not bootstrap ignored packages", (done) => {
       const bootstrapCommand = new BootstrapCommand([], {
         ignore: "package-@(3|4)"
-      });
+      }, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -218,7 +218,7 @@ describe("BootstrapCommand", () => {
     it("should only bootstrap scoped packages", (done) => {
       const bootstrapCommand = new BootstrapCommand([], {
         scope: "package-@(3|4)"
-      });
+      }, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -249,7 +249,7 @@ describe("BootstrapCommand", () => {
     afterEach(resetSymlink);
 
     it("should bootstrap packages", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -272,7 +272,7 @@ describe("BootstrapCommand", () => {
     it("should not bootstrap ignored packages", (done) => {
       const bootstrapCommand = new BootstrapCommand([], {
         ignore: "package-@(3|4)"
-      });
+      }, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -295,7 +295,7 @@ describe("BootstrapCommand", () => {
       const bootstrapCommand = new BootstrapCommand([], {
         scope: "package-2",
         includeFilteredDependencies: true
-      });
+      }, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -318,7 +318,7 @@ describe("BootstrapCommand", () => {
       const bootstrapCommand = new BootstrapCommand([], {
         ignore: "{@test/package-1,package-@(3|4)}",
         includeFilteredDependencies: true
-      });
+      }, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -345,7 +345,7 @@ describe("BootstrapCommand", () => {
     }));
 
     it("should get installed", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -365,10 +365,14 @@ describe("BootstrapCommand", () => {
   });
 
   describe("with external dependencies that have already been installed", () => {
-    beforeEach(() => initFixture("BootstrapCommand/warm"));
+    let testDir;
+
+    beforeEach(() => initFixture("BootstrapCommand/warm").then((dir) => {
+      testDir = dir;
+    }));
 
     it("should not get re-installed", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -395,7 +399,7 @@ describe("BootstrapCommand", () => {
     }));
 
     it("should install all dependencies", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -415,10 +419,14 @@ describe("BootstrapCommand", () => {
   });
 
   describe("with package peerDependencies", () => {
-    beforeEach(() => initFixture("BootstrapCommand/peer"));
+    let testDir;
+
+    beforeEach(() => initFixture("BootstrapCommand/peer").then((dir) => {
+      testDir = dir;
+    }));
 
     it("does not bootstrap peerDependencies", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -438,10 +446,14 @@ describe("BootstrapCommand", () => {
   });
 
   describe("zero packages", () => {
-    beforeEach(() => initFixture("BootstrapCommand/zero-pkgs"));
+    let testDir;
+
+    beforeEach(() => initFixture("BootstrapCommand/zero-pkgs").then((dir) => {
+      testDir = dir;
+    }));
 
     it("should succeed in repositories with zero packages", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();
@@ -458,7 +470,7 @@ describe("BootstrapCommand", () => {
     }));
 
     it("should install packages from registry", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {});
+      const bootstrapCommand = new BootstrapCommand([], {}, testDir);
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();

--- a/test/CleanCommand.js
+++ b/test/CleanCommand.js
@@ -46,7 +46,7 @@ describe("CleanCommand", () => {
     }));
 
     it("should rm -rf the node_modules", (done) => {
-      const cleanCommand = new CleanCommand([], {});
+      const cleanCommand = new CleanCommand([], {}, testDir);
 
       cleanCommand.runValidations();
       cleanCommand.runPreparations();
@@ -72,7 +72,7 @@ describe("CleanCommand", () => {
     it("should be possible to skip asking for confirmation", (done) => {
       const cleanCommand = new CleanCommand([], {
         yes: true
-      });
+      }, testDir);
 
       cleanCommand.runValidations();
       cleanCommand.runPreparations();
@@ -99,7 +99,7 @@ describe("CleanCommand", () => {
       it(filter.test, (done) => {
         const cleanCommand = new CleanCommand([], {
           [filter.flag]: filter.flagValue
-        });
+        }, testDir);
 
         cleanCommand.runValidations();
         cleanCommand.runPreparations();
@@ -132,7 +132,7 @@ describe("CleanCommand", () => {
       const cleanCommand = new CleanCommand([], {
         scope: "@test/package-2",
         includeFilteredDependencies: true
-      });
+      }, testDir);
 
       cleanCommand.runValidations();
       cleanCommand.runPreparations();

--- a/test/Command.js
+++ b/test/Command.js
@@ -100,7 +100,11 @@ describe("Command", () => {
   });
 
   describe(".run()", () => {
-    beforeEach(() => initFixture("Command/basic"));
+    let testDir;
+
+    beforeAll(() => initFixture("Command/basic").then((dir) => {
+      testDir = dir;
+    }));
 
     it("should exist", (done) => {
       class TestCommand extends Command {
@@ -112,7 +116,7 @@ describe("Command", () => {
         }
       }
 
-      const testCommand = new TestCommand([], {});
+      const testCommand = new TestCommand([], {}, testDir);
       testCommand.run();
     });
 
@@ -138,7 +142,7 @@ describe("Command", () => {
         it(title, (done) => {
           ChildProcessUtilities.getChildProcessCount = jest.fn(() => idx);
 
-          const exitCommand = new ExitCommand([], {});
+          const exitCommand = new ExitCommand([], {}, testDir);
           const logInfo = jest.spyOn(exitCommand.logger, "info");
 
           exitCommand.runValidations();
@@ -174,7 +178,11 @@ describe("Command", () => {
   });
 
   describe(".getOptions()", () => {
-    beforeEach(() => initFixture("Command/basic"));
+    let testDir;
+
+    beforeAll(() => initFixture("Command/basic").then((dir) => {
+      testDir = dir;
+    }));
 
     class TestACommand extends Command {
     }
@@ -187,45 +195,49 @@ describe("Command", () => {
     }
 
     it("should pick up global options", () => {
-      const instance = new TestACommand([], {});
+      const instance = new TestACommand([], {}, testDir);
       expect(instance.getOptions().testOption).toBe("default");
     });
 
     it("should override global options with command-level options", () => {
-      const instance = new TestBCommand([], {});
+      const instance = new TestBCommand([], {}, testDir);
       expect(instance.getOptions().testOption).toBe("b");
     });
 
     it("should override global options with inherited command-level options", () => {
-      const instance = new TestCCommand([], {});
+      const instance = new TestCCommand([], {}, testDir);
       expect(instance.getOptions().testOption).toBe("b");
     });
 
     it("should override inherited command-level options with local command-level options", () => {
-      const instance = new TestCCommand([], {});
+      const instance = new TestCCommand([], {}, testDir);
       expect(instance.getOptions().testOption2).toBe("c");
     });
 
     it("should override command-level options with passed-in options", () => {
-      const instance = new TestCCommand([], {});
+      const instance = new TestCCommand([], {}, testDir);
       expect(instance.getOptions({ testOption2: "p" }).testOption2).toBe("p");
     });
 
     it("should sieve properly within passed-in options", () => {
-      const instance = new TestCCommand([], {});
+      const instance = new TestCCommand([], {}, testDir);
       expect(instance.getOptions({ testOption2: "p" }, { testOption2: "p2" }).testOption2).toBe("p2");
     });
 
     it("should override everything with a CLI flag", () => {
       const instance = new TestCCommand([], {
         testOption2: "f",
-      });
+      }, testDir);
       expect(instance.getOptions({ testOption2: "p" }).testOption2).toBe("f");
     });
   });
 
   describe("legacy options", () => {
-    beforeEach(() => initFixture("Command/legacy"));
+    let testDir;
+
+    beforeAll(() => initFixture("Command/legacy").then((dir) => {
+      testDir = dir;
+    }));
 
     class TestCommand extends Command {
     }
@@ -235,7 +247,7 @@ describe("Command", () => {
       }
 
       it("should warn when used", () => {
-        const instance = new BootstrapCommand([], {});
+        const instance = new BootstrapCommand([], {}, testDir);
         const logWarn = jest.spyOn(instance.logger, "warn");
 
         instance.getOptions();
@@ -245,12 +257,12 @@ describe("Command", () => {
       });
 
       it("should provide a correct value", () => {
-        const instance = new BootstrapCommand([], {});
+        const instance = new BootstrapCommand([], {}, testDir);
         expect(instance.getOptions().ignore).toBe("package-a");
       });
 
       it("should not warn with other commands", () => {
-        const instance = new TestCommand([], {});
+        const instance = new TestCommand([], {}, testDir);
         const logWarn = jest.spyOn(instance.logger, "warn");
 
         instance.getOptions();
@@ -258,7 +270,7 @@ describe("Command", () => {
       });
 
       it("should not provide a value to other commands", () => {
-        const instance = new TestCommand([], {});
+        const instance = new TestCommand([], {}, testDir);
         expect(instance.getOptions().ignore).toBe(undefined);
       });
     });
@@ -268,7 +280,7 @@ describe("Command", () => {
       }
 
       it("should warn when used", () => {
-        const instance = new PublishCommand([], {});
+        const instance = new PublishCommand([], {}, testDir);
         const logWarn = jest.spyOn(instance.logger, "warn");
 
         instance.getOptions();
@@ -278,12 +290,12 @@ describe("Command", () => {
       });
 
       it("should provide a correct value", () => {
-        const instance = new PublishCommand([], {});
+        const instance = new PublishCommand([], {}, testDir);
         expect(instance.getOptions().ignore).toBe("package-b");
       });
 
       it("should not warn with other commands", () => {
-        const instance = new TestCommand([], {});
+        const instance = new TestCommand([], {}, testDir);
         const logWarn = jest.spyOn(instance.logger, "warn");
 
         instance.getOptions();
@@ -291,7 +303,7 @@ describe("Command", () => {
       });
 
       it("should not provide a value to other commands", () => {
-        const instance = new TestCommand([], {});
+        const instance = new TestCommand([], {}, testDir);
         expect(instance.getOptions().ignore).toBe(undefined);
       });
     });

--- a/test/ConventionalCommitUtilities.js
+++ b/test/ConventionalCommitUtilities.js
@@ -18,15 +18,18 @@ describe("ConventionalCommitUtilities", () => {
     it("should invoke conventional-changelog-recommended bump to fetch next version", () => {
       ChildProcessUtilities.execSync = jest.fn(() => "major");
 
+      const opts = { cwd: "test" };
+
       const recommendVersion = ConventionalCommitUtilities.recommendVersion({
         name: "bar",
         version: "1.0.0",
         location: "/foo/bar",
-      });
+      }, opts);
 
       expect(recommendVersion).toBe("2.0.0");
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         `${require.resolve("conventional-recommended-bump/cli.js")} -l bar --commit-path=/foo/bar -p angular`,
+        opts,
       );
     });
   });
@@ -36,16 +39,19 @@ describe("ConventionalCommitUtilities", () => {
       FileSystemUtilities.existsSync = jest.fn(() => false);
       ChildProcessUtilities.execSync = jest.fn(() => "<a name='change' />feat: I should be placed in the CHANGELOG");
 
+      const opts = { cwd: "test" };
+
       ConventionalCommitUtilities.updateChangelog({
         name: "bar",
         location: "/foo/bar"
-      });
+      }, opts);
 
       expect(FileSystemUtilities.existsSync).lastCalledWith(
         path.normalize("/foo/bar/CHANGELOG.md")
       );
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         `${require.resolve("conventional-changelog-cli/cli.js")} -l bar --commit-path=/foo/bar --pkg=${path.normalize("/foo/bar/package.json")} -p angular`,
+        opts,
       );
       expect(FileSystemUtilities.writeFileSync).lastCalledWith(
         path.normalize("/foo/bar/CHANGELOG.md"),

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -46,7 +46,9 @@ describe("DiffCommand", () => {
             "beefcafe",
             "--color=auto",
           ],
-          { cwd: testDir },
+          expect.objectContaining({
+            cwd: testDir,
+          }),
           expect.any(Function)
         );
         done();
@@ -76,7 +78,9 @@ describe("DiffCommand", () => {
             "cafedead",
             "--color=auto",
           ],
-          { cwd: testDir },
+          expect.objectContaining({
+            cwd: testDir,
+          }),
           expect.any(Function)
         );
         done();
@@ -107,7 +111,9 @@ describe("DiffCommand", () => {
             "--",
             path.join(testDir, "packages/package-1"),
           ],
-          { cwd: testDir },
+          expect.objectContaining({
+            cwd: testDir,
+          }),
           expect.any(Function)
         );
         done();

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -31,7 +31,7 @@ describe("DiffCommand", () => {
     GitUtilities.getFirstCommit.mockImplementation(() => "beefcafe");
     ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
 
-    const diffCommand = new DiffCommand([], {});
+    const diffCommand = new DiffCommand([], {}, testDir);
 
     diffCommand.runValidations();
     diffCommand.runPreparations();
@@ -63,7 +63,7 @@ describe("DiffCommand", () => {
     GitUtilities.getLastTaggedCommit.mockImplementation(() => "cafedead");
     ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
 
-    const diffCommand = new DiffCommand([], {});
+    const diffCommand = new DiffCommand([], {}, testDir);
 
     diffCommand.runValidations();
     diffCommand.runPreparations();
@@ -94,7 +94,7 @@ describe("DiffCommand", () => {
     GitUtilities.getFirstCommit.mockImplementation(() => "deadbeef");
     ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
 
-    const diffCommand = new DiffCommand(["package-1"], {});
+    const diffCommand = new DiffCommand(["package-1"], {}, testDir);
 
     diffCommand.runValidations();
     diffCommand.runPreparations();
@@ -124,7 +124,7 @@ describe("DiffCommand", () => {
   });
 
   it("should error when attempting to diff a package that doesn't exist", (done) => {
-    const diffCommand = new DiffCommand(["missing"], {});
+    const diffCommand = new DiffCommand(["missing"], {}, testDir);
 
     diffCommand.runValidations();
     diffCommand.runPreparations();
@@ -143,7 +143,7 @@ describe("DiffCommand", () => {
     // override beforeEach mock
     GitUtilities.hasCommit.mockImplementation(() => false);
 
-    const diffCommand = new DiffCommand(["package-1"], {});
+    const diffCommand = new DiffCommand(["package-1"], {}, testDir);
 
     diffCommand.runValidations();
     diffCommand.runPreparations();
@@ -161,7 +161,7 @@ describe("DiffCommand", () => {
   it("should error when git diff exits non-zero", (done) => {
     ChildProcessUtilities.spawn.mockImplementation(callbackNonZero);
 
-    const diffCommand = new DiffCommand(["package-1"], {});
+    const diffCommand = new DiffCommand(["package-1"], {}, testDir);
 
     diffCommand.runValidations();
     diffCommand.runPreparations();

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -29,12 +29,12 @@ describe("ExecCommand", () => {
   describe("in a basic repo", () => {
     let testDir;
 
-    beforeEach(() => initFixture("ExecCommand/basic").then((dir) => {
+    beforeAll(() => initFixture("ExecCommand/basic").then((dir) => {
       testDir = dir;
     }));
 
     it("should complain if invoked without command", (done) => {
-      const execCommand = new ExecCommand([], {});
+      const execCommand = new ExecCommand([], {}, testDir);
 
       execCommand.runValidations();
       execCommand.runPreparations();
@@ -53,7 +53,7 @@ describe("ExecCommand", () => {
     it("passes execution error to callback", (done) => {
       ChildProcessUtilities.spawn = jest.fn(callsBack(1));
 
-      const execCommand = new ExecCommand(["boom"], {});
+      const execCommand = new ExecCommand(["boom"], {}, testDir);
 
       execCommand.runValidations();
       execCommand.runPreparations();
@@ -77,7 +77,7 @@ describe("ExecCommand", () => {
     it("should filter packages with `ignore`", (done) => {
       const execCommand = new ExecCommand(["ls"], {
         ignore: "package-1",
-      });
+      }, testDir);
 
       execCommand.runValidations();
       execCommand.runPreparations();
@@ -102,7 +102,7 @@ describe("ExecCommand", () => {
     });
 
     it("should run a command", (done) => {
-      const execCommand = new ExecCommand(["ls"], {});
+      const execCommand = new ExecCommand(["ls"], {}, testDir);
 
       execCommand.runValidations();
       execCommand.runPreparations();
@@ -125,7 +125,7 @@ describe("ExecCommand", () => {
     });
 
     it("should run a command with parameters", (done) => {
-      const execCommand = new ExecCommand(["ls", "-la"], {});
+      const execCommand = new ExecCommand(["ls", "-la"], {}, testDir);
 
       execCommand.runValidations();
       execCommand.runPreparations();
@@ -153,7 +153,7 @@ describe("ExecCommand", () => {
       it(filter.test, (done) => {
         const execCommand = new ExecCommand(["ls"], {
           [filter.flag]: filter.flagValue,
-        });
+        }, testDir);
 
         execCommand.runValidations();
         execCommand.runPreparations();

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -26,11 +26,18 @@ describe("GitUtilities", () => {
       GitUtilities.getCurrentBranch = jest.fn(() => "master");
       expect(GitUtilities.isDetachedHead()).toBe(false);
     });
+
+    it("passes opts to getCurrentBranch()", () => {
+      GitUtilities.getCurrentBranch = jest.fn();
+      const opts = { cwd: "test" };
+      GitUtilities.isDetachedHead(opts);
+      expect(GitUtilities.getCurrentBranch).lastCalledWith(opts);
+    });
   });
 
   describe(".isInitialized()", () => {
     it("returns true when git command succeeds", () => {
-      expect(GitUtilities.isInitialized("test")).toBe(true);
+      expect(GitUtilities.isInitialized({ cwd: "test" })).toBe(true);
       expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse", { cwd: "test", stdio: "ignore" });
     });
 
@@ -45,42 +52,48 @@ describe("GitUtilities", () => {
 
   describe(".addFile()", () => {
     it("calls git add with file argument", () => {
-      GitUtilities.addFile("foo");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git add foo");
+      const opts = { cwd: "test" };
+      GitUtilities.addFile("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git add foo", opts);
     });
   });
 
   describe(".commit()", () => {
     it("calls git commit with message", () => {
-      GitUtilities.commit("foo");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git commit -m \"$(echo \"foo\")\"");
+      const opts = { cwd: "oneline" };
+      GitUtilities.commit("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git commit -m \"$(echo \"foo\")\"", opts);
     });
 
     it("allows multiline message", () => {
-      GitUtilities.commit(`foo${EOL}bar`);
-      expect(ChildProcessUtilities.execSync).lastCalledWith(`git commit -m "$(echo "foo${EOL}bar")"`);
+      const opts = { cwd: "multiline" };
+      GitUtilities.commit(`foo${EOL}bar`, opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(`git commit -m "$(echo "foo${EOL}bar")"`, opts);
     });
   });
 
   describe(".addTag()", () => {
     it("creates annotated git tag", () => {
-      GitUtilities.addTag("foo");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -a foo -m \"foo\"");
+      const opts = { cwd: "test" };
+      GitUtilities.addTag("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -a foo -m \"foo\"", opts);
     });
   });
 
   describe(".removeTag()", () => {
     it("deletes specified git tag", () => {
-      GitUtilities.removeTag("foo");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -d foo");
+      const opts = { cwd: "test" };
+      GitUtilities.removeTag("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -d foo", opts);
     });
   });
 
   describe(".hasTags()", () => {
     it("returns true when one or more git tags exist", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "v1.0.0");
-      expect(GitUtilities.hasTags()).toBe(true);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.hasTags(opts)).toBe(true);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag", opts);
     });
 
     it("returns false when no git tags exist", () => {
@@ -92,8 +105,9 @@ describe("GitUtilities", () => {
   describe(".getLastTaggedCommit()", () => {
     it("returns SHA of closest git tag", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "deadbeef");
-      expect(GitUtilities.getLastTaggedCommit()).toBe("deadbeef");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --tags --max-count=1");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getLastTaggedCommit(opts)).toBe("deadbeef");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --tags --max-count=1", opts);
     });
   });
 
@@ -106,16 +120,18 @@ describe("GitUtilities", () => {
     it("returns SHA of closest git tag in branch", () => {
       GitUtilities.getLastTag = jest.fn(() => "v1.0.0");
       ChildProcessUtilities.execSync.mockImplementation(() => "deadbeef");
-      expect(GitUtilities.getLastTaggedCommitInBranch()).toBe("deadbeef");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list -n 1 v1.0.0");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getLastTaggedCommitInBranch(opts)).toBe("deadbeef");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list -n 1 v1.0.0", opts);
     });
   });
 
   describe(".getFirstCommit()", () => {
     it("returns SHA of first commit", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "beefcafe");
-      expect(GitUtilities.getFirstCommit()).toBe("beefcafe");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --max-parents=0 HEAD");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getFirstCommit(opts)).toBe("beefcafe");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --max-parents=0 HEAD", opts);
     });
   });
 
@@ -127,71 +143,80 @@ describe("GitUtilities", () => {
 
     it("pushes current branch and specified tag(s) to origin", () => {
       GitUtilities.getCurrentBranch = jest.fn(() => "master");
-      GitUtilities.pushWithTags("origin", ["foo@1.0.1", "foo-bar@1.0.0"]);
-      expect(ChildProcessUtilities.execSync).toBeCalledWith("git push origin master");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git push origin foo@1.0.1 foo-bar@1.0.0");
+      const opts = { cwd: "test" };
+      GitUtilities.pushWithTags("origin", ["foo@1.0.1", "foo-bar@1.0.0"], opts);
+      expect(ChildProcessUtilities.execSync).toBeCalledWith("git push origin master", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git push origin foo@1.0.1 foo-bar@1.0.0", opts);
     });
   });
 
   describe(".getLastTag()", () => {
     it("returns the closest tag", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "v1.0.0");
-      expect(GitUtilities.getLastTag()).toBe("v1.0.0");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags --abbrev=0");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getLastTag(opts)).toBe("v1.0.0");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags --abbrev=0", opts);
     });
   });
 
   describe(".describeTag()", () => {
     it("returns description of specified tag", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "foo@1.0.0");
-      expect(GitUtilities.describeTag("deadbeef")).toBe("foo@1.0.0");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags deadbeef");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.describeTag("deadbeef", opts)).toBe("foo@1.0.0");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags deadbeef", opts);
     });
   });
 
   describe(".diffSinceIn()", () => {
     it("returns list of files changed since commit at location", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "files");
-      expect(GitUtilities.diffSinceIn("foo@1.0.0", "packages/foo")).toBe("files");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git diff --name-only foo@1.0.0 -- packages/foo");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.diffSinceIn("foo@1.0.0", "packages/foo", opts)).toBe("files");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git diff --name-only foo@1.0.0 -- packages/foo", opts);
     });
   });
 
   describe(".getCurrentBranch()", () => {
     it("calls `git rev-parse --abbrev-ref HEAD`", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "master");
-      expect(GitUtilities.getCurrentBranch()).toBe("master");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse --abbrev-ref HEAD");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getCurrentBranch(opts)).toBe("master");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse --abbrev-ref HEAD", opts);
     });
   });
 
   describe(".getCurrentSHA()", () => {
     it("returns SHA of current ref", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "deadcafe");
-      expect(GitUtilities.getCurrentSHA()).toBe("deadcafe");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse HEAD");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getCurrentSHA(opts)).toBe("deadcafe");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse HEAD", opts);
     });
   });
 
   describe(".checkoutChanges()", () => {
     it("calls git checkout with specified arg", () => {
-      GitUtilities.checkoutChanges("packages/*/package.json");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git checkout -- packages/*/package.json");
+      const opts = { cwd: "test" };
+      GitUtilities.checkoutChanges("packages/*/package.json", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git checkout -- packages/*/package.json", opts);
     });
   });
 
   describe(".init()", () => {
     it("calls git init", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "stdout for logger");
-      expect(GitUtilities.init("test")).toBe("stdout for logger");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git init", { cwd: "test" });
+      const opts = { cwd: "test" };
+      expect(GitUtilities.init(opts)).toBe("stdout for logger");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git init", opts);
     });
   });
 
   describe(".hasCommit()", () => {
     it("returns true when git command succeeds", () => {
-      expect(GitUtilities.hasCommit()).toBe(true);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git log");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.hasCommit(opts)).toBe(true);
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git log", opts);
     });
 
     it("returns false when git command fails", () => {

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -33,15 +33,13 @@ describe("ImportCommand", () => {
     let externalDir;
 
     beforeEach(() =>
-      Promise.resolve()
-        .then(() => initExternalFixture("ImportCommand/external"))
-        .then((dir) => {
-          externalDir = dir;
-        })
-        .then(() => initFixture("ImportCommand/basic"))
-        .then((dir) => {
-          testDir = dir;
-        })
+      Promise.all([
+        initExternalFixture("ImportCommand/external"),
+        initFixture("ImportCommand/basic"),
+      ]).then(([extDir, basicDir]) => {
+        externalDir = extDir;
+        testDir = basicDir;
+      })
     );
 
     it("creates a module in packages location with imported commit history", (done) => {

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -45,7 +45,7 @@ describe("ImportCommand", () => {
     );
 
     it("creates a module in packages location with imported commit history", (done) => {
-      const importCommand = new ImportCommand([externalDir], {});
+      const importCommand = new ImportCommand([externalDir], {}, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();
@@ -72,7 +72,7 @@ describe("ImportCommand", () => {
       execa.sync("git", ["mv", "old-file", "new-file"], { cwd: externalDir });
       execa.sync("git", ["commit", "-m", "Moved old-file to new-file"], { cwd: externalDir });
 
-      const importCommand = new ImportCommand([externalDir], {});
+      const importCommand = new ImportCommand([externalDir], {}, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();
@@ -96,7 +96,7 @@ describe("ImportCommand", () => {
     it("allows skipping confirmation prompt", (done) => {
       const importCommand = new ImportCommand([externalDir], {
         yes: true
-      });
+      }, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();
@@ -105,7 +105,7 @@ describe("ImportCommand", () => {
     });
 
     it("errors without an argument", (done) => {
-      const importCommand = new ImportCommand([], {});
+      const importCommand = new ImportCommand([], {}, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();
@@ -122,7 +122,7 @@ describe("ImportCommand", () => {
 
     it("errors when external directory is missing", (done) => {
       const missing = externalDir + "_invalidSuffix";
-      const importCommand = new ImportCommand([missing], {});
+      const importCommand = new ImportCommand([missing], {}, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();
@@ -140,7 +140,7 @@ describe("ImportCommand", () => {
     it("errors when external package.json is missing", (done) => {
       fs.unlinkSync(path.join(externalDir, "package.json"));
 
-      const importCommand = new ImportCommand([externalDir], {});
+      const importCommand = new ImportCommand([externalDir], {}, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();
@@ -157,7 +157,7 @@ describe("ImportCommand", () => {
     });
 
     it("errors when external package.json has no name property", (done) => {
-      const importCommand = new ImportCommand([externalDir], {});
+      const importCommand = new ImportCommand([externalDir], {}, testDir);
 
       const packageJson = path.join(externalDir, "package.json");
 
@@ -181,7 +181,7 @@ describe("ImportCommand", () => {
 
       fs.ensureDirSync(targetDir);
 
-      const importCommand = new ImportCommand([externalDir], {});
+      const importCommand = new ImportCommand([externalDir], {}, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();
@@ -206,7 +206,7 @@ describe("ImportCommand", () => {
         packages: ["pkg/*"],
       });
 
-      const importCommand = new ImportCommand([externalDir], {});
+      const importCommand = new ImportCommand([externalDir], {}, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();
@@ -228,7 +228,7 @@ describe("ImportCommand", () => {
       fs.writeFileSync(uncommittedFile, "stuff");
       execa.sync("git", ["add", uncommittedFile], { cwd: testDir });
 
-      const importCommand = new ImportCommand([externalDir], {});
+      const importCommand = new ImportCommand([externalDir], {}, testDir);
 
       importCommand.runValidations();
       importCommand.runPreparations();

--- a/test/InitCommand.js
+++ b/test/InitCommand.js
@@ -1,4 +1,3 @@
-import fs from "fs-promise";
 import path from "path";
 
 // mocked modules
@@ -12,7 +11,6 @@ import GitUtilities from "../src/GitUtilities";
 
 // helpers
 import initDirName from "./helpers/initDirName";
-import initFixture from "./helpers/initFixture";
 
 // file under test
 import InitCommand from "../src/commands/InitCommand";
@@ -27,14 +25,6 @@ jest.mock("write-json-file");
 jest.mock("write-pkg");
 jest.mock("../src/FileSystemUtilities");
 jest.mock("../src/GitUtilities");
-
-const initEmptyDir = () =>
-  initDirName("InitCommand/empty").then((dir) => {
-    return fs.ensureDir(dir).then(() => {
-      process.chdir(dir);
-      return dir;
-    });
-  });
 
 describe("InitCommand", () => {
   beforeEach(() => {
@@ -56,7 +46,7 @@ describe("InitCommand", () => {
   describe("in an empty directory", () => {
     let testDir;
 
-    beforeEach(() => initEmptyDir().then((dir) => {
+    beforeEach(() => initDirName("InitCommand/empty").then((dir) => {
       testDir = dir;
 
       GitUtilities.isInitialized = jest.fn(() => false);
@@ -199,7 +189,7 @@ describe("InitCommand", () => {
   describe("in a subdirectory of a git repo", () => {
     let testDir;
 
-    beforeEach(() => initEmptyDir().then((dir) => {
+    beforeEach(() => initDirName("InitCommand/empty").then((dir) => {
       testDir = path.join(dir, "subdir");
 
       findUp.sync = jest.fn(() => path.join(testDir, "lerna.json"));
@@ -246,7 +236,7 @@ describe("InitCommand", () => {
   describe("when package.json exists", () => {
     let testDir;
 
-    beforeEach(() => initFixture("InitCommand/has-package").then((dir) => {
+    beforeEach(() => initDirName("InitCommand/has-package").then((dir) => {
       testDir = dir;
     }));
 
@@ -362,7 +352,7 @@ describe("InitCommand", () => {
   describe("when lerna.json exists", () => {
     let testDir;
 
-    beforeEach(() => initFixture("InitCommand/has-lerna").then((dir) => {
+    beforeEach(() => initDirName("InitCommand/has-lerna").then((dir) => {
       testDir = dir;
 
       findUp.sync = jest.fn(() => path.join(testDir, "lerna.json"));
@@ -433,7 +423,7 @@ describe("InitCommand", () => {
   describe("when VERSION exists", () => {
     let testDir;
 
-    beforeEach(() => initFixture("InitCommand/has-version").then((dir) => {
+    beforeEach(() => initDirName("InitCommand/has-version").then((dir) => {
       testDir = dir;
 
       FileSystemUtilities.existsSync = jest.fn(() => true);
@@ -486,7 +476,7 @@ describe("InitCommand", () => {
   describe("when re-initializing with --exact", () => {
     let testDir;
 
-    beforeEach(() => initFixture("InitCommand/updates").then((dir) => {
+    beforeEach(() => initDirName("InitCommand/updates").then((dir) => {
       testDir = dir;
 
       findUp.sync = jest.fn(() => path.join(testDir, "lerna.json"));

--- a/test/InitCommand.js
+++ b/test/InitCommand.js
@@ -63,13 +63,14 @@ describe("InitCommand", () => {
     }));
 
     it("completely ignores validation and preparation lifecycle", () => {
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
+
       expect(() => instance.runValidations()).not.toThrow();
       expect(() => instance.runPreparations()).not.toThrow();
     });
 
     it("initializes git repo with lerna files", (done) => {
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -112,7 +113,7 @@ describe("InitCommand", () => {
     it("initializes git repo with lerna files in independent mode", (done) => {
       const instance = new InitCommand([], {
         independent: true,
-      });
+      }, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -139,7 +140,7 @@ describe("InitCommand", () => {
       it("uses exact version when adding lerna dependency", (done) => {
         const instance = new InitCommand([], {
           exact: true,
-        });
+        }, testDir);
 
         instance.runCommand((err, code) => {
           if (err) return done.fail(err);
@@ -166,7 +167,7 @@ describe("InitCommand", () => {
       it("sets lerna.json command.init.exact to true", (done) => {
         const instance = new InitCommand([], {
           exact: true,
-        });
+        }, testDir);
 
         instance.runCommand((err, code) => {
           if (err) return done.fail(err);
@@ -205,7 +206,7 @@ describe("InitCommand", () => {
     }));
 
     it("creates lerna files", (done) => {
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -257,7 +258,7 @@ describe("InitCommand", () => {
         },
       }));
 
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -294,7 +295,7 @@ describe("InitCommand", () => {
         },
       }));
 
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -331,7 +332,7 @@ describe("InitCommand", () => {
         },
       }));
 
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -373,7 +374,7 @@ describe("InitCommand", () => {
         version: "1.2.3",
       }));
 
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -404,7 +405,7 @@ describe("InitCommand", () => {
 
       const instance = new InitCommand([], {
         independent: true,
-      });
+      }, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -440,7 +441,7 @@ describe("InitCommand", () => {
     }));
 
     it("removes file", (done) => {
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -458,7 +459,7 @@ describe("InitCommand", () => {
     });
 
     it("uses value for lerna.json version property", (done) => {
-      const instance = new InitCommand([], {});
+      const instance = new InitCommand([], {}, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);
@@ -510,7 +511,7 @@ describe("InitCommand", () => {
 
       const instance = new InitCommand([], {
         exact: true,
-      });
+      }, testDir);
 
       instance.runCommand((err, code) => {
         if (err) return done.fail(err);

--- a/test/InitCommand.js
+++ b/test/InitCommand.js
@@ -77,7 +77,11 @@ describe("InitCommand", () => {
         try {
           expect(code).toBe(0);
 
-          expect(GitUtilities.init).toBeCalled();
+          const execOpts = expect.objectContaining({
+            cwd: testDir,
+          });
+          expect(GitUtilities.isInitialized).lastCalledWith(execOpts);
+          expect(GitUtilities.init).lastCalledWith(execOpts);
 
           expect(writeJsonFile.sync).lastCalledWith(
             path.join(testDir, "lerna.json"),

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -29,10 +29,14 @@ afterEach(() => {
 
 describe("LsCommand", () => {
   describe("in a basic repo", () => {
-    beforeEach(() => initFixture("LsCommand/basic"));
+    let testDir;
+
+    beforeEach(() => initFixture("LsCommand/basic").then((dir) => {
+      testDir = dir;
+    }));
 
     it("should list packages", (done) => {
-      const lsCommand = new LsCommand([], {});
+      const lsCommand = new LsCommand([], {}, testDir);
 
       lsCommand.runValidations();
       lsCommand.runPreparations();
@@ -57,7 +61,9 @@ describe("LsCommand", () => {
     ];
     filters.forEach((filter) => {
       it(filter.test, (done) => {
-        const lsCommand = new LsCommand([], {[filter.flag]: filter.flagValue});
+        const lsCommand = new LsCommand([], {
+          [filter.flag]: filter.flagValue,
+        }, testDir);
 
         lsCommand.runValidations();
         lsCommand.runPreparations();
@@ -78,10 +84,14 @@ describe("LsCommand", () => {
   });
 
   describe("in a repo with packages outside of packages/", () => {
-    beforeEach(() => initFixture("LsCommand/extra"));
+    let testDir;
+
+    beforeEach(() => initFixture("LsCommand/extra").then((dir) => {
+      testDir = dir;
+    }));
 
     it("should list packages", (done) => {
-      const lsCommand = new LsCommand([], {});
+      const lsCommand = new LsCommand([], {}, testDir);
 
       lsCommand.runValidations();
       lsCommand.runPreparations();
@@ -101,13 +111,17 @@ describe("LsCommand", () => {
   });
 
   describe("with --include-filtered-dependencies", () => {
-    beforeEach(() => initFixture("LsCommand/include-filtered-dependencies"));
+    let testDir;
+
+    beforeEach(() => initFixture("LsCommand/include-filtered-dependencies").then((dir) => {
+      testDir = dir;
+    }));
 
     it("should list packages, including filtered ones", (done) => {
       const lsCommand = new LsCommand([], {
         scope: "@test/package-2",
         includeFilteredDependencies: true
-      });
+      }, testDir);
 
       lsCommand.runValidations();
       lsCommand.runPreparations();

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -19,7 +19,7 @@ describe("PackageUtilities", () => {
     }));
 
     it("should collect all the packages from the given packages directory", () => {
-      const result = PackageUtilities.getPackages(new Repository());
+      const result = PackageUtilities.getPackages(new Repository(testDir));
       expect(result).toHaveLength(4);
 
       const pkgOne = result[0];
@@ -33,8 +33,8 @@ describe("PackageUtilities", () => {
   describe(".filterPackages()", () => {
     let packages;
 
-    beforeAll(() => initFixture("PackageUtilities/filtering").then(() => {
-      packages = PackageUtilities.getPackages(new Repository);
+    beforeAll(() => initFixture("PackageUtilities/filtering").then((testDir) => {
+      packages = PackageUtilities.getPackages(new Repository(testDir));
     }));
 
     it("includes all packages when --scope is omitted", () => {
@@ -151,8 +151,8 @@ describe("PackageUtilities", () => {
   describe(".topologicallyBatchPackages()", () => {
     let packages;
 
-    beforeEach(() => initFixture("PackageUtilities/toposort").then(() => {
-      packages = PackageUtilities.getPackages(new Repository);
+    beforeEach(() => initFixture("PackageUtilities/toposort").then((testDir) => {
+      packages = PackageUtilities.getPackages(new Repository(testDir));
     }));
 
     it("should batch roots, then internal/leaf nodes, then cycles", () => {

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -119,7 +119,7 @@ describe("PublishCommand", () => {
     }));
 
     it("should publish the changed packages", (done) => {
-      const publishCommand = new PublishCommand([], {});
+      const publishCommand = new PublishCommand([], {}, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -184,7 +184,7 @@ describe("PublishCommand", () => {
     it("should publish the changed packages in independent mode", (done) => {
       const publishCommand = new PublishCommand([], {
         independent: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -255,7 +255,7 @@ describe("PublishCommand", () => {
     it("should publish the changed packages", (done) => {
       const publishCommand = new PublishCommand([], {
         canary: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -315,7 +315,7 @@ describe("PublishCommand", () => {
       const publishCommand = new PublishCommand([], {
         independent: true,
         canary: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -368,7 +368,7 @@ describe("PublishCommand", () => {
     it("should publish the changed packages", (done) => {
       const publishCommand = new PublishCommand([], {
         skipGit: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -411,7 +411,7 @@ describe("PublishCommand", () => {
     it("should update versions and push changes but not publish", (done) => {
       const publishCommand = new PublishCommand([], {
         skipNpm: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -457,7 +457,7 @@ describe("PublishCommand", () => {
       const publishCommand = new PublishCommand([], {
         skipGit: true,
         skipNpm: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -519,7 +519,7 @@ describe("PublishCommand", () => {
     it("should publish the changed packages without the temp tag", (done) => {
       const publishCommand = new PublishCommand([], {
         skipTempTag: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -562,7 +562,7 @@ describe("PublishCommand", () => {
     it("should publish the changed packages with npm tag", (done) => {
       const publishCommand = new PublishCommand([], {
         npmTag: "custom"
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -625,7 +625,7 @@ describe("PublishCommand", () => {
       const registry = "https://my-private-registry";
       const publishCommand = new PublishCommand([], {
         registry,
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -690,7 +690,7 @@ describe("PublishCommand", () => {
     it("skips version prompt and publishes changed packages with designated version", (done) => {
       const publishCommand = new PublishCommand([], {
         repoVersion: "1.0.1-beta"
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -729,7 +729,7 @@ describe("PublishCommand", () => {
     it("updates matching local dependencies of published packages with exact versions", (done) => {
       const publishCommand = new PublishCommand([], {
         exact: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -780,7 +780,7 @@ describe("PublishCommand", () => {
     it("should use semver increments when passed to cdVersion flag", (done) => {
       const publishCommand = new PublishCommand([], {
         cdVersion: "minor"
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -820,7 +820,7 @@ describe("PublishCommand", () => {
       const publishCommand = new PublishCommand([], {
         independent: true,
         cdVersion: "patch"
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -859,7 +859,7 @@ describe("PublishCommand", () => {
     it("pushes tags to specified remote", (done) => {
       const publishCommand = new PublishCommand([], {
         gitRemote: "upstream"
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -897,7 +897,7 @@ describe("PublishCommand", () => {
     it("does not publish ignored packages", (done) => {
       const publishCommand = new PublishCommand([], {
         ignore: ["package-2", "package-3", "package-4"],
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -936,7 +936,7 @@ describe("PublishCommand", () => {
     it("commits changes with a custom message", (done) => {
       const publishCommand = new PublishCommand([], {
         message: "A custom publish message"
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -975,7 +975,7 @@ describe("PublishCommand", () => {
       const publishCommand = new PublishCommand([], {
         independent: true,
         message: "A custom publish message"
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -1031,7 +1031,7 @@ describe("PublishCommand", () => {
       const publishCommand = new PublishCommand([], {
         independent: true,
         conventionalCommits: true
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();
@@ -1092,7 +1092,7 @@ describe("PublishCommand", () => {
         npmTag: "next",
         yes: true,
         exact: true,
-      });
+      }, testDir);
 
       publishCommand.runValidations();
       publishCommand.runPreparations();

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -42,12 +42,12 @@ describe("RunCommand", () => {
   describe("in a basic repo", () => {
     let testDir;
 
-    beforeEach(() => initFixture("RunCommand/basic").then((dir) => {
+    beforeAll(() => initFixture("RunCommand/basic").then((dir) => {
       testDir = dir;
     }));
 
     it("runs a script in packages", (done) => {
-      const runCommand = new RunCommand(["my-script"], {});
+      const runCommand = new RunCommand(["my-script"], {}, testDir);
 
       runCommand.runValidations();
       runCommand.runPreparations();
@@ -68,7 +68,7 @@ describe("RunCommand", () => {
     it("runs a script in packages with --stream", (done) => {
       const runCommand = new RunCommand(["my-script"], {
         stream: true,
-      });
+      }, testDir);
 
       runCommand.runValidations();
       runCommand.runPreparations();
@@ -91,7 +91,7 @@ describe("RunCommand", () => {
       "env",
     ].forEach((defaultScript) => {
       it(`always runs ${defaultScript} script`, (done) => {
-        const runCommand = new RunCommand([defaultScript], {});
+        const runCommand = new RunCommand([defaultScript], {}, testDir);
 
         runCommand.runValidations();
         runCommand.runPreparations();
@@ -119,7 +119,7 @@ describe("RunCommand", () => {
       it(filter.test, (done) => {
         const runCommand = new RunCommand(["my-script"], {
           [filter.flag]: filter.flagValue,
-        });
+        }, testDir);
 
         runCommand.runValidations();
         runCommand.runPreparations();
@@ -142,7 +142,7 @@ describe("RunCommand", () => {
   describe("with --include-filtered-dependencies", () => {
     let testDir;
 
-    beforeEach(() => initFixture("RunCommand/include-filtered-dependencies").then((dir) => {
+    beforeAll(() => initFixture("RunCommand/include-filtered-dependencies").then((dir) => {
       testDir = dir;
     }));
 
@@ -150,7 +150,7 @@ describe("RunCommand", () => {
       const runCommand = new RunCommand(["my-script"], {
         scope: "@test/package-2",
         includeFilteredDependencies: true
-      });
+      }, testDir);
 
       runCommand.runValidations();
       runCommand.runPreparations();

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -63,7 +63,7 @@ describe("UpdatedCommand", () => {
         "packages/package-2/random-file",
       ]);
 
-      const updatedCommand = new UpdatedCommand([], {});
+      const updatedCommand = new UpdatedCommand([], {}, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -82,7 +82,7 @@ describe("UpdatedCommand", () => {
     });
 
     it("should list all packages when no tag is found", (done) => {
-      const updatedCommand = new UpdatedCommand([], {});
+      const updatedCommand = new UpdatedCommand([], {}, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -107,7 +107,7 @@ describe("UpdatedCommand", () => {
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "*"
-      });
+      }, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -132,7 +132,7 @@ describe("UpdatedCommand", () => {
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "package-2,package-4"
-      });
+      }, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -164,7 +164,7 @@ describe("UpdatedCommand", () => {
         "packages/package-3/random-file",
       ]);
 
-      const updatedCommand = new UpdatedCommand([], {});
+      const updatedCommand = new UpdatedCommand([], {}, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -189,7 +189,7 @@ describe("UpdatedCommand", () => {
 
       const updatedCommand = new UpdatedCommand([], {
         [SECRET_FLAG]: true
-      });
+      }, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -212,7 +212,7 @@ describe("UpdatedCommand", () => {
         "packages/package-5/random-file",
       ]);
 
-      const updatedCommand = new UpdatedCommand([], {});
+      const updatedCommand = new UpdatedCommand([], {}, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -247,7 +247,7 @@ describe("UpdatedCommand", () => {
         "packages/package-3/random-file",
       ]);
 
-      const updatedCommand = new UpdatedCommand([], {});
+      const updatedCommand = new UpdatedCommand([], {}, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -272,7 +272,7 @@ describe("UpdatedCommand", () => {
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "*"
-      });
+      }, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -297,7 +297,7 @@ describe("UpdatedCommand", () => {
 
       const updatedCommand = new UpdatedCommand([], {
         forcePublish: "package-2"
-      });
+      }, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();
@@ -329,7 +329,7 @@ describe("UpdatedCommand", () => {
         "packages/package-3/random-file",
       ]);
 
-      const updatedCommand = new UpdatedCommand([], {});
+      const updatedCommand = new UpdatedCommand([], {}, testDir);
 
       updatedCommand.runValidations();
       updatedCommand.runPreparations();

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -85,18 +85,6 @@ exports[`[independent] git commit message 1`] = `
  - package-4@1.1.0"
 `;
 
-exports[`[independent] git push <remote> [tags] 1`] = `
-Array [
-  "origin",
-  Array [
-    "package-1@1.0.1",
-    "package-2@1.1.0",
-    "package-3@2.0.0",
-    "package-4@1.1.0",
-  ],
-]
-`;
-
 exports[`[independent] git tags added 1`] = `
 Array [
   "package-1@1.0.1",
@@ -218,15 +206,6 @@ Array [
   "packages/package-3/package.json",
   "packages/package-4/package.json",
   "packages/package-5/package.json",
-]
-`;
-
-exports[`[normal] git push <remote> [tags] 1`] = `
-Array [
-  "origin",
-  Array [
-    "v1.0.1",
-  ],
 ]
 `;
 

--- a/test/helpers/initFixture.js
+++ b/test/helpers/initFixture.js
@@ -12,12 +12,6 @@ const getFixtureName = fixtureNamer();
 const createdDirectories = [];
 afterAll(() => removeAll(createdDirectories));
 
-const originalCwd = process.cwd();
-afterEach((done) => {
-  process.chdir(originalCwd);
-  process.nextTick(done);
-});
-
 export default function initFixture(fixturePath) {
   const fixtureDir = path.resolve(__dirname, `../fixtures/${fixturePath}`);
   const fixtureName = getFixtureName(fixturePath);
@@ -27,9 +21,6 @@ export default function initFixture(fixturePath) {
 
     return fs.copy(fixtureDir, testDir)
       .then(() => gitInit(testDir))
-      .then(() => {
-        process.chdir(testDir);
-        return testDir;
-      });
+      .then(() => testDir);
   });
 }

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -3,7 +3,7 @@ import path from "path";
 import execa from "execa";
 import readPkg from "read-pkg";
 import writePkg from "write-pkg";
-import initExternalFixture from "../helpers/initExternalFixture";
+import initFixture from "../helpers/initFixture";
 import replaceLernaVersion from "../helpers/replaceLernaVersion";
 
 expect.addSnapshotSerializer(replaceLernaVersion);
@@ -17,9 +17,6 @@ const LERNA = path.join(ROOTDIR, PACKAGE.bin.lerna);
 const copyTarball = (cwd) =>
   fs.copy(TGZ_SRC, path.join(cwd, "lerna-latest.tgz"));
 
-const initFixture = (name) =>
-  initExternalFixture(`BootstrapCommand/${name}`);
-
 const installInDir = (cwd) =>
   execa("yarn", ["install", "--mutex", "network:42042"], { cwd });
 
@@ -29,7 +26,7 @@ const npmTestInDir = (cwd) =>
 
 describe("lerna bootstrap", () => {
   describe("from CLI", () => {
-    test.concurrent("bootstraps all packages", () => initFixture("integration").then((cwd) => {
+    test.concurrent("bootstraps all packages", () => initFixture("BootstrapCommand/integration").then((cwd) => {
       return Promise.resolve()
         .then(() => execa(LERNA, ["bootstrap"], { cwd }))
         .then((result) => {
@@ -43,7 +40,7 @@ describe("lerna bootstrap", () => {
   });
 
   describe("from npm script", () => {
-    test.concurrent("bootstraps all packages", () => initFixture("integration").then((cwd) => {
+    test.concurrent("bootstraps all packages", () => initFixture("BootstrapCommand/integration").then((cwd) => {
       return copyTarball(cwd)
         .then(() => writePkg(cwd, {
           "name": "integration",

--- a/test/integration/lerna-init.test.js
+++ b/test/integration/lerna-init.test.js
@@ -4,7 +4,7 @@ import execa from "execa";
 import readPkg from "read-pkg";
 import loadJsonFile from "load-json-file";
 import initDirName from "../helpers/initDirName";
-import initExternalFixture from "../helpers/initExternalFixture";
+import initFixture from "../helpers/initFixture";
 import replaceLernaVersion from "../helpers/replaceLernaVersion";
 
 expect.addSnapshotSerializer(replaceLernaVersion);
@@ -17,9 +17,6 @@ const initEmptyDir = () =>
   initDirName("InitCommand/empty").then((dir) => {
     return fs.ensureDir(dir).then(() => dir);
   });
-
-const initFixture = (name) =>
-  initExternalFixture(`InitCommand/${name}`);
 
 const parsePackageJson = (cwd) =>
   readPkg(path.join(cwd, "package.json"), { normalize: false });
@@ -44,7 +41,7 @@ describe("lerna init", () => {
     });
   }));
 
-  test.concurrent("updates existing metadata", () => initFixture("updates").then((cwd) => {
+  test.concurrent("updates existing metadata", () => initFixture("InitCommand/updates").then((cwd) => {
     return execa(LERNA, ["init", "--exact"], { cwd }).then((result) => {
       expect(result.stdout).toMatchSnapshot("stdout: updates");
 
@@ -55,7 +52,7 @@ describe("lerna init", () => {
     });
   }));
 
-  test.concurrent("removes VERSION file", () => initFixture("has-version").then((cwd) => {
+  test.concurrent("removes VERSION file", () => initFixture("InitCommand/has-version").then((cwd) => {
     return execa(LERNA, ["init"], { cwd }).then((result) => {
       expect(result.stdout).toMatchSnapshot("stdout: has-version");
     });


### PR DESCRIPTION
## Description
Pass an explicit CWD parameter to Repository during Command instantiation.

## Motivation and Context
By passing this to every test instance, we improve test isolation and open the door to more concurrency.

This builds on the work done in #714 and #733.

## How Has This Been Tested?
Updated existing unit test suite.

## Types of changes
- [x] Internal

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
