### PR TITLE
npm init starts at 1.0.0 and so should we

### DIFF
--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -69,7 +69,7 @@ export default class InitCommand extends Command {
     } else if (this.repository.version) {
       version = this.repository.version;
     } else {
-      version = "0.0.0";
+      version = "1.0.0";
     }
 
     if (!this.repository.initVersion) {


### PR DESCRIPTION
## Description

The `npm init` starts at version 1.0.0. It's better for the package environment to not ship 0.X.Y packages. So for lerna's initialization we should match their practice.

## Motivation and Context

Matching peer tool's best practice.

## How Has This Been Tested?

## Types of changes

This is a patch level change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
