### PR TITLE
Publish: Add a `diff` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ $ lerna publish --conventional-commits
 
 When run with this flag, `publish` will use angular conventional-commit format to [determine version bump](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump) and [generate CHANGELOG](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli)
 
+#### --diff
+
+```sh
+$ lerna publish --diff
+```
+
+When run with this flag, `publish` will present you with a simple `git diff` of each package before the version selection.
+
 #### --git-remote [remote]
 
 ```sh

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -16,14 +16,6 @@ import chalk from "chalk";
 import path from "path";
 import { EOL } from "os";
 
-function getLastCommit(execOpts) {
-  if (GitUtilities.hasTags(execOpts)) {
-    return GitUtilities.getLastTaggedCommit(execOpts);
-  }
-
-  return GitUtilities.getFirstCommit(execOpts);
-}
-
 export default class PublishCommand extends Command {
   initialize(callback) {
     this.gitEnabled = !(this.flags.canary || this.flags.skipGit);
@@ -273,11 +265,16 @@ export default class PublishCommand extends Command {
       const args = [
         "--no-pager",
         "diff",
-        getLastCommit(this.execOpts),
-        "--color=auto",
-        "--",
-        targetPackage.location
+        this.getLastCommit(this.execOpts),
+        "--color=auto"
       ];
+
+      if (packageName) {
+        args.push(
+          "--",
+          targetPackage.location
+        );
+      }
 
       ChildProcessUtilities.spawn("git", args, this.execOpts, (code) => {
         if (code) {
@@ -578,5 +575,13 @@ export default class PublishCommand extends Command {
   getDistTag() {
     const { npmTag, canary } = this.getOptions();
     return npmTag || (canary && "canary") || "latest";
+  }
+
+  getLastCommit(execOpts) {
+    if (GitUtilities.hasTags(execOpts)) {
+      return GitUtilities.getLastTaggedCommit(execOpts);
+    }
+
+    return GitUtilities.getFirstCommit(execOpts);
   }
 }

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -8,6 +8,7 @@ import normalizeNewline from "normalize-newline";
 import writeJsonFile from "write-json-file";
 import writePkg from "write-pkg";
 import ConventionalCommitUtilities from "../src/ConventionalCommitUtilities";
+import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import GitUtilities from "../src/GitUtilities";
 import NpmUtilities from "../src/NpmUtilities";
 import PromptUtilities from "../src/PromptUtilities";
@@ -849,6 +850,118 @@ describe("PublishCommand", () => {
       }));
     });
   });
+
+  /** =========================================================================
+   * NORMAL - DIFF
+   * ======================================================================= */
+
+  describe("normal mode with --diff", () => {
+    let testDir;
+
+    beforeEach(() => initFixture("PublishCommand/normal").then((dir) => {
+      testDir = dir;
+    }));
+
+    it("shows a git diff before each version prompt", (done) => {
+      const publishCommand = new PublishCommand([], {
+        diff: true
+      }, testDir);
+
+      ChildProcessUtilities.spawn = jest.fn();
+      publishCommand.getLastCommit = jest.fn().mockReturnValue("commit_id");
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      publishCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          if (pathExists.sync(path.join(testDir, "lerna-debug.log"))) {
+            // TODO: there has to be a better way to do this
+            throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
+          }
+
+          const gitDiffArgs = [
+            "--no-pager",
+            "diff",
+            "commit_id",
+            "--color=auto"
+          ];
+
+          expect(ChildProcessUtilities.spawn).lastCalledWith(
+            "git", gitDiffArgs, { cwd: testDir }, () => {}
+          );
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+  });
+
+  /** =========================================================================
+   * INDEPENDENT - DIFF
+   * ======================================================================= */
+
+  describe("independent mode with --diff", () => {
+    let testDir;
+
+    beforeEach(() => initFixture("PublishCommand/independent").then((dir) => {
+      testDir = dir;
+    }));
+
+    it("shows a git diff before each version prompt", (done) => {
+      const publishCommand = new PublishCommand([], {
+        diff: true
+      }, testDir);
+
+      ChildProcessUtilities.spawn = jest.fn();
+      publishCommand.getLastCommit = jest.fn().mockReturnValue("commit_id");
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      publishCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          if (pathExists.sync(path.join(testDir, "lerna-debug.log"))) {
+            // TODO: there has to be a better way to do this
+            throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
+          }
+
+          const gitDiffArgs = [
+            "--no-pager",
+            "diff",
+            "commit_id",
+            "--color=auto",
+            "--"
+          ];
+
+          [
+            ["package-1", "1.0.0"],
+            ["package-2", "2.0.0"],
+            ["package-3", "3.0.0"],
+            ["package-4", "4.0.0"],
+          ].forEach(([name, version]) => {
+            expect(ChildProcessUtilities.spawn).toHaveBeenCalledWith(
+              "git",
+              gitDiffArgs.concat(`${testDir}/packages/${name}`),
+              { cwd: testDir },
+              () => {}
+            );
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+  });
+
 
   /** =========================================================================
    * NORMAL - GIT REMOTE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch basically takes some lines from `DiffCommand` and executes
them if the `--diff` flag is set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using lerna sometimes I want to know the code that lerna is about
to publish to help me figure out the version I would like for it to be
published as.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I some manual testing of this after looking at the tests for publish and it worked fine for me when independent publishing. I proceeded to add some tests for normal and independent mode but they are sadly both failing and I'm not sure on what's wrong with them. Any pointers here would be great 😊

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
