### PR TITLE
Use relative path when specifying file: dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lerna",
-  "version": "2.0.0-beta.38",
+  "version": "2.0.0-rc.0",
   "description": "Tool for managing JavaScript projects with multiple packages",
   "main": "lib/index.js",
   "files": [

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -52,7 +52,7 @@ describe("lerna bootstrap", () => {
               test: "lerna run test",
             },
             devDependencies: {
-              lerna: "file:lerna-latest.tgz",
+              lerna: "file:./lerna-latest.tgz",
             }
           }))
           .then(() => installInDir(cwd))


### PR DESCRIPTION
Fix the test that broke when I published `v2.0.0-rc.0`