### PR TITLE
Use temp-write for multi-line commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "safe-buffer": "^5.0.1",
     "semver": "^5.1.0",
     "signal-exit": "^3.0.2",
-    "tempy": "^0.1.0",
+    "temp-write": "^3.2.0",
     "write-json-file": "^2.0.0",
     "write-pkg": "^2.1.0",
     "yargs": "^7.0.2"
@@ -80,7 +80,8 @@
     "jest": "^19.0.2",
     "normalize-newline": "^3.0.0",
     "normalize-path": "^2.1.1",
-    "replacestream": "^4.0.2"
+    "replacestream": "^4.0.2",
+    "tempy": "^0.1.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -1,3 +1,5 @@
+import { EOL } from "os";
+import tempWrite from "temp-write";
 import ChildProcessUtilities from "./ChildProcessUtilities";
 import logger from "./logger";
 import escapeArgs from "command-join";
@@ -29,8 +31,16 @@ export default class GitUtilities {
 
   @logger.logifySync()
   static commit(message, opts) {
-    // Use echo to allow multi\nline strings.
-    ChildProcessUtilities.execSync("git commit -m \"$(echo \"" + message + "\")\"", opts);
+    const cmd = ["git", "commit"];
+
+    if (message.indexOf(EOL) > -1) {
+      // Use tempfile to allow multi\nline strings.
+      cmd.push("-F", tempWrite.sync(message, "lerna-commit.txt"));
+    } else {
+      cmd.push("-m", message);
+    }
+
+    ChildProcessUtilities.execSync(cmd.join(" "), opts);
   }
 
   @logger.logifySync()

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`commit: updates fixed versions 1`] = `
+"v1.0.1
+"
+`;
+
+exports[`commit: updates independent versions 1`] = `
+"Publish
+
+ - package-1@2.0.0
+ - package-2@3.0.0
+ - package-3@4.0.0
+ - package-4@5.0.0
+"
+`;
+
 exports[`packages: updates fixed versions 1`] = `
 Array [
   Object {
@@ -66,19 +81,6 @@ Array [
     "version": "5.0.0",
   },
 ]
-`;
-
-exports[`packages: updates independent versions by npm 1`] = `
-"Lerna __TEST_VERSION__
-Current version: 1.0.0
-Checking for updated packages...
-No tags found! Comparing with initial commit.
-
-Changes:
-- @integration/package-1: 1.0.0 => 2.0.0
-- @integration/package-2: 1.0.0 => 2.0.0
-
-Assuming confirmation."
 `;
 
 exports[`stdout: updates fixed versions 1`] = `

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -1,59 +1,56 @@
 import execa from "execa";
+import normalizeNewline from "normalize-newline";
 import initFixture from "../helpers/initFixture";
 import { loadAllPackages } from "../helpers/packageTools";
 import { LERNA_BIN } from "../helpers/constants";
 
-const installInDir = (cwd) =>
-  execa("npm", ["install", "--cache-min=99999"], { cwd });
+const lastCommitMessage = (cwd) =>
+  execa.stdout("git", ["log", "-1", "--format=%B"], { cwd }).then(normalizeNewline);
 
 describe("lerna publish", () => {
-  test.concurrent("updates fixed versions", () => initFixture("PublishCommand/normal").then((cwd) => {
-    const args = [
-      "publish",
-      "--skip-npm",
-      "--cd-version=patch",
-      "--yes",
-    ];
-
-    return execa(LERNA_BIN, args, { cwd }).then((result) => {
-      expect(result.stdout).toMatchSnapshot("stdout: updates fixed versions");
-
-      return loadAllPackages(cwd).then((allPackageJsons) => {
-        expect(allPackageJsons).toMatchSnapshot("packages: updates fixed versions");
-      });
-    });
-  }));
-
-  test("updates independent versions", () => initFixture("PublishCommand/independent").then((cwd) => {
-    const args = [
-      "publish",
-      "--skip-npm",
-      "--cd-version=major",
-      "--yes",
-    ];
-
-    return execa(LERNA_BIN, args, { cwd }).then((result) => {
-      expect(result.stdout).toMatchSnapshot("stdout: updates independent versions");
-
-      return loadAllPackages(cwd).then((allPackageJsons) => {
-        expect(allPackageJsons).toMatchSnapshot("packages: updates independent versions");
-      });
-    });
-  }));
-
-  test("updates independent versions by npm", () => {
-    return initFixture("PublishCommand/integration").then((cwd) => {
+  test.concurrent("updates fixed versions", () => {
+    return initFixture("PublishCommand/normal").then((cwd) => {
       const args = [
-        "run",
-        "lp",
-        "--silent"
+        "publish",
+        "--skip-npm",
+        "--cd-version=patch",
+        "--yes",
       ];
-      return Promise.resolve()
-        .then(() => installInDir(cwd))
-        .then(() => execa("npm", args, { cwd }))
-        .then((result) => {
-          expect(result.stdout).toMatchSnapshot("packages: updates independent versions by npm");
+
+      return execa(LERNA_BIN, args, { cwd }).then((result) => {
+        expect(result.stdout).toMatchSnapshot("stdout: updates fixed versions");
+
+        return Promise.all([
+          loadAllPackages(cwd),
+          lastCommitMessage(cwd),
+        ]).then(([allPackageJsons, commitMessage]) => {
+          expect(allPackageJsons).toMatchSnapshot("packages: updates fixed versions");
+          expect(commitMessage).toMatchSnapshot("commit: updates fixed versions");
         });
+      });
+    });
+  });
+
+  test.concurrent("updates independent versions", () => {
+    return initFixture("PublishCommand/independent").then((cwd) => {
+      const args = [
+        "publish",
+        "--skip-npm",
+        "--cd-version=major",
+        "--yes",
+      ];
+
+      return execa(LERNA_BIN, args, { cwd }).then((result) => {
+        expect(result.stdout).toMatchSnapshot("stdout: updates independent versions");
+
+        return Promise.all([
+          loadAllPackages(cwd),
+          lastCommitMessage(cwd),
+        ]).then(([allPackageJsons, commitMessage]) => {
+          expect(allPackageJsons).toMatchSnapshot("packages: updates independent versions");
+          expect(commitMessage).toMatchSnapshot("commit: updates independent versions");
+        });
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3006,7 +3006,7 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
-pify@^2.0.0, pify@^2.3.0:
+pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -3608,6 +3608,17 @@ temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
 
+temp-write@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.2.0.tgz#9de5c847b952918ad2be13433da25772cfed5241"
+  dependencies:
+    graceful-fs "^4.1.2"
+    is-stream "^1.1.0"
+    mkdirp "^0.5.0"
+    pify "^2.2.0"
+    temp-dir "^1.0.0"
+    uuid "^3.0.1"
+
 tempfile@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-1.1.1.tgz#5bcc4eaecc4ab2c707d8bc11d99ccc9a2cb287f2"
@@ -3767,7 +3778,7 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 


### PR DESCRIPTION
* Move `tempy` to `devDependencies`
* Remove `lerna-publish` lifecycle integration test
* Add multi-line commit validation integration tests

Fixes #552, #551