### PR TITLE
Use execa for child_process calls

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -38,5 +38,3 @@ yargs
   .help("h").alias("h", "help")
   .version().alias("v", "version")
   .argv;
-
-require("signal-exit").unload();

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -8,10 +8,16 @@ const path = require("path");
 
 logger.setLogLevel(yargs.argv.loglevel);
 
+// workaround non-interactive yargs.terminalWidth() error
+// until https://github.com/yargs/yargs/pull/837 is released
+function terminalWidth() {
+  return typeof process.stdout.columns !== "undefined" ? process.stdout.columns : null;
+}
+
 yargs
   .epilogue("For more information, find our manual at https://github.com/lerna/lerna")
   .usage("$ lerna [command] [flags]")
-  .wrap(yargs.terminalWidth())
+  .wrap(terminalWidth())
   .option("loglevel", {
     default: "info",
     describe: "What level of logs to report. On failure, all logs are written to lerna-debug.log in the"

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -6,6 +6,13 @@ const logger = require("../lib/logger");
 const yargs = require("yargs");
 const path = require("path");
 
+// the options grouped under "Global Options:" header
+const globalKeys = Object.keys(globalOptions).concat([
+  "loglevel",
+  "help",
+  "version",
+]);
+
 logger.setLogLevel(yargs.argv.loglevel);
 
 // workaround non-interactive yargs.terminalWidth() error
@@ -16,7 +23,7 @@ function terminalWidth() {
 
 yargs
   .epilogue("For more information, find our manual at https://github.com/lerna/lerna")
-  .usage("$ lerna [command] [flags]")
+  .usage("Usage: $0 <command> [options]")
   .wrap(terminalWidth())
   .option("loglevel", {
     default: "info",
@@ -25,10 +32,11 @@ yargs
     type: "string",
     global: true
   })
-  .options(globalOptions).group(Object.keys(globalOptions), "Global Options:")
+  .options(globalOptions).group(globalKeys, "Global Options:")
   .commandDir(path.join(__dirname, "..", "lib", "commands"))
   .demandCommand()
-  .help()
+  .help("h").alias("h", "help")
+  .version().alias("v", "version")
   .argv;
 
 require("signal-exit").unload();

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -13,13 +13,13 @@ const globalKeys = Object.keys(globalOptions).concat([
   "version",
 ]);
 
-logger.setLogLevel(yargs.argv.loglevel);
-
 // workaround non-interactive yargs.terminalWidth() error
 // until https://github.com/yargs/yargs/pull/837 is released
 function terminalWidth() {
   return typeof process.stdout.columns !== "undefined" ? process.stdout.columns : null;
 }
+
+logger.setLogLevel(yargs.argv.loglevel);
 
 yargs
   .epilogue("For more information, find our manual at https://github.com/lerna/lerna")

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "load-json-file": "^2.0.0",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.0",
+    "p-finally": "^1.0.0",
     "path-exists": "^3.0.0",
     "progress": "^2.0.0",
     "read-cmd-shim": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "safe-buffer": "^5.0.1",
     "semver": "^5.1.0",
     "signal-exit": "^3.0.2",
+    "strong-log-transformer": "^1.0.6",
     "temp-write": "^3.2.0",
     "write-json-file": "^2.0.0",
     "write-pkg": "^2.1.0",

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -1,113 +1,46 @@
-import child from "child_process";
-import spawn from "cross-spawn";
 import { EventEmitter } from "events";
+import execa from "execa";
+import pFinally from "p-finally";
+import logTransformer from "strong-log-transformer";
 
 // Keep track of how many live children we have.
 let children = 0;
 
-// maxBuffer value for running exec
-const MAX_BUFFER = 500 * 1024;
-
 // This is used to alert listeners when all children have exited.
-const emitter = new EventEmitter;
+const emitter = new EventEmitter();
 
 export default class ChildProcessUtilities {
-  static exec(command, opts, callback) {
-    const mergedOpts = Object.assign({
-      maxBuffer: MAX_BUFFER
-    }, opts);
-    return ChildProcessUtilities.registerChild(
-      child.exec(command, mergedOpts, (err, stdout, stderr) => {
-        if (err != null) {
+  static exec(command, args, opts, callback) {
+    const options = Object.assign({}, opts);
+    options.stdio = "pipe"; // node default
 
-          // If the error from `child.exec` is just that the child process
-          // emitted too much on stderr, then that stderr output is likely to
-          // be useful.
-          if (/^stderr maxBuffer exceeded/.test(err.message)) {
-            err = `Error: ${err.message}.  Partial output follows:\n\n${stderr}`;
-          }
-
-          callback(err || stderr, stdout);
-        } else {
-          callback(null, stdout);
-        }
-      })
-    );
+    return _spawn(command, args, options, callback);
   }
 
-  static execSync(command, opts) {
-    const mergedOpts = Object.assign({
-      encoding: "utf8",
-      maxBuffer: MAX_BUFFER
-    }, opts);
-
-    let stdout = child.execSync(command, mergedOpts);
-    if (stdout) {
-      // stdout is undefined when stdio[1] is anything other than "pipe"
-      // and there's no point trimming an empty string (no piped stdout)
-      stdout = stdout.trim();
-    }
-
-    return stdout;
+  static execSync(command, args, opts) {
+    return execa.sync(command, args, opts).stdout;
   }
 
   static spawn(command, args, opts, callback) {
-    let output = "";
+    const options = Object.assign({}, opts);
+    options.stdio = "inherit";
 
-    const childProcess = _spawn(command, args, opts, (err) => callback(err, output));
-
-    // By default stderr, stdout are inherited from us (just sent to _our_ output).
-    // If the caller overrode that to "pipe", then we'll gather that up and
-    // call back with it in case of failure.
-    if (childProcess.stderr) {
-      childProcess.stderr.setEncoding("utf8");
-      childProcess.stderr.on("data", (chunk) => output += chunk);
-    }
-
-    if (childProcess.stdout) {
-      childProcess.stdout.setEncoding("utf8");
-      childProcess.stdout.on("data", (chunk) => output += chunk);
-    }
+    return _spawn(command, args, options, callback);
   }
 
   static spawnStreaming(command, args, opts, prefix, callback) {
-    opts = Object.assign({}, opts, {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const options = Object.assign({}, opts);
+    options.stdio = ["ignore", "pipe", "pipe"];
 
-    const childProcess = _spawn(command, args, opts, callback);
+    const spawned = _spawn(command, args, options, callback);
 
-    ["stdout", "stderr"].forEach((stream) => {
-      let partialLine = "";
-      childProcess[stream].setEncoding("utf8")
-        .on("data", (chunk) => {
-          const lines = chunk.split("\n");
-          lines[0] = partialLine + lines[0];
-          partialLine = lines.pop();
-          lines.forEach((line) => process[stream].write(prefix + line + "\n"));
-        })
-        .on("end", () => {
-          if (partialLine) {
+    const prefixedStdout = logTransformer({ tag: `${prefix}:` });
+    const prefixedStderr = logTransformer({ tag: `${prefix} ERROR`, mergeMultiline: true });
 
-            // If the child process ended its output with no final newline we
-            // need to flush that out.  We'll add a newline ourselves so we
-            // don't end up with output from multiple children on the same
-            // line.
-            process[stream].write(prefix + partialLine + "\n");
-          }
-        });
-    });
-  }
+    spawned.stdout.pipe(prefixedStdout).pipe(process.stdout);
+    spawned.stderr.pipe(prefixedStderr).pipe(process.stderr);
 
-  static registerChild(child) {
-    children++;
-    child.on("exit", () => {
-      children--;
-      if (children === 0) {
-        emitter.emit("empty");
-      }
-    });
-    return child;
+    return spawned;
   }
 
   static getChildProcessCount() {
@@ -119,18 +52,29 @@ export default class ChildProcessUtilities {
   }
 }
 
+function registerChild(child) {
+  children++;
+
+  pFinally(child, () => {
+    children--;
+
+    if (children === 0) {
+      emitter.emit("empty");
+    }
+  });
+}
+
 function _spawn(command, args, opts, callback) {
-  return ChildProcessUtilities.registerChild(
-    spawn(command, args, Object.assign({
-      stdio: "inherit"
-    }, opts))
-      .on("error", () => {})
-      .on("close", (code) => {
-        if (code) {
-          callback(`Command exited with status ${code}: ${command} ${args.join(" ")}`);
-        } else {
-          callback(null);
-        }
-      })
-  );
+  const child = execa(command, args, opts);
+
+  registerChild(child);
+
+  if (callback) {
+    child.then(
+      (result) => callback(null, result.stdout),
+      (err) => callback(err)
+    );
+  }
+
+  return child;
 }

--- a/src/Command.js
+++ b/src/Command.js
@@ -15,7 +15,6 @@ export const builder = {
     type: "number",
     requiresArg: true,
     default: DEFAULT_CONCURRENCY,
-    coerce: (val) => Math.max(1, val)
   },
   "ignore": {
     describe: "Ignores packages with names matching the given glob (Works only in combination with the "
@@ -41,6 +40,7 @@ export const builder = {
   },
   "sort": {
     describe: "Sort packages topologically",
+    type: "boolean",
     default: true
   }
 };

--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -11,29 +11,21 @@ const CHANGELOG_HEADER = dedent(`# Change Log
   All notable changes to this project will be documented in this file.
   See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.`);
 
-const RECOMMEND_CLI = require.resolve("conventional-recommended-bump/cli.js");
-const CHANGELOG_CLI = require.resolve("conventional-changelog-cli/cli.js");
-
 export default class ConventionalCommitUtilities {
   @logger.logifySync()
   static recommendVersion(pkg, opts) {
-    const name = pkg.name;
-    const version = pkg.version;
-    const pkgLocation = pkg.location;
-
     const recommendedBump = ChildProcessUtilities.execSync(
-      `${RECOMMEND_CLI} -l ${name} --commit-path=${pkgLocation} -p angular`,
+      "conventional-recommended-bump",
+      ["-l", pkg.name, "--commit-path", pkg.location, "-p", "angular"],
       opts
     );
 
-    return semver.inc(version, recommendedBump);
+    return semver.inc(pkg.version, recommendedBump);
   }
 
   @logger.logifySync()
   static updateChangelog(pkg, opts) {
-    const name = pkg.name;
-    const pkgLocation = pkg.location;
-    const pkgJsonLocation = path.join(pkgLocation, "package.json");
+    const pkgJsonLocation = path.join(pkg.location, "package.json");
     const changelogLocation = ConventionalCommitUtilities.changelogLocation(pkg);
 
     let changelogContents = "";
@@ -44,7 +36,8 @@ export default class ConventionalCommitUtilities {
     // run conventional-changelog-cli to generate the markdown
     // for the upcoming release.
     const newEntry = ChildProcessUtilities.execSync(
-      `${CHANGELOG_CLI} -l ${name} --commit-path=${pkgLocation} --pkg=${pkgJsonLocation} -p angular`,
+      "conventional-changelog",
+      ["-l", pkg.name, "--commit-path", pkg.location, "--pkg", pkgJsonLocation, "-p", "angular"],
       opts
     );
 

--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -12,6 +12,11 @@ function ensureEndsWithNewLine(string) {
   return ENDS_WITH_NEW_LINE.test(string) ? string : string + "\n";
 }
 
+// globs only return directories with a trailing slash
+function trailingSlash(filePath) {
+  return path.normalize(`${filePath}/`);
+}
+
 export default class FileSystemUtilities {
   @logger.logifyAsync()
   static mkdirp(filePath, callback) {
@@ -59,16 +64,14 @@ export default class FileSystemUtilities {
   }
 
   @logger.logifyAsync()
-  static rimraf(filePath, callback) {
-
+  static rimraf(dirPath, callback) {
     // Shelling out to a child process for a noop is expensive.
-    // Checking if `filePath` exists to be removed is cheap.
+    // Checking if `dirPath` exists to be removed is cheap.
     // This lets us short-circuit if we don't have anything to do.
-    pathExists(filePath).then((exists) => {
+    pathExists(dirPath).then((exists) => {
       if (!exists) return callback();
 
-      // Note: if rimraf moves the location of its executable, this will need to be updated
-      ChildProcessUtilities.spawn(require.resolve("rimraf/bin"), [filePath], {}, callback);
+      ChildProcessUtilities.spawn("rimraf", ["--no-glob", trailingSlash(dirPath)], {}, callback);
     });
   }
 

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -2,7 +2,6 @@ import { EOL } from "os";
 import tempWrite from "temp-write";
 import ChildProcessUtilities from "./ChildProcessUtilities";
 import logger from "./logger";
-import escapeArgs from "command-join";
 
 export default class GitUtilities {
   @logger.logifySync()
@@ -15,7 +14,7 @@ export default class GitUtilities {
   static isInitialized(opts) {
     try {
       // we only want the return code, so ignore stdout/stderr
-      ChildProcessUtilities.execSync("git rev-parse", Object.assign({}, opts, {
+      ChildProcessUtilities.execSync("git", ["rev-parse"], Object.assign({}, opts, {
         stdio: "ignore"
       }));
       return true;
@@ -26,100 +25,100 @@ export default class GitUtilities {
 
   @logger.logifySync()
   static addFile(file, opts) {
-    ChildProcessUtilities.execSync("git add " + escapeArgs(file), opts);
+    ChildProcessUtilities.execSync("git", ["add", file], opts);
   }
 
   @logger.logifySync()
   static commit(message, opts) {
-    const cmd = ["git", "commit"];
+    const args = ["commit"];
 
     if (message.indexOf(EOL) > -1) {
       // Use tempfile to allow multi\nline strings.
-      cmd.push("-F", tempWrite.sync(message, "lerna-commit.txt"));
+      args.push("-F", tempWrite.sync(message, "lerna-commit.txt"));
     } else {
-      cmd.push("-m", message);
+      args.push("-m", message);
     }
 
-    ChildProcessUtilities.execSync(cmd.join(" "), opts);
+    ChildProcessUtilities.execSync("git", args, opts);
   }
 
   @logger.logifySync()
   static addTag(tag, opts) {
-    ChildProcessUtilities.execSync("git tag -a " + tag + " -m \"" + tag + "\"", opts);
+    ChildProcessUtilities.execSync("git", ["tag", "-a", tag, "-m", tag], opts);
   }
 
   @logger.logifySync()
   static removeTag(tag, opts) {
-    ChildProcessUtilities.execSync("git tag -d " + tag, opts);
+    ChildProcessUtilities.execSync("git", ["tag", "-d", tag], opts);
   }
 
   @logger.logifySync()
   static hasTags(opts) {
-    return !!ChildProcessUtilities.execSync("git tag", opts);
+    return !!ChildProcessUtilities.execSync("git", ["tag"], opts);
   }
 
   @logger.logifySync()
   static getLastTaggedCommit(opts) {
-    return ChildProcessUtilities.execSync("git rev-list --tags --max-count=1", opts);
+    return ChildProcessUtilities.execSync("git", ["rev-list", "--tags", "--max-count=1"], opts);
   }
 
   @logger.logifySync()
   static getLastTaggedCommitInBranch(opts) {
     const tagName = GitUtilities.getLastTag(opts);
-    return ChildProcessUtilities.execSync("git rev-list -n 1 " + tagName, opts);
+    return ChildProcessUtilities.execSync("git", ["rev-list", "-n", "1", tagName], opts);
   }
 
   @logger.logifySync()
   static getFirstCommit(opts) {
-    return ChildProcessUtilities.execSync("git rev-list --max-parents=0 HEAD", opts);
+    return ChildProcessUtilities.execSync("git", ["rev-list", "--max-parents=0", "HEAD"], opts);
   }
 
   @logger.logifySync()
   static pushWithTags(remote, tags, opts) {
     const branch = GitUtilities.getCurrentBranch(opts);
-    ChildProcessUtilities.execSync(`git push ${remote} ${branch}`, opts);
-    ChildProcessUtilities.execSync(`git push ${remote} ${tags.join(" ")}`, opts);
+    ChildProcessUtilities.execSync("git", ["push", remote, branch], opts);
+    ChildProcessUtilities.execSync("git", ["push", remote].concat(tags), opts);
   }
 
   @logger.logifySync()
   static getLastTag(opts) {
-    return ChildProcessUtilities.execSync("git describe --tags --abbrev=0", opts);
+    return ChildProcessUtilities.execSync("git", ["describe", "--tags", "--abbrev=0"], opts);
   }
 
   @logger.logifySync()
   static describeTag(commit, opts) {
-    return ChildProcessUtilities.execSync("git describe --tags " + commit, opts);
+    return ChildProcessUtilities.execSync("git", ["describe", "--tags", commit], opts);
   }
 
   @logger.logifySync()
   static diffSinceIn(since, location, opts) {
-    return ChildProcessUtilities.execSync(`git diff --name-only ${since} -- ${escapeArgs(location)}`, opts);
+    return ChildProcessUtilities.execSync("git", ["diff", "--name-only", since, "--", location], opts);
   }
 
   @logger.logifySync()
   static getCurrentBranch(opts) {
-    return ChildProcessUtilities.execSync("git rev-parse --abbrev-ref HEAD", opts);
+    return ChildProcessUtilities.execSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], opts);
   }
 
   @logger.logifySync()
   static getCurrentSHA(opts) {
-    return ChildProcessUtilities.execSync("git rev-parse HEAD", opts);
+    return ChildProcessUtilities.execSync("git", ["rev-parse", "HEAD"], opts);
   }
 
   @logger.logifySync()
-  static checkoutChanges(changes, opts) {
-    ChildProcessUtilities.execSync("git checkout -- " + changes, opts);
+  static checkoutChanges(fileGlob, opts) {
+    ChildProcessUtilities.execSync("git", ["checkout", "--", fileGlob], opts);
   }
 
   @logger.logifySync()
   static init(opts) {
-    return ChildProcessUtilities.execSync("git init", opts);
+    return ChildProcessUtilities.execSync("git", ["init"], opts);
   }
 
   @logger.logifySync()
   static hasCommit(opts) {
     try {
-      ChildProcessUtilities.execSync("git log", opts);
+      ChildProcessUtilities.execSync("git", ["log"], opts);
       return true;
     } catch (e) {
       return false;

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -53,9 +53,9 @@ export default class DiffCommand extends Command {
   }
 
   execute(callback) {
-    ChildProcessUtilities.spawn("git", this.args, this.execOpts, (code) => {
-      if (code) {
-        callback(new Error("Errored while spawning `git diff`."));
+    ChildProcessUtilities.spawn("git", this.args, this.execOpts, (err) => {
+      if (err && err.code) {
+        callback(err);
       } else {
         callback(null, true);
       }

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -3,10 +3,10 @@ import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 
 export function handler(argv) {
-  return new ExecCommand(argv._, argv).run();
+  return new ExecCommand([argv.command, ...argv.arguments], argv).run();
 }
 
-export const command = "exec";
+export const command = "exec <command> [arguments..]";
 
 export const describe = "Run an arbitrary command in each package.";
 

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -35,16 +35,21 @@ export default class ExecCommand extends Command {
     }, this.concurrency, callback);
   }
 
-  runCommandInPackage(pkg, callback) {
-    ChildProcessUtilities.spawn(this.command, this.args, {
+  getOpts(pkg) {
+    return {
       cwd: pkg.location,
-      env: Object.assign({}, process.env, { LERNA_PACKAGE_NAME: pkg.name })
-    }, (code) => {
-      if (code) {
-        this.logger.error(`Errored while running command '${this.command}' ` +
-                          `with arguments '${this.args.join(" ")}' in '${pkg.name}'`);
+      env: Object.assign({}, process.env, {
+        LERNA_PACKAGE_NAME: pkg.name,
+      }),
+    };
+  }
+
+  runCommandInPackage(pkg, callback) {
+    ChildProcessUtilities.spawn(this.command, this.args, this.getOpts(pkg), (err) => {
+      if (err && err.code) {
+        this.logger.error(`Errored while executing '${err.cmd}' in '${pkg.name}'`);
       }
-      callback(code);
+      callback(err);
     });
   }
 }

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -77,9 +77,10 @@ export default class RunCommand extends Command {
 
   runScriptInPackageCapturing(pkg, callback) {
     NpmUtilities.runScriptInDir(this.script, this.args, pkg.location, (err, stdout) => {
-      this.logger.info(stdout);
       if (err) {
         this.logger.error(`Errored while running npm script '${this.script}' in '${pkg.name}'`);
+      } else {
+        this.logger.info(stdout);
       }
       callback(err);
     });

--- a/test/ChildProcessUtilities.js
+++ b/test/ChildProcessUtilities.js
@@ -1,25 +1,31 @@
-import { EOL } from "os";
-
 // file under test
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
 
 describe("ChildProcessUtilities", () => {
   describe(".execSync()", () => {
     it("should execute a command in a child process and return the result", () => {
-      expect(ChildProcessUtilities.execSync("echo foo")).toBe("foo");
+      expect(ChildProcessUtilities.execSync("echo", ["execSync"])).toBe("execSync");
     });
 
     it("does not error when stdout is ignored", () => {
-      expect(() => ChildProcessUtilities.execSync("echo foo", { stdio: "ignore" })).not.toThrow();
+      expect(() => ChildProcessUtilities.execSync("echo", ["ignored"], { stdio: "ignore" })).not.toThrow();
     });
   });
 
   describe(".exec()", () => {
+    afterEach((done) => {
+      if (ChildProcessUtilities.getChildProcessCount()) {
+        ChildProcessUtilities.onAllExited(done);
+      } else {
+        done();
+      }
+    });
+
     it("should execute a command in a child process and call the callback with the result", (done) => {
-      ChildProcessUtilities.exec("echo foo", null, (stderr, stdout) => {
+      ChildProcessUtilities.exec("echo", ["foo"], null, (stderr, stdout) => {
         try {
           expect(stderr).toBe(null);
-          expect(stdout).toBe(`foo${EOL}`);
+          expect(stdout).toBe("foo");
           done();
         } catch (ex) {
           done.fail(ex);
@@ -28,10 +34,13 @@ describe("ChildProcessUtilities", () => {
     });
 
     it("passes an error object to callback when stdout maxBuffer exceeded", (done) => {
-      ChildProcessUtilities.exec("echo foo", { maxBuffer: 1 }, (stderr, stdout) => {
+      // this is expected
+      process.once("unhandledRejection", () => {});
+
+      ChildProcessUtilities.exec("echo", ["wat"], { maxBuffer: 1 }, (stderr, stdout) => {
         try {
           expect(String(stderr)).toBe("Error: stdout maxBuffer exceeded");
-          expect(stdout).toBe("");
+          expect(stdout).toBeUndefined();
           done();
         } catch (ex) {
           done.fail(ex);
@@ -39,44 +48,60 @@ describe("ChildProcessUtilities", () => {
       });
     });
 
-    if (process.platform !== "win32") {
-      // windows is too weird
-      it("passes an error object to callback when stdout maxBuffer exceeded", (done) => {
-        ChildProcessUtilities.exec("echo foo >&2", { maxBuffer: 1 }, (stderr, stdout) => {
-          try {
-            expect(stderr).toBe("Error: stderr maxBuffer exceeded.  Partial output follows:\n\n");
-            expect(stdout).toBe("");
-            done();
-          } catch (ex) {
-            done.fail(ex);
-          }
-        });
+    it("does not require a callback, instead returning a Promise", () => {
+      return ChildProcessUtilities.exec("echo", ["Promise"]).then((result) => {
+        expect(result.stdout).toBe("Promise");
       });
-    }
+    });
+
+    it("passes error object to callback", (done) => {
+      // this is also expected
+      process.once("unhandledRejection", () => {});
+
+      ChildProcessUtilities.exec("nowImTheModelOfAModernMajorGeneral", [], {}, (err) => {
+        try {
+          expect(err.message).toMatch(/\bnowImTheModelOfAModernMajorGeneral\b/);
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      });
+    });
+
+    it("passes Promise rejection through", () => {
+      return ChildProcessUtilities.exec("theVeneratedVirginianVeteranWhoseMenAreAll", []).catch((err) => {
+        // this is also expected, despite being in a weird place
+        process.once("unhandledRejection", () => {});
+
+        expect(err.message).toMatch(/\btheVeneratedVirginianVeteranWhoseMenAreAll\b/);
+      });
+    });
+
+    it("registers child processes that are created", () => {
+      const echoOne = ChildProcessUtilities.exec("echo", ["one"]);
+      expect(ChildProcessUtilities.getChildProcessCount()).toBe(1);
+
+      const echoTwo = ChildProcessUtilities.exec("echo", ["two"]);
+      expect(ChildProcessUtilities.getChildProcessCount()).toBe(2);
+
+      return Promise.all([
+        echoOne,
+        echoTwo,
+      ]).then(([one, two]) => {
+        expect(one.stdout).toBe("one");
+        expect(two.stdout).toBe("two");
+      });
+    });
   });
 
   describe(".spawn()", () => {
-    it("should spawn a command in a child process", (done) => {
-      ChildProcessUtilities.spawn("echo", ["foo"], { stdio: "pipe" }, (err, output) => {
-        if (err) return done.fail(err);
+    it("should spawn a command in a child process that always inherits stdio", () => {
+      const child = ChildProcessUtilities.spawn("echo", ["-n"]);
+      expect(child.stdio).toEqual([null, null, null]);
 
-        try {
-          expect(output.trim()).toBe("foo");
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      });
-    });
-
-    it("passes error message to callback", (done) => {
-      ChildProcessUtilities.spawn("iAmTheModelOfAModernMajorGeneral", [], { stdio: "pipe" }, (err) => {
-        try {
-          expect(String(err)).toMatch("iAmTheModelOfAModernMajorGeneral");
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
+      return child.then((result) => {
+        expect(result.code).toBe(0);
+        expect(result.signal).toBe(null);
       });
     });
   });

--- a/test/ConventionalCommitUtilities.js
+++ b/test/ConventionalCommitUtilities.js
@@ -31,7 +31,8 @@ describe("ConventionalCommitUtilities", () => {
 
       expect(recommendVersion).toBe("2.0.0");
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        `${require.resolve("conventional-recommended-bump/cli.js")} -l bar --commit-path=/foo/bar -p angular`,
+        "conventional-recommended-bump",
+        ["-l", "bar", "--commit-path", "/foo/bar", "-p", "angular"],
         opts,
       );
     });
@@ -53,7 +54,8 @@ describe("ConventionalCommitUtilities", () => {
         path.normalize("/foo/bar/CHANGELOG.md")
       );
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        `${require.resolve("conventional-changelog-cli/cli.js")} -l bar --commit-path=/foo/bar --pkg=${path.normalize("/foo/bar/package.json")} -p angular`,
+        "conventional-changelog",
+        ["-l", "bar", "--commit-path", "/foo/bar", "--pkg", path.normalize("/foo/bar/package.json"), "-p", "angular"],
         opts,
       );
       expect(FileSystemUtilities.writeFileSync).lastCalledWith(

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -17,7 +17,6 @@ jest.mock("../src/GitUtilities");
 
 describe("DiffCommand", () => {
   const callbackSuccess = callsBack(null, true);
-  const callbackNonZero = callsBack(1);
 
   let testDir;
 
@@ -159,7 +158,9 @@ describe("DiffCommand", () => {
   });
 
   it("should error when git diff exits non-zero", (done) => {
-    ChildProcessUtilities.spawn.mockImplementation(callbackNonZero);
+    const err = new Error("An actual non-zero, not git diff pager SIGPIPE");
+    err.code = 1;
+    ChildProcessUtilities.spawn.mockImplementation(callsBack(err));
 
     const diffCommand = new DiffCommand(["package-1"], {}, testDir);
 
@@ -168,7 +169,7 @@ describe("DiffCommand", () => {
 
     diffCommand.runCommand(exitWithCode(1, (err) => {
       try {
-        expect(err.message).toBe("Errored while spawning `git diff`.");
+        expect(err.message).toBe("An actual non-zero, not git diff pager SIGPIPE");
         done();
       } catch (ex) {
         done.fail(ex);

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -51,7 +51,11 @@ describe("ExecCommand", () => {
     });
 
     it("passes execution error to callback", (done) => {
-      ChildProcessUtilities.spawn = jest.fn(callsBack(1));
+      const err = new Error("execa error");
+      err.code = 1;
+      err.cmd = "boom";
+
+      ChildProcessUtilities.spawn = jest.fn(callsBack(err));
 
       const execCommand = new ExecCommand(["boom"], {}, testDir);
 
@@ -63,9 +67,7 @@ describe("ExecCommand", () => {
       execCommand.runCommand(exitWithCode(1, () => {
         try {
           expect(spy).toHaveBeenCalledTimes(2);
-          expect(spy).toBeCalledWith(
-            expect.stringContaining("Errored while running command 'boom'")
-          );
+          expect(spy).toBeCalledWith("Errored while executing 'boom' in 'package-1'");
 
           done();
         } catch (ex) {

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -94,13 +94,15 @@ describe("FileSystemUtilities", () => {
       ChildProcessUtilities.spawn.mockImplementation(callsBack());
     });
 
-    it("calls rimraf CLI with argument", (done) => {
-      const dirPath = "rimraf/test";
+    it("calls rimraf CLI with arguments", (done) => {
       pathExists.mockImplementation(() => Promise.resolve(true));
-      FileSystemUtilities.rimraf(dirPath, () => {
+      FileSystemUtilities.rimraf("rimraf/test", () => {
         try {
           expect(ChildProcessUtilities.spawn).lastCalledWith(
-            require.resolve("rimraf/bin"), [dirPath], {}, expect.any(Function)
+            "rimraf",
+            ["--no-glob", path.normalize("rimraf/test/")],
+            {},
+            expect.any(Function)
           );
           done();
         } catch (ex) {

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -41,7 +41,8 @@ describe("GitUtilities", () => {
     it("returns true when git command succeeds", () => {
       expect(GitUtilities.isInitialized({ cwd: "test" })).toBe(true);
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "git rev-parse",
+        "git",
+        ["rev-parse"],
         { cwd: "test", stdio: "ignore" }
       );
     });
@@ -59,7 +60,9 @@ describe("GitUtilities", () => {
     it("calls git add with file argument", () => {
       const opts = { cwd: "test" };
       GitUtilities.addFile("foo", opts);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git add foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["add", "foo"], opts
+      );
     });
   });
 
@@ -69,7 +72,8 @@ describe("GitUtilities", () => {
       GitUtilities.commit("foo", opts);
 
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "git commit -m foo",
+        "git",
+        ["commit", "-m", "foo"],
         opts
       );
       expect(tempWrite.sync).not.toBeCalled();
@@ -82,7 +86,8 @@ describe("GitUtilities", () => {
       GitUtilities.commit(`foo${EOL}bar`, opts);
 
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "git commit -F TEMPFILE",
+        "git",
+        ["commit", "-F", "TEMPFILE"],
         opts
       );
       expect(tempWrite.sync).lastCalledWith(`foo${EOL}bar`, "lerna-commit.txt");
@@ -93,7 +98,9 @@ describe("GitUtilities", () => {
     it("creates annotated git tag", () => {
       const opts = { cwd: "test" };
       GitUtilities.addTag("foo", opts);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -a foo -m \"foo\"", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["tag", "-a", "foo", "-m", "foo"], opts
+      );
     });
   });
 
@@ -101,7 +108,9 @@ describe("GitUtilities", () => {
     it("deletes specified git tag", () => {
       const opts = { cwd: "test" };
       GitUtilities.removeTag("foo", opts);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag -d foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["tag", "-d", "foo"], opts
+      );
     });
   });
 
@@ -110,7 +119,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "v1.0.0");
       const opts = { cwd: "test" };
       expect(GitUtilities.hasTags(opts)).toBe(true);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git tag", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["tag"], opts
+      );
     });
 
     it("returns false when no git tags exist", () => {
@@ -124,7 +135,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "deadbeef");
       const opts = { cwd: "test" };
       expect(GitUtilities.getLastTaggedCommit(opts)).toBe("deadbeef");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --tags --max-count=1", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["rev-list", "--tags", "--max-count=1"], opts
+      );
     });
   });
 
@@ -139,7 +152,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "deadbeef");
       const opts = { cwd: "test" };
       expect(GitUtilities.getLastTaggedCommitInBranch(opts)).toBe("deadbeef");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list -n 1 v1.0.0", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["rev-list", "-n", "1", "v1.0.0"], opts
+      );
     });
   });
 
@@ -148,7 +163,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "beefcafe");
       const opts = { cwd: "test" };
       expect(GitUtilities.getFirstCommit(opts)).toBe("beefcafe");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-list --max-parents=0 HEAD", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["rev-list", "--max-parents=0", "HEAD"], opts
+      );
     });
   });
 
@@ -162,8 +179,12 @@ describe("GitUtilities", () => {
       GitUtilities.getCurrentBranch = jest.fn(() => "master");
       const opts = { cwd: "test" };
       GitUtilities.pushWithTags("origin", ["foo@1.0.1", "foo-bar@1.0.0"], opts);
-      expect(ChildProcessUtilities.execSync).toBeCalledWith("git push origin master", opts);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git push origin foo@1.0.1 foo-bar@1.0.0", opts);
+      expect(ChildProcessUtilities.execSync).toBeCalledWith(
+        "git", ["push", "origin", "master"], opts
+      );
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["push", "origin", "foo@1.0.1", "foo-bar@1.0.0"], opts
+      );
     });
   });
 
@@ -172,7 +193,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "v1.0.0");
       const opts = { cwd: "test" };
       expect(GitUtilities.getLastTag(opts)).toBe("v1.0.0");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags --abbrev=0", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["describe", "--tags", "--abbrev=0"], opts
+      );
     });
   });
 
@@ -181,7 +204,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "foo@1.0.0");
       const opts = { cwd: "test" };
       expect(GitUtilities.describeTag("deadbeef", opts)).toBe("foo@1.0.0");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git describe --tags deadbeef", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["describe", "--tags", "deadbeef"], opts
+      );
     });
   });
 
@@ -191,8 +216,7 @@ describe("GitUtilities", () => {
       const opts = { cwd: "test" };
       expect(GitUtilities.diffSinceIn("foo@1.0.0", "packages/foo", opts)).toBe("files");
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "git diff --name-only foo@1.0.0 -- packages/foo",
-        opts
+        "git", ["diff", "--name-only", "foo@1.0.0", "--", "packages/foo"], opts
       );
     });
   });
@@ -202,7 +226,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "master");
       const opts = { cwd: "test" };
       expect(GitUtilities.getCurrentBranch(opts)).toBe("master");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse --abbrev-ref HEAD", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["rev-parse", "--abbrev-ref", "HEAD"], opts
+      );
     });
   });
 
@@ -211,7 +237,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "deadcafe");
       const opts = { cwd: "test" };
       expect(GitUtilities.getCurrentSHA(opts)).toBe("deadcafe");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git rev-parse HEAD", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["rev-parse", "HEAD"], opts
+      );
     });
   });
 
@@ -219,7 +247,9 @@ describe("GitUtilities", () => {
     it("calls git checkout with specified arg", () => {
       const opts = { cwd: "test" };
       GitUtilities.checkoutChanges("packages/*/package.json", opts);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git checkout -- packages/*/package.json", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["checkout", "--", "packages/*/package.json"], opts
+      );
     });
   });
 
@@ -228,7 +258,9 @@ describe("GitUtilities", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "stdout for logger");
       const opts = { cwd: "test" };
       expect(GitUtilities.init(opts)).toBe("stdout for logger");
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git init", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["init"], opts
+      );
     });
   });
 
@@ -236,7 +268,9 @@ describe("GitUtilities", () => {
     it("returns true when git command succeeds", () => {
       const opts = { cwd: "test" };
       expect(GitUtilities.hasCommit(opts)).toBe(true);
-      expect(ChildProcessUtilities.execSync).lastCalledWith("git log", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["log"], opts
+      );
     });
 
     it("returns false when git command fails", () => {

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -1,6 +1,5 @@
 import { EOL } from "os";
 import path from "path";
-import escapeArgs from "command-join";
 
 // mocked modules
 import writePkg from "write-pkg";
@@ -42,18 +41,20 @@ describe("NpmUtilities", () => {
     it("adds a dist-tag for a given package@version", () => {
       NpmUtilities.addDistTag(directory, packageName, version, tag);
 
-      const cmd = `npm dist-tag add ${packageName}@${version} ${tag}`;
+      const cmd = "npm";
+      const args = ["dist-tag", "add", "foo-pkg@1.0.0", "added-tag"];
       const opts = { directory, registry: undefined };
-      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
     });
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/add";
       NpmUtilities.addDistTag(directory, packageName, version, tag, registry);
 
-      const cmd = `npm dist-tag add ${packageName}@${version} ${tag}`;
+      const cmd = "npm";
+      const args = ["dist-tag", "add", "foo-pkg@1.0.0", "added-tag"];
       const opts = { directory, registry };
-      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
     });
   });
 
@@ -68,18 +69,20 @@ describe("NpmUtilities", () => {
     it("removes a dist-tag for a given package", () => {
       NpmUtilities.removeDistTag(directory, packageName, tag);
 
-      const cmd = `npm dist-tag rm ${packageName} ${tag}`;
+      const cmd = "npm";
+      const args = ["dist-tag", "rm", "bar-pkg", "removed-tag"];
       const opts = { directory, registry: undefined };
-      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
     });
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/remove";
       NpmUtilities.removeDistTag(directory, packageName, tag, registry);
 
-      const cmd = `npm dist-tag rm ${packageName} ${tag}`;
+      const cmd = "npm";
+      const args = ["dist-tag", "rm", "bar-pkg", "removed-tag"];
       const opts = { directory, registry };
-      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
     });
   });
 
@@ -97,9 +100,10 @@ describe("NpmUtilities", () => {
       expect(NpmUtilities.checkDistTag(directory, packageName, "latest")).toBe(true);
       expect(NpmUtilities.checkDistTag(directory, packageName, "missing")).toBe(false);
 
-      const cmd = `npm dist-tag ls ${packageName}`;
+      const cmd = "npm";
+      const args = ["dist-tag", "ls", "baz-pkg"];
       const opts = { directory, registry: undefined };
-      expect(ChildProcessUtilities.execSync).toBeCalledWith(cmd, opts);
+      expect(ChildProcessUtilities.execSync).toBeCalledWith(cmd, args, opts);
     });
 
     it("supports custom registry", () => {
@@ -108,9 +112,10 @@ describe("NpmUtilities", () => {
 
       expect(NpmUtilities.checkDistTag(directory, packageName, "target-tag", registry)).toBe(true);
 
-      const cmd = `npm dist-tag ls ${packageName}`;
+      const cmd = "npm";
+      const args = ["dist-tag", "ls", "baz-pkg"];
       const opts = { directory, registry };
-      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
     });
   });
 
@@ -123,12 +128,12 @@ describe("NpmUtilities", () => {
 
       NpmUtilities.runScriptInDir(script, args, directory, callback);
 
-      const cmd = `npm run ${script} ${escapeArgs(args)}`;
+      const cmd = "npm";
+      const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
         cwd: directory,
-        env: process.env,
       };
-      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, opts, expect.any(Function));
+      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
   });
 
@@ -146,19 +151,17 @@ describe("NpmUtilities", () => {
 
       expect(ChildProcessUtilities.spawnStreaming).lastCalledWith(
         "npm",
-        ["run", script, ...args],
+        ["run", "foo", "--bar", "baz"],
         {
           cwd: pkg.location,
-          env: process.env,
         },
-        "qux: ",
+        "qux",
         expect.any(Function)
       );
     });
   });
 
   describe(".publishTaggedInDir()", () => {
-    const tag = "published-tag";
     const directory = "/test/publishTaggedInDir";
     const callback = () => {};
 
@@ -166,27 +169,29 @@ describe("NpmUtilities", () => {
     afterEach(resetExecOpts);
 
     it("runs npm publish in a directory with --tag support", () => {
-      NpmUtilities.publishTaggedInDir(tag, directory, undefined, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, undefined, callback);
 
-      const cmd = `npm publish --tag ${tag}`;
+      const cmd = "npm";
+      const args = ["publish", "--tag", "published-tag"];
       const opts = { directory, registry: undefined };
-      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, opts, expect.any(Function));
+      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
     });
 
     it("trims trailing whitespace in tag parameter", () => {
-      NpmUtilities.publishTaggedInDir(`${tag}  `, directory, callback);
+      NpmUtilities.publishTaggedInDir("trailing-tag  ", directory, callback);
 
-      const actualCommand = ChildProcessUtilities.exec.mock.calls[0][0];
-      expect(actualCommand).toBe(`npm publish --tag ${tag}`);
+      const actualtag = ChildProcessUtilities.exec.mock.calls[0][1][2];
+      expect(actualtag).toBe("trailing-tag");
     });
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/publishTaggedInDir";
-      NpmUtilities.publishTaggedInDir(tag, directory, registry, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, registry, callback);
 
-      const cmd = `npm publish --tag ${tag}`;
+      const cmd = "npm";
+      const args = ["publish", "--tag", "published-tag"];
       const opts = { directory, registry };
-      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, opts, expect.any(Function));
+      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
     });
   });
 
@@ -228,7 +233,7 @@ describe("NpmUtilities", () => {
 
     beforeEach(() => {
       stubExecOpts();
-      ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
+      ChildProcessUtilities.exec.mockImplementation(callbackSuccess);
       FileSystemUtilities.rename.mockImplementation(callbackSuccess);
       writePkg.mockImplementation(() => Promise.resolve());
     });
@@ -269,10 +274,9 @@ describe("NpmUtilities", () => {
               },
             },
           );
-          expect(ChildProcessUtilities.spawn).lastCalledWith("npm", ["install"], {
+          expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install"], {
             directory,
             registry: undefined,
-            stdio: ["ignore", "pipe", "pipe"],
           }, expect.any(Function));
 
           done();
@@ -305,7 +309,7 @@ describe("NpmUtilities", () => {
               },
             },
           );
-          expect(ChildProcessUtilities.spawn.mock.calls[0][2]).toMatchObject({
+          expect(ChildProcessUtilities.exec.mock.calls[0][2]).toMatchObject({
             registry,
           });
 
@@ -338,10 +342,9 @@ describe("NpmUtilities", () => {
               },
             },
           );
-          expect(ChildProcessUtilities.spawn).lastCalledWith("yarn", ["install"], {
+          expect(ChildProcessUtilities.exec).lastCalledWith("yarn", ["install"], {
             directory,
             registry: undefined,
-            stdio: ["ignore", "pipe", "pipe"],
           }, expect.any(Function));
 
           done();
@@ -451,7 +454,7 @@ describe("NpmUtilities", () => {
       ];
       const config = {};
 
-      ChildProcessUtilities.spawn.mockImplementation((client, args, opts, cb) => {
+      ChildProcessUtilities.exec.mockImplementation((client, args, opts, cb) => {
         return cb(new Error("Unable to install dependency"));
       });
 

--- a/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -1,24 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`stdout: postinstall 1`] = `
-"Lerna __TEST_VERSION__
-package-1
-
-package-2
-
-cli package-2 OK
-
-package-3 cli1 OK
-package-3 cli2 package-2 OK
-
-Successfully ran npm script 'test' in packages:
-- @integration/package-1
-- @integration/package-2
-- @integration/package-3
-- package-4"
-`;
-
-exports[`stdout: simple 1`] = `
+exports[`stdout: --ignore 1`] = `
 "Lerna __TEST_VERSION__
 Ignoring packages that match '@integration/package-1'
 Bootstrapping 3 packages
@@ -30,7 +12,21 @@ Prepublishing packages
 Successfully bootstrapped 3 packages."
 `;
 
-exports[`stdout: simple 2`] = `
+exports[`stdout: postinstall 1`] = `
+"Lerna __TEST_VERSION__
+package-1
+package-2
+cli package-2 OK
+package-3 cli1 OK
+package-3 cli2 package-2 OK
+Successfully ran npm script 'test' in packages:
+- @integration/package-1
+- @integration/package-2
+- @integration/package-3
+- package-4"
+`;
+
+exports[`stdout: simple 1`] = `
 "Lerna __TEST_VERSION__
 Bootstrapping 4 packages
 Preinstalling packages
@@ -41,17 +37,13 @@ Prepublishing packages
 Successfully bootstrapped 4 packages."
 `;
 
-exports[`stdout: simple 3`] = `
+exports[`stdout: simple 2`] = `
 "Lerna __TEST_VERSION__
 package-1
-
 package-2
-
 cli package-2 OK
-
 package-3 cli1 OK
 package-3 cli2 package-2 OK
-
 Successfully ran npm script 'test' in packages:
 - @integration/package-1
 - @integration/package-2

--- a/test/integration/__snapshots__/lerna-exec.test.js.snap
+++ b/test/integration/__snapshots__/lerna-exec.test.js.snap
@@ -1,7 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`exec: with ignore 1`] = `
+exports[`ls: --ignore 1`] = `
 "Lerna __TEST_VERSION__
 Ignoring packages that match 'package-1'
-package-2 v1.0.0 "
+file-2.js
+package.json"
+`;
+
+exports[`ls: --scope 1`] = `
+"Lerna __TEST_VERSION__
+Scoping to packages that match 'package-1'
+file-1.js
+package.json"
 `;

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`stdout: simple 1`] = `
+exports[`stdout: my-script --scope 1`] = `
 "Lerna __TEST_VERSION__
 Scoping to packages that match 'package-1'
 package-1
@@ -8,10 +8,14 @@ Successfully ran npm script 'my-script' in packages:
 - package-1"
 `;
 
-exports[`stdout: simple-npm 1`] = `
+exports[`stdout: test --ignore 1`] = `
 "Lerna __TEST_VERSION__
-Scoping to packages that match 'package-1'
-package-1
+Ignoring packages that match 'package-1'
+Error: no test specified
+package-4
+Error: no test specified
 Successfully ran npm script 'test' in packages:
-- package-1"
+- package-2
+- package-3
+- package-4"
 `;

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -10,12 +10,8 @@ Successfully ran npm script 'my-script' in packages:
 
 exports[`stdout: test --ignore 1`] = `
 "Lerna __TEST_VERSION__
-Ignoring packages that match 'package-1'
-Error: no test specified
+Ignoring packages that match 'package-@(1|2|3)'
 package-4
-Error: no test specified
 Successfully ran npm script 'test' in packages:
-- package-2
-- package-3
 - package-4"
 `;

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -4,7 +4,6 @@ exports[`stdout: simple 1`] = `
 "Lerna __TEST_VERSION__
 Scoping to packages that match 'package-1'
 package-1
-
 Successfully ran npm script 'my-script' in packages:
 - package-1"
 `;
@@ -13,7 +12,6 @@ exports[`stdout: simple-npm 1`] = `
 "Lerna __TEST_VERSION__
 Scoping to packages that match 'package-1'
 package-1
-
 Successfully ran npm script 'test' in packages:
 - package-1"
 `;

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -27,12 +27,13 @@ describe("lerna bootstrap", () => {
           });
       });
     });
+
     test.concurrent("respects ignore flag", () => {
       return initFixture("BootstrapCommand/integration").then((cwd) => {
         return Promise.resolve()
           .then(() => execa(LERNA_BIN, ["bootstrap", "--ignore", "@integration/package-1"], { cwd }))
           .then((result) => {
-            expect(result.stdout).toMatchSnapshot("stdout: simple");
+            expect(result.stdout).toMatchSnapshot("stdout: --ignore");
           });
       });
     });

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -3,17 +3,37 @@ import initFixture from "../helpers/initFixture";
 import { LERNA_BIN } from "../helpers/constants";
 
 describe("lerna exec", () => {
-  test.concurrent("works with ignore flag", () => {
+  test.concurrent("--ignore <pkg> ls -- -1", () => {
     return initFixture("ExecCommand/basic").then((cwd) => {
       const args = [
+        "exec",
+        "--ignore=package-1",
         "ls",
-        "--ignore=package-1"
+        "--concurrency=1",
+        "--",
+        // args to ls
+        "-1",
       ];
-      return Promise.resolve()
-        .then(() => execa(LERNA_BIN, args, { cwd: cwd }))
-        .then((result) => {
-          expect(result.stdout).toMatchSnapshot("exec: with ignore");
-        });
+
+      return execa(LERNA_BIN, args, { cwd }).then((result) => {
+        expect(result.stdout).toMatchSnapshot("ls: --ignore");
+      });
+    });
+  });
+
+  test.concurrent("ls --scope <pkg>", () => {
+    return initFixture("ExecCommand/basic").then((cwd) => {
+      const args = [
+        "exec",
+        "--concurrency=1",
+        "ls",
+        "--scope=package-1",
+        // no args to ls
+      ];
+
+      return execa(LERNA_BIN, args, { cwd }).then((result) => {
+        expect(result.stdout).toMatchSnapshot("ls: --scope");
+      });
     });
   });
 });

--- a/test/integration/lerna-import.test.js
+++ b/test/integration/lerna-import.test.js
@@ -5,24 +5,23 @@ import { LERNA_BIN } from "../helpers/constants";
 
 describe("lerna import", () => {
   test.concurrent("works with argument provided", () => {
-    return Promise
-      .all([
-        initFixture("ImportCommand/external", "Init external commit"),
-        initFixture("ImportCommand/basic"),
-      ])
-      .then(([externalPath, basicPath]) => {
-        const args = [
-          "import",
-          externalPath,
-          "--yes"
-        ];
-        return Promise.resolve()
-          .then(() => execa(LERNA_BIN, args, { cwd: basicPath }))
-          .then(() => {
-            return loadAllPackages(basicPath).then((allPackageJsons) => {
-              expect(allPackageJsons).toMatchSnapshot("simple: import with argument");
-            });
+    return Promise.all([
+      initFixture("ImportCommand/external", "Init external commit"),
+      initFixture("ImportCommand/basic"),
+    ]).then(([externalPath, basicPath]) => {
+      const args = [
+        "import",
+        externalPath,
+        "--yes"
+      ];
+
+      return Promise.resolve()
+        .then(() => execa(LERNA_BIN, args, { cwd: basicPath }))
+        .then(() => {
+          return loadAllPackages(basicPath).then((allPackageJsons) => {
+            expect(allPackageJsons).toMatchSnapshot("simple: import with argument");
           });
-      });
+        });
+    });
   });
 });

--- a/test/integration/lerna-import.test.js
+++ b/test/integration/lerna-import.test.js
@@ -15,12 +15,10 @@ describe("lerna import", () => {
         "--yes"
       ];
 
-      return Promise.resolve()
-        .then(() => execa(LERNA_BIN, args, { cwd: basicPath }))
-        .then(() => {
-          return loadAllPackages(basicPath).then((allPackageJsons) => {
-            expect(allPackageJsons).toMatchSnapshot("simple: import with argument");
-          });
+      return execa(LERNA_BIN, args, { cwd: basicPath })
+        .then(() => loadAllPackages(basicPath))
+        .then((allPackageJsons) => {
+          expect(allPackageJsons).toMatchSnapshot("simple: import with argument");
         });
     });
   });

--- a/test/integration/lerna-init.test.js
+++ b/test/integration/lerna-init.test.js
@@ -24,10 +24,10 @@ describe("lerna init", () => {
     return execa(LERNA_BIN, ["init"], { cwd }).then((result) => {
       expect(result.stdout).toMatchSnapshot("stdout: empty directory");
 
-      return loadMetaData(cwd).then(([packageJson, lernaJson]) => {
-        expect(packageJson).toMatchSnapshot("package.json: empty directory");
-        expect(lernaJson).toMatchSnapshot("lerna.json: empty directory");
-      });
+      return loadMetaData(cwd);
+    }).then(([packageJson, lernaJson]) => {
+      expect(packageJson).toMatchSnapshot("package.json: empty directory");
+      expect(lernaJson).toMatchSnapshot("lerna.json: empty directory");
     });
   }));
 
@@ -35,10 +35,10 @@ describe("lerna init", () => {
     return execa(LERNA_BIN, ["init", "--exact"], { cwd }).then((result) => {
       expect(result.stdout).toMatchSnapshot("stdout: updates");
 
-      return loadMetaData(cwd).then(([packageJson, lernaJson]) => {
-        expect(packageJson).toMatchSnapshot("package.json: updates");
-        expect(lernaJson).toMatchSnapshot("lerna.json: updates");
-      });
+      return loadMetaData(cwd);
+    }).then(([packageJson, lernaJson]) => {
+      expect(packageJson).toMatchSnapshot("package.json: updates");
+      expect(lernaJson).toMatchSnapshot("lerna.json: updates");
     });
   }));
 

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -23,10 +23,10 @@ describe("lerna publish", () => {
         return Promise.all([
           loadAllPackages(cwd),
           lastCommitMessage(cwd),
-        ]).then(([allPackageJsons, commitMessage]) => {
-          expect(allPackageJsons).toMatchSnapshot("packages: updates fixed versions");
-          expect(commitMessage).toMatchSnapshot("commit: updates fixed versions");
-        });
+        ]);
+      }).then(([allPackageJsons, commitMessage]) => {
+        expect(allPackageJsons).toMatchSnapshot("packages: updates fixed versions");
+        expect(commitMessage).toMatchSnapshot("commit: updates fixed versions");
       });
     });
   });
@@ -46,10 +46,10 @@ describe("lerna publish", () => {
         return Promise.all([
           loadAllPackages(cwd),
           lastCommitMessage(cwd),
-        ]).then(([allPackageJsons, commitMessage]) => {
-          expect(allPackageJsons).toMatchSnapshot("packages: updates independent versions");
-          expect(commitMessage).toMatchSnapshot("commit: updates independent versions");
-        });
+        ]);
+      }).then(([allPackageJsons, commitMessage]) => {
+        expect(allPackageJsons).toMatchSnapshot("packages: updates independent versions");
+        expect(commitMessage).toMatchSnapshot("commit: updates independent versions");
       });
     });
   });

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -9,6 +9,7 @@ describe("lerna run", () => {
         "run",
         "my-script",
         "--scope=package-1",
+        "--concurrency=1",
         // args below tell npm to be quiet
         "--", "--silent",
       ];
@@ -23,6 +24,7 @@ describe("lerna run", () => {
     return initFixture("RunCommand/integration-lifecycle").then((cwd) => {
       const args = [
         "run",
+        "--concurrency=1",
         "test",
         "--ignore=package-1",
         // args below tell npm to be quiet

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -26,7 +26,8 @@ describe("lerna run", () => {
         "run",
         "--concurrency=1",
         "test",
-        "--ignore=package-1",
+        "--ignore",
+        "package-@(1|2|3)",
         // args below tell npm to be quiet
         "--", "--silent",
       ];

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -9,7 +9,6 @@ const npmTestInDir = (cwd) =>
   execa("npm", ["test", "--silent"], { cwd });
 
 describe("lerna run", () => {
-
   test.concurrent("can run script in packages", () => {
     return initFixture("RunCommand/basic").then((cwd) => {
       const args = [

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -2,39 +2,36 @@ import execa from "execa";
 import initFixture from "../helpers/initFixture";
 import { LERNA_BIN } from "../helpers/constants";
 
-const installInDir = (cwd) =>
-  execa("npm", ["install", "--cache-min=99999"], { cwd });
-
-const npmTestInDir = (cwd) =>
-  execa("npm", ["test", "--silent"], { cwd });
-
 describe("lerna run", () => {
-  test.concurrent("can run script in packages", () => {
+  test.concurrent("my-script --scope", () => {
     return initFixture("RunCommand/basic").then((cwd) => {
       const args = [
         "run",
         "my-script",
         "--scope=package-1",
-        "--",
-        "--silent"
+        // args below tell npm to be quiet
+        "--", "--silent",
       ];
-      return Promise.resolve()
-        .then(() => installInDir(cwd))
-        .then(() => execa(LERNA_BIN, args, { cwd }))
-        .then((result) => {
-          expect(result.stdout).toMatchSnapshot("stdout: simple");
-        });
+
+      return execa(LERNA_BIN, args, { cwd }).then((result) => {
+        expect(result.stdout).toMatchSnapshot("stdout: my-script --scope");
+      });
     });
   });
 
-  test.concurrent("can run script in packages through npm lifecycle hook", () => {
+  test.concurrent("test --ignore", () => {
     return initFixture("RunCommand/integration-lifecycle").then((cwd) => {
-      return Promise.resolve()
-        .then(() => installInDir(cwd))
-        .then(() => npmTestInDir(cwd))
-        .then((result) => {
-          expect(result.stdout).toMatchSnapshot("stdout: simple-npm");
-        });
+      const args = [
+        "run",
+        "test",
+        "--ignore=package-1",
+        // args below tell npm to be quiet
+        "--", "--silent",
+      ];
+
+      return execa(LERNA_BIN, args, { cwd }).then((result) => {
+        expect(result.stdout).toMatchSnapshot("stdout: test --ignore");
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,6 +823,10 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+byline@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1321,6 +1325,10 @@ dot-prop@^3.0.0:
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
   dependencies:
     is-obj "^1.0.0"
+
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -2731,6 +2739,10 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
@@ -2744,6 +2756,10 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
 modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
+
+moment@^2.6.0:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
 ms@0.7.1:
   version "0.7.1"
@@ -3558,6 +3574,16 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+strong-log-transformer@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz#f7fb93758a69a571140181277eea0c2eb1301fa3"
+  dependencies:
+    byline "^5.0.0"
+    duplexer "^0.1.1"
+    minimist "^0.1.0"
+    moment "^2.6.0"
+    through "^2.3.4"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -3675,7 +3701,7 @@ through2@^2.0.0, through2@^2.0.2:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
## Description
`execa` gives us much more robust interface for `child_process`, with a Promise API that will make async/await much easier to migrate to.

### Notables
* `execa` makes calling dependency binaries a cinch.
* Registering children takes advantage of the rich Promise API.
* Streamed output now has prefixing via `strong-log-transformer` pipes (timestamps available with an option).

## How Has This Been Tested?
Updated unit and integration tests, as well as local testing via `yarn link`.

## Types of changes
- [x] Internal

There are cleanups to the recent CLI refactoring; unfortunately they're too tightly coupled with the other changes in the PR.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
