### PR TITLE
Fix durable option resolution

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -4,7 +4,6 @@
 const globalOptions = require("../lib/Command").builder;
 const logger = require("../lib/logger");
 const yargs = require("yargs");
-const path = require("path");
 
 // the options grouped under "Global Options:" header
 const globalKeys = Object.keys(globalOptions).concat([
@@ -33,7 +32,7 @@ yargs
     global: true
   })
   .options(globalOptions).group(globalKeys, "Global Options:")
-  .commandDir(path.join(__dirname, "..", "lib", "commands"))
+  .commandDir("../lib/commands")
   .demandCommand()
   .help("h").alias("h", "help")
   .version().alias("v", "version")

--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 "use strict";
 
-const globalOptions = require("../lib/Command").builder;
-const logger = require("../lib/logger");
 const yargs = require("yargs");
+const dedent = require("dedent");
+const globalOptions = require("../lib/Command").builder;
 
 // the options grouped under "Global Options:" header
 const globalKeys = Object.keys(globalOptions).concat([
-  "loglevel",
   "help",
   "version",
 ]);
@@ -18,19 +17,14 @@ function terminalWidth() {
   return typeof process.stdout.columns !== "undefined" ? process.stdout.columns : null;
 }
 
-logger.setLogLevel(yargs.argv.loglevel);
-
 yargs
-  .epilogue("For more information, find our manual at https://github.com/lerna/lerna")
+  .epilogue(dedent`
+    When a command fails, all logs are written to lerna-debug.log in the current working directory.
+
+    For more information, find our manual at https://github.com/lerna/lerna
+  `)
   .usage("Usage: $0 <command> [options]")
   .wrap(terminalWidth())
-  .option("loglevel", {
-    default: "info",
-    describe: "What level of logs to report. On failure, all logs are written to lerna-debug.log in the"
-            + "current working directory.",
-    type: "string",
-    global: true
-  })
   .options(globalOptions).group(globalKeys, "Global Options:")
   .commandDir("../lib/commands")
   .demandCommand()

--- a/src/Command.js
+++ b/src/Command.js
@@ -227,12 +227,15 @@ export default class Command {
     if (scope) {
       this.logger.info(`Scoping to packages that match '${scope}'`);
     }
+
     if (ignore) {
       this.logger.info(`Ignoring packages that match '${ignore}'`);
     }
+
     if (registry) {
       this.npmRegistry = registry;
     }
+
     try {
       this.repository.buildPackageGraph();
       this.packages = this.repository.packages;

--- a/src/Command.js
+++ b/src/Command.js
@@ -10,6 +10,11 @@ import logger from "./logger";
 const DEFAULT_CONCURRENCY = 4;
 
 export const builder = {
+  "loglevel": {
+    default: "info",
+    describe: "What level of logs to report.",
+    type: "string",
+  },
   "concurrency": {
     describe: "How many threads to use if lerna parallelises the tasks.",
     type: "number",
@@ -52,8 +57,9 @@ export default class Command {
 
     this.lernaVersion = require("../package.json").version;
     this.logger = logger;
-    this.repository = new Repository(cwd);
+    this.logger.setLogLevel(flags.loglevel);
     this.progressBar = progressBar;
+    this.repository = new Repository(cwd);
   }
 
   get concurrency() {

--- a/src/Command.js
+++ b/src/Command.js
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import ChildProcessUtilities from "./ChildProcessUtilities";
 import FileSystemUtilities from "./FileSystemUtilities";
 import GitUtilities from "./GitUtilities";
@@ -21,33 +22,37 @@ export const builder = {
     requiresArg: true,
     default: DEFAULT_CONCURRENCY,
   },
-  "ignore": {
-    describe: "Ignores packages with names matching the given glob (Works only in combination with the "
-            + "'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
+  "scope": {
+    describe: dedent`
+      Restricts the scope to package names matching the given glob.
+      (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)
+    `,
     type: "string",
-    requiresArg: true
+    requiresArg: true,
+  },
+  "ignore": {
+    describe: dedent`
+      Ignore packages with names matching the given glob.
+      (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)
+    `,
+    type: "string",
+    requiresArg: true,
   },
   "include-filtered-dependencies": {
-    describe: "Flag to force lerna to include all dependencies and transitive dependencies when running "
-            + "'bootstrap', even if they should not be included by the scope or ignore flags."
+    describe: dedent`
+      Include all transitive dependencies when running a command, regardless of --scope or --ignore.
+    `,
   },
   "registry": {
-    describe: "When run with this flag, forwarded npm commands will use the specified registry for your "
-            + "package(s).",
+    describe: "Use the specified registry for all npm client operations.",
     type: "string",
-    requiresArg: true
-  },
-  "scope": {
-    describe: "Restricts the scope to package names matching the given glob (Works only in combination "
-            + "with the 'run', 'exec', 'clean', 'ls' and 'bootstrap' commands).",
-    type: "string",
-    requiresArg: true
+    requiresArg: true,
   },
   "sort": {
-    describe: "Sort packages topologically",
+    describe: "Sort packages topologically (all dependencies before dependents)",
     type: "boolean",
-    default: true
-  }
+    default: true,
+  },
 };
 
 export default class Command {

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -17,7 +17,7 @@ export default class UpdatedPackagesCollector {
     this.packages = command.filteredPackages;
     this.packageGraph = command.repository.packageGraph;
     this.progressBar = command.progressBar;
-    this.flags = command.getOptions();
+    this.options = command.options;
   }
 
   getUpdates() {
@@ -42,11 +42,11 @@ export default class UpdatedPackagesCollector {
 
     let commits;
 
-    if (this.flags.canary) {
+    if (this.options.canary) {
       let currentSHA;
 
-      if (this.flags.canary !== true) {
-        currentSHA = this.flags.canary;
+      if (this.options.canary !== true) {
+        currentSHA = this.options.canary;
       } else {
         currentSHA = GitUtilities.getCurrentSHA(this.execOpts);
       }
@@ -68,7 +68,7 @@ export default class UpdatedPackagesCollector {
         return true;
       }
 
-      const forcePublish = (this.flags.forcePublish || "").split(",");
+      const forcePublish = (this.options.forcePublish || "").split(",");
 
       if (forcePublish.indexOf("*") > -1) {
         return true;
@@ -137,8 +137,8 @@ export default class UpdatedPackagesCollector {
     return this.packages.filter((pkg) => {
       return (
         this.updatedPackages[pkg.name] ||
-        (this.flags[SECRET_FLAG] ? false : this.dependents[pkg.name]) ||
-        this.flags.canary
+        (this.options[SECRET_FLAG] ? false : this.dependents[pkg.name]) ||
+        this.options.canary
       );
     }).map((pkg) => {
       return new Update(pkg);
@@ -163,9 +163,9 @@ export default class UpdatedPackagesCollector {
       return file.replace(folder + path.sep, "");
     });
 
-    if (this.flags.ignore) {
+    if (this.options.ignore) {
       changedFiles = changedFiles.filter((file) => {
-        return !find(this.flags.ignore, (pattern) => {
+        return !find(this.options.ignore, (pattern) => {
           return minimatch(file, pattern, { matchBase: true });
         });
       });

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -17,8 +17,9 @@ export const describe = "Link local packages together and install remaining pack
 
 export const builder = {
   "hoist": {
-    describe: "Install external dependencies matching [glob] to the repo root.  Use with no glob for all.",
-    type: "string"
+    describe: "Install external dependencies matching [glob] to the repo root",
+    type: "string",
+    defaultDescription: "'**'",
   },
   "nohoist": {
     describe: "Don't hoist external dependencies matching [glob] to the repo root",

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -36,7 +36,7 @@ export default class BootstrapCommand extends Command {
   initialize(callback) {
     this.npmConfig = {
       registry: this.npmRegistry,
-      client: this.getOptions().npmClient,
+      client: this.options.npmClient,
     };
 
     this.batchedPackages = this.toposort
@@ -199,7 +199,7 @@ export default class BootstrapCommand extends Command {
 
     // Configuration for what packages to hoist may be in lerna.json or it may
     // come in as command line options.
-    const { hoist, nohoist } = this.getOptions();
+    const { hoist, nohoist } = this.options;
 
     // This will contain entries for each hoistable dependency.
     const root = [];

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -19,7 +19,7 @@ export const builder = {
 
 export default class CleanCommand extends Command {
   initialize(callback) {
-    if (this.flags.yes) {
+    if (this.options.yes) {
       callback(null, true);
     } else {
       this.logger.info(`About to remove the following directories:\n${

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -3,10 +3,10 @@ import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 
 export function handler(argv) {
-  return new ExecCommand([argv.command, ...argv.arguments], argv).run();
+  return new ExecCommand([argv.command, ...argv.args], argv).run();
 }
 
-export const command = "exec <command> [arguments..]";
+export const command = "exec <command> [args..]";
 
 export const describe = "Run an arbitrary command in each package.";
 

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -25,7 +25,6 @@ export const builder = {
 
 export default class ImportCommand extends Command {
   initialize(callback) {
-    const { yes } = this.getOptions();
     const inputPath = this.input[0];
 
     if (!inputPath) {
@@ -87,7 +86,7 @@ export default class ImportCommand extends Command {
       `About to import ${this.commits.length} commits from ${inputPath} into ${this.targetDir}`
     );
 
-    if (yes) {
+    if (this.options.yes) {
       callback(null, true);
     } else {
       const message = "Are you sure you want to import these commits onto the current branch?";

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -1,5 +1,6 @@
 import path from "path";
 import async from "async";
+import dedent from "dedent";
 import Command from "../Command";
 import PromptUtilities from "../PromptUtilities";
 import ChildProcessUtilities from "../ChildProcessUtilities";
@@ -7,13 +8,14 @@ import FileSystemUtilities from "../FileSystemUtilities";
 import GitUtilities from "../GitUtilities";
 
 export function handler(argv) {
-  return new ImportCommand([argv.repo], argv).run();
+  return new ImportCommand([argv.pathToRepo], argv).run();
 }
 
-export const command = "import <repo>";
+export const command = "import <pathToRepo>";
 
-export const describe = "Import the package at <path-to-external-repository>, with commit history, "
-                      + "into packages/<directory-name>.";
+export const describe = dedent`
+  Import the package in <pathToRepo> into packages/<directory-name> with commit history.
+`;
 
 export const builder = {
   "yes": {

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -36,11 +36,14 @@ export default class ImportCommand extends Command {
 
     try {
       const stats = FileSystemUtilities.statSync(externalRepoPath);
+
       if (!stats.isDirectory()) {
         throw new Error(`Input path "${inputPath}" is not a directory`);
       }
+
       const packageJson = path.join(externalRepoPath, "package.json");
       const packageName = require(packageJson).name;
+
       if (!packageName) {
         throw new Error(`No package name specified in "${packageJson}"`);
       }
@@ -48,6 +51,7 @@ export default class ImportCommand extends Command {
       if (e.code === "ENOENT") {
         return callback(new Error(`No repository found at "${inputPath}"`));
       }
+
       return callback(e);
     }
 
@@ -90,6 +94,7 @@ export default class ImportCommand extends Command {
       callback(null, true);
     } else {
       const message = "Are you sure you want to import these commits onto the current branch?";
+
       PromptUtilities.confirm(message, (confirmed) => {
         if (confirmed) {
           callback(null, true);
@@ -154,5 +159,6 @@ function getTargetBase(packageConfigs) {
   const straightPackageDirectories = packageConfigs
     .filter((p) => path.basename(p) === "*")
     .map((p) => path.dirname(p));
+
   return straightPackageDirectories[0] || "packages";
 }

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -35,7 +35,7 @@ export default class InitCommand extends Command {
       GitUtilities.init(this.execOpts);
     }
 
-    this.exact = this.getOptions().exact;
+    this.exact = this.options.exact;
 
     callback(null, true);
   }
@@ -76,14 +76,12 @@ export default class InitCommand extends Command {
   }
 
   ensureLernaJson() {
-    const { independent } = this.getOptions();
-
     // lernaJson already defaulted to empty object in Repository constructor
     const lernaJson = this.repository.lernaJson;
 
     let version;
 
-    if (independent) {
+    if (this.options.independent) {
       version = "independent";
     } else if (FileSystemUtilities.existsSync(this.repository.versionLocation)) {
       version = FileSystemUtilities.readFileSync(this.repository.versionLocation);

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -82,6 +82,7 @@ export const builder = {
 
 export default class PublishCommand extends Command {
   initialize(callback) {
+    this.gitRemote = this.options.gitRemote || "origin";
     this.gitEnabled = !(this.flags.canary || this.flags.skipGit);
 
     if (this.flags.canary) {
@@ -210,7 +211,7 @@ export default class PublishCommand extends Command {
         if (this.gitEnabled) {
           this.logger.info("Pushing tags to git...");
           this.logger.newLine();
-          GitUtilities.pushWithTags(this.getOptions().gitRemote || "origin", this.tags, this.execOpts);
+          GitUtilities.pushWithTags(this.gitRemote, this.tags, this.execOpts);
         }
 
         let message = "Successfully published:";
@@ -407,7 +408,7 @@ export default class PublishCommand extends Command {
   }
 
   updateUpdatedPackages() {
-    const { exact } = this.getOptions();
+    const { exact } = this.options;
     const changedFiles = [];
 
     this.updates.forEach((update) => {
@@ -506,10 +507,9 @@ export default class PublishCommand extends Command {
   }
 
   npmPublishAsPrerelease(callback) {
-    const { skipTempTag } = this.getOptions();
     // if we skip temp tags we should tag with the proper value immediately
     // therefore no updates will be needed
-    const tag = skipTempTag ? this.getDistTag() : "lerna-temp";
+    const tag = this.options.skipTempTag ? this.getDistTag() : "lerna-temp";
 
     this.updates.forEach((update) => {
       this.execScript(update.package, "prepublish");
@@ -556,9 +556,7 @@ export default class PublishCommand extends Command {
   }
 
   npmUpdateAsLatest(callback) {
-    const { skipTempTag } = this.getOptions();
-
-    if (skipTempTag) {
+    if (this.options.skipTempTag) {
       return callback();
     }
 
@@ -611,7 +609,6 @@ export default class PublishCommand extends Command {
   }
 
   getDistTag() {
-    const { npmTag, canary } = this.getOptions();
-    return npmTag || (canary && "canary") || "latest";
+    return this.options.npmTag || (this.options.canary && "canary") || "latest";
   }
 }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -186,7 +186,6 @@ export default class PublishCommand extends Command {
   }
 
   publishPackagesToNpm(callback) {
-
     this.logger.newLine();
     this.logger.info("Publishing packages to npm...");
 
@@ -402,6 +401,7 @@ export default class PublishCommand extends Command {
   updateVersionInLernaJson() {
     this.repository.lernaJson.version = this.masterVersion;
     writeJsonFile.sync(this.repository.lernaJsonLocation, this.repository.lernaJson, { indent: 2 });
+
     if (!this.flags.skipGit) {
       GitUtilities.addFile(this.repository.lernaJsonLocation, this.execOpts);
     }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -20,7 +20,7 @@ export function handler(argv) {
 
 export const command = "publish";
 
-export const describe = "Publish packages in the current Lerna project.";
+export const describe = "Publish packages in the current project.";
 
 export const builder = {
   "canary": {
@@ -28,8 +28,9 @@ export const builder = {
     alias: "c"
   },
   "cd-version": {
-    describe: "Skip the version selection prompt (in independent mode) and use the next specified semantic "
-            + "version."
+    describe: "Skip the version selection prompt and increment semver 'major', 'minor', or 'patch'.",
+    type: "string",
+    requiresArg: true,
   },
   "conventional-commits": {
     describe: "Use angular conventional-commit format to determine version bump and generate CHANGELOG."
@@ -38,6 +39,7 @@ export const builder = {
     describe: "Specify cross-dependency version numbers exactly rather than with a caret (^)."
   },
   "git-remote": {
+    defaultDescription: "origin",
     describe: "Push git changes to the specified remote instead of 'origin'.",
     type: "string",
     requiresArg: true
@@ -68,8 +70,7 @@ export const builder = {
     describe: "Stop before actually publishing change to npm."
   },
   "skip-temp-tag": {
-    describe: "Do not create a temporary tag while publishing. In stead use the normal npm publish"
-            + "methodology."
+    describe: "Do not create a temporary tag while publishing."
   }
 };
 

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -64,7 +64,7 @@ export default class RunCommand extends Command {
   }
 
   runScriptInPackage(pkg, callback) {
-    if (this.getOptions().stream) {
+    if (this.options.stream) {
       this.runScriptInPackageStreaming(pkg, callback);
     } else {
       this.runScriptInPackageCapturing(pkg, callback);

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -3,10 +3,10 @@ import PackageUtilities from "../PackageUtilities";
 import Command from "../Command";
 
 export function handler(argv) {
-  return new RunCommand([argv.script, ...argv.arguments], argv).run();
+  return new RunCommand([argv.script, ...argv.args], argv).run();
 }
 
-export const command = "run <script> [arguments..]";
+export const command = "run <script> [args..]";
 
 export const describe = "Run an npm script in each package that contains that script.";
 

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -9,9 +9,9 @@ export function handler(argv) {
 
 export const command = "updated";
 
-export const describe = "Check which packages have changed since the last release (the last git tag).";
+export const describe = "Check which packages have changed since the last publish.";
 
-export const builder = Object.assign({}, publishOptions);
+export const builder = (yargs) => yargs.options(publishOptions);
 
 export default class UpdatedCommand extends Command {
   initialize(callback) {

--- a/test/Command.js
+++ b/test/Command.js
@@ -29,7 +29,7 @@ describe("Command", () => {
 
   describe(".input", () => {
     it("should be added to the instance", () => {
-      const command = new Command(["a", "b", "c"]);
+      const command = new Command(["a", "b", "c"], {});
       expect(command.input).toEqual(["a", "b", "c"]);
     });
   });
@@ -43,21 +43,21 @@ describe("Command", () => {
 
   describe(".lernaVersion", () => {
     it("should be added to the instance", () => {
-      const command = new Command();
+      const command = new Command([], {});
       expect(command.lernaVersion).toEqual(require("../package.json").version);
     });
   });
 
   describe(".progressBar", () => {
     it("should be added to the instance", () => {
-      const command = new Command();
+      const command = new Command([], {});
       expect(command.progressBar).toBe(progressBar);
     });
   });
 
   describe(".logger", () => {
     it("should be added to the instance", () => {
-      const command = new Command();
+      const command = new Command([], {});
       expect(command.logger).toBe(logger);
     });
   });

--- a/test/Command.js
+++ b/test/Command.js
@@ -177,7 +177,7 @@ describe("Command", () => {
     it("needs tests");
   });
 
-  describe(".getOptions()", () => {
+  describe("get .options", () => {
     let testDir;
 
     beforeAll(() => initFixture("Command/basic").then((dir) => {
@@ -194,41 +194,43 @@ describe("Command", () => {
       }
     }
 
+    it("is a lazy getter", () => {
+      const instance = new TestACommand([], {}, testDir);
+      expect(instance.options).toBe(instance.options);
+    });
+
     it("should pick up global options", () => {
       const instance = new TestACommand([], {}, testDir);
-      expect(instance.getOptions().testOption).toBe("default");
+      expect(instance.options.testOption).toBe("default");
     });
 
     it("should override global options with command-level options", () => {
       const instance = new TestBCommand([], {}, testDir);
-      expect(instance.getOptions().testOption).toBe("b");
+      expect(instance.options.testOption).toBe("b");
     });
 
     it("should override global options with inherited command-level options", () => {
       const instance = new TestCCommand([], {}, testDir);
-      expect(instance.getOptions().testOption).toBe("b");
+      expect(instance.options.testOption).toBe("b");
     });
 
     it("should override inherited command-level options with local command-level options", () => {
       const instance = new TestCCommand([], {}, testDir);
-      expect(instance.getOptions().testOption2).toBe("c");
-    });
-
-    it("should override command-level options with passed-in options", () => {
-      const instance = new TestCCommand([], {}, testDir);
-      expect(instance.getOptions({ testOption2: "p" }).testOption2).toBe("p");
-    });
-
-    it("should sieve properly within passed-in options", () => {
-      const instance = new TestCCommand([], {}, testDir);
-      expect(instance.getOptions({ testOption2: "p" }, { testOption2: "p2" }).testOption2).toBe("p2");
+      expect(instance.options.testOption2).toBe("c");
     });
 
     it("should override everything with a CLI flag", () => {
       const instance = new TestCCommand([], {
         testOption2: "f",
       }, testDir);
-      expect(instance.getOptions({ testOption2: "p" }).testOption2).toBe("f");
+      expect(instance.options.testOption2).toBe("f");
+    });
+
+    it("should inherit durable options when a CLI flag is undefined", () => {
+      const instance = new TestCCommand([], {
+        testOption: undefined, // yargs does this when --test-option is not passed
+      }, testDir);
+      expect(instance.options.testOption).toBe("b");
     });
   });
 
@@ -250,7 +252,7 @@ describe("Command", () => {
         const instance = new BootstrapCommand([], {}, testDir);
         const logWarn = jest.spyOn(instance.logger, "warn");
 
-        instance.getOptions();
+        instance.options;
         expect(logWarn).lastCalledWith(
           "`bootstrapConfig.ignore` is deprecated.  Use `commands.bootstrap.ignore`."
         );
@@ -258,20 +260,20 @@ describe("Command", () => {
 
       it("should provide a correct value", () => {
         const instance = new BootstrapCommand([], {}, testDir);
-        expect(instance.getOptions().ignore).toBe("package-a");
+        expect(instance.options.ignore).toBe("package-a");
       });
 
       it("should not warn with other commands", () => {
         const instance = new TestCommand([], {}, testDir);
         const logWarn = jest.spyOn(instance.logger, "warn");
 
-        instance.getOptions();
+        instance.options;
         expect(logWarn).not.toBeCalled();
       });
 
       it("should not provide a value to other commands", () => {
         const instance = new TestCommand([], {}, testDir);
-        expect(instance.getOptions().ignore).toBe(undefined);
+        expect(instance.options.ignore).toBe(undefined);
       });
     });
 
@@ -283,7 +285,7 @@ describe("Command", () => {
         const instance = new PublishCommand([], {}, testDir);
         const logWarn = jest.spyOn(instance.logger, "warn");
 
-        instance.getOptions();
+        instance.options;
         expect(logWarn).lastCalledWith(
           "`publishConfig.ignore` is deprecated.  Use `commands.publish.ignore`."
         );
@@ -291,20 +293,20 @@ describe("Command", () => {
 
       it("should provide a correct value", () => {
         const instance = new PublishCommand([], {}, testDir);
-        expect(instance.getOptions().ignore).toBe("package-b");
+        expect(instance.options.ignore).toBe("package-b");
       });
 
       it("should not warn with other commands", () => {
         const instance = new TestCommand([], {}, testDir);
         const logWarn = jest.spyOn(instance.logger, "warn");
 
-        instance.getOptions();
+        instance.options;
         expect(logWarn).not.toBeCalled();
       });
 
       it("should not provide a value to other commands", () => {
         const instance = new TestCommand([], {}, testDir);
-        expect(instance.getOptions().ignore).toBe(undefined);
+        expect(instance.options.ignore).toBe(undefined);
       });
     });
   });

--- a/test/integration/__snapshots__/lerna-exec.test.js.snap
+++ b/test/integration/__snapshots__/lerna-exec.test.js.snap
@@ -13,3 +13,11 @@ Scoping to packages that match 'package-1'
 file-1.js
 package.json"
 `;
+
+exports[`ls: without -- 1`] = `
+"Lerna __TEST_VERSION__
+file-1.js
+package.json
+file-2.js
+package.json"
+`;

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -36,4 +36,20 @@ describe("lerna exec", () => {
       });
     });
   });
+
+  test.concurrent("without --", () => {
+    return initFixture("ExecCommand/basic").then((cwd) => {
+      const args = [
+        "--concurrency=1",
+        "exec",
+        "ls",
+        // no --
+        "-C",
+      ];
+
+      return execa(LERNA_BIN, args, { cwd }).then((result) => {
+        expect(result.stdout).toMatchSnapshot("ls: without --");
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description
A funny thing happened on the way to the forum...

Well, turns out I broke "durable" option config yesterday, so I decided to pull off the bandaid that's been itching me for weeks (the `Command#getOptions()` API) and convert it into a lazy getter with lodash `_.defaults()` instead of `Object.assign()`.

I've also made edits and tweaks to the `yargs` options.

## Motivation and Context
Restoring durable config patterns, with some optimization thrown in.

## How Has This Been Tested?
Local hoisted bootstraps and other operations, as well as more integration tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
