### PR TITLE
Reference conventionalcommits.org website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ When run with this flag, `publish` publishes packages in a more granular way (pe
 $ lerna publish --conventional-commits
 ```
 
-When run with this flag, `publish` will use angular conventional-commit format to [determine version bump](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump) and [generate CHANGELOG](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli)
+When run with this flag, `publish` will use the [Conventional Commits Specification](https://conventionalcommits.org/) to [determine the version bump](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump) and [generate CHANGELOG](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli)
 
 #### --git-remote [remote]
 


### PR DESCRIPTION
## Description

I've switched to referencing the [conventionalcommits.org](conventionalcommits.org) website in the section of documentation on the `--conventional-commits` flag.

## Motivation and Context

I think it's worth having a centralized website that describes the concept of conventional commits, rather than it being spread out across various projects.