### PR TITLE
Add eslint-plugin-node

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,10 @@
 {
-  "extends": "babel"
+  "extends": ["babel", "plugin:node/recommended"],
+  "plugins": ["node"],
+  "rules": {
+    "node/no-unsupported-features": ["error", {
+      "version": 4,
+      "ignores": ["syntax"]
+    }]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "read-cmd-shim": "^1.0.1",
     "read-pkg": "^2.0.0",
     "rimraf": "^2.6.1",
+    "safe-buffer": "^5.0.1",
     "semver": "^5.1.0",
     "signal-exit": "^3.0.2",
     "write-json-file": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-config-babel": "^6.0.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-flowtype": "^2.30.4",
+    "eslint-plugin-node": "^4.2.2",
     "file-url": "^2.0.2",
     "jest": "^19.0.2",
     "normalize-newline": "^3.0.0",

--- a/src/Command.js
+++ b/src/Command.js
@@ -246,6 +246,8 @@ export default class Command {
       }
 
       if (process.env.NODE_ENV !== "lerna-test") {
+        // TODO: don't call process.exit()
+        // eslint-disable-next-line no-process-exit
         process.exit(code);
       }
     };

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -175,5 +175,5 @@ export default class UpdatedPackagesCollector {
   }
 }
 
-// eslint-disable-next-line max-len
+// eslint-disable-next-line max-len, node/no-deprecated-api
 const SECRET_FLAG = new Buffer("ZGFuZ2Vyb3VzbHlPbmx5UHVibGlzaEV4cGxpY2l0VXBkYXRlc1RoaXNJc0FDdXN0b21GbGFnRm9yQmFiZWxBbmRZb3VTaG91bGROb3RCZVVzaW5nSXRKdXN0RGVhbFdpdGhNb3JlUGFja2FnZXNCZWluZ1B1Ymxpc2hlZEl0SXNOb3RBQmlnRGVhbA==", "base64").toString("ascii");

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -175,5 +175,7 @@ export default class UpdatedPackagesCollector {
   }
 }
 
-// eslint-disable-next-line max-len, node/no-deprecated-api
-const SECRET_FLAG = new Buffer("ZGFuZ2Vyb3VzbHlPbmx5UHVibGlzaEV4cGxpY2l0VXBkYXRlc1RoaXNJc0FDdXN0b21GbGFnRm9yQmFiZWxBbmRZb3VTaG91bGROb3RCZVVzaW5nSXRKdXN0RGVhbFdpdGhNb3JlUGFja2FnZXNCZWluZ1B1Ymxpc2hlZEl0SXNOb3RBQmlnRGVhbA==", "base64").toString("ascii");
+// TODO: remove this when we _really_ remove support for SECRET_FLAG
+const Buffer = require("safe-buffer").Buffer;
+// eslint-disable-next-line max-len
+const SECRET_FLAG = Buffer.from("ZGFuZ2Vyb3VzbHlPbmx5UHVibGlzaEV4cGxpY2l0VXBkYXRlc1RoaXNJc0FDdXN0b21GbGFnRm9yQmFiZWxBbmRZb3VTaG91bGROb3RCZVVzaW5nSXRKdXN0RGVhbFdpdGhNb3JlUGFja2FnZXNCZWluZ1B1Ymxpc2hlZEl0SXNOb3RBQmlnRGVhbA==", "base64").toString("ascii");

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -349,5 +349,5 @@ describe("UpdatedCommand", () => {
   });
 });
 
-// eslint-disable-next-line max-len
+// eslint-disable-next-line max-len, node/no-deprecated-api
 const SECRET_FLAG = new Buffer("ZGFuZ2Vyb3VzbHlPbmx5UHVibGlzaEV4cGxpY2l0VXBkYXRlc1RoaXNJc0FDdXN0b21GbGFnRm9yQmFiZWxBbmRZb3VTaG91bGROb3RCZVVzaW5nSXRKdXN0RGVhbFdpdGhNb3JlUGFja2FnZXNCZWluZ1B1Ymxpc2hlZEl0SXNOb3RBQmlnRGVhbA==", "base64").toString("ascii");

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -349,5 +349,7 @@ describe("UpdatedCommand", () => {
   });
 });
 
-// eslint-disable-next-line max-len, node/no-deprecated-api
-const SECRET_FLAG = new Buffer("ZGFuZ2Vyb3VzbHlPbmx5UHVibGlzaEV4cGxpY2l0VXBkYXRlc1RoaXNJc0FDdXN0b21GbGFnRm9yQmFiZWxBbmRZb3VTaG91bGROb3RCZVVzaW5nSXRKdXN0RGVhbFdpdGhNb3JlUGFja2FnZXNCZWluZ1B1Ymxpc2hlZEl0SXNOb3RBQmlnRGVhbA==", "base64").toString("ascii");
+// TODO: remove this when we _really_ remove support for SECRET_FLAG
+const Buffer = require("safe-buffer").Buffer;
+// eslint-disable-next-line max-len
+const SECRET_FLAG = Buffer.from("ZGFuZ2Vyb3VzbHlPbmx5UHVibGlzaEV4cGxpY2l0VXBkYXRlc1RoaXNJc0FDdXN0b21GbGFnRm9yQmFiZWxBbmRZb3VTaG91bGROb3RCZVVzaW5nSXRKdXN0RGVhbFdpdGhNb3JlUGFja2FnZXNCZWluZ1B1Ymxpc2hlZEl0SXNOb3RBQmlnRGVhbA==", "base64").toString("ascii");

--- a/test/fixtures/.eslintrc
+++ b/test/fixtures/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "extends": "../../.eslintrc",
+  "rules": {
+    "node/no-missing-require": ["error", {
+      "allowModules": [
+        "@integration/package-1",
+        "@integration/package-2"
+      ]
+    }]
+  }
+}

--- a/test/fixtures/BootstrapCommand/basic/packages/package-2/cli.js
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-2/cli.js
@@ -1,2 +1,2 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/basic/packages/package-3/cli1.js
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-3/cli1.js
@@ -1,2 +1,2 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/basic/packages/package-3/cli2.js
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-3/cli2.js
@@ -1,2 +1,2 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/extra/package-3/cli1.js
+++ b/test/fixtures/BootstrapCommand/extra/package-3/cli1.js
@@ -1,2 +1,2 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/extra/package-3/cli2.js
+++ b/test/fixtures/BootstrapCommand/extra/package-3/cli2.js
@@ -1,2 +1,2 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/extra/packages/package-2/cli.js
+++ b/test/fixtures/BootstrapCommand/extra/packages/package-2/cli.js
@@ -1,2 +1,2 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/integration-lifecycle/package-2/cli.js
+++ b/test/fixtures/BootstrapCommand/integration-lifecycle/package-2/cli.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 const msg = require("./");
 

--- a/test/fixtures/BootstrapCommand/integration-lifecycle/package-3/cli1.js
+++ b/test/fixtures/BootstrapCommand/integration-lifecycle/package-3/cli1.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 const msg = require("@integration/package-1");
 

--- a/test/fixtures/BootstrapCommand/integration-lifecycle/package-3/cli2.js
+++ b/test/fixtures/BootstrapCommand/integration-lifecycle/package-3/cli2.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 const msg = require("@integration/package-2");
 

--- a/test/fixtures/BootstrapCommand/integration/package-2/cli.js
+++ b/test/fixtures/BootstrapCommand/integration/package-2/cli.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 const msg = require("./");
 

--- a/test/fixtures/BootstrapCommand/integration/package-3/cli1.js
+++ b/test/fixtures/BootstrapCommand/integration/package-3/cli1.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 const msg = require("@integration/package-1");
 

--- a/test/fixtures/BootstrapCommand/integration/package-3/cli2.js
+++ b/test/fixtures/BootstrapCommand/integration/package-3/cli2.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 const msg = require("@integration/package-2");
 

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -1,3 +1,4 @@
+/* eslint node/no-unsupported-features: ["error", { version: 4 }] */
 // this file is not transpiled by Jest when required in replaceLernaVersion.js
 "use strict";
 

--- a/test/helpers/serializePlaceholders.js
+++ b/test/helpers/serializePlaceholders.js
@@ -1,3 +1,4 @@
+/* eslint node/no-unsupported-features: ["error", { version: 4 }] */
 // this file is not transpiled by Jest when configured in "snapshotSerializers"
 "use strict";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,6 +3342,10 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
+safe-buffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
 sane@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.5.0.tgz#a4adeae764d048621ecb27d5f9ecf513101939f3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,6 +1430,16 @@ eslint-plugin-flowtype@^2.30.4:
   dependencies:
     lodash "^4.15.0"
 
+eslint-plugin-node@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz#82959ca9aed79fcbd28bb1b188d05cac04fb3363"
+  dependencies:
+    ignore "^3.0.11"
+    minimatch "^3.0.2"
+    object-assign "^4.0.1"
+    resolve "^1.1.7"
+    semver "5.3.0"
+
 eslint@^3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
@@ -1939,7 +1949,7 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-ignore@^3.2.0:
+ignore@^3.0.11, ignore@^3.2.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.6.tgz#26e8da0644be0bb4cb39516f6c79f0e0f4ffe48c"
 
@@ -3274,7 +3284,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.2.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
   dependencies:
@@ -3348,7 +3358,7 @@ sax@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.0.1, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 


### PR DESCRIPTION
## Description
Add `eslint-plugin-node` with enforcement of node v4 compatibility.

## Motivation and Context
It's really frustrating when you write code that doesn't work on a supported platform.

Specifically, when writing CommonJS (because Jest a `snapshotSerializer` isn't transpiled), I forget what is and isn't supported by Node v4, which I basically never run anymore (except when trying to debug mysterious CI failures).

We also have a few issues with "best-practice" compliance. I fixed one of them with `safe-buffer`, but the `process.exit()` thing I just ignored and added a `TODO`. It'll get easier to fix that one once we're in `async`/`await` land.

## How Has This Been Tested?
Running automated tests.

## Types of changes
- [x] Internal

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
