### PR TITLE
Replace manual arg check with yargs built in mechanics

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -31,12 +31,7 @@ export const builder = {
     describe: "Skip the version selection prompt and increment semver 'major', 'minor', or 'patch'.",
     type: "string",
     requiresArg: true,
-    coerce: (choice) => {
-      if (!["major", "minor", "patch"].some((inc) => choice === inc)) {
-        throw new Error(`--cd-version must be one of 'major', 'minor', or 'patch', got '${choice}'`);
-      }
-      return choice;
-    },
+    choices: ["major", "minor", "patch"]
   },
   "conventional-commits": {
     describe: "Use angular conventional-commit format to determine version bump and generate CHANGELOG."

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -113,3 +113,39 @@ Changes:
 
 Assuming confirmation."
 `;
+
+exports[`stdout: validates cd-version 1`] = `
+[Error: Command failed: /home/noherczeg/work/blackbelt/lerna/bin/lerna.js publish --skip-npm --cd-version=nope --yes
+/home/noherczeg/work/blackbelt/lerna/bin/lerna.js publish
+
+Global Options:
+  --loglevel                       What level of logs to report.  [string] [default: "info"]
+  --concurrency                    How many threads to use if lerna parallelises the tasks.  [number] [default: 4]
+  --scope                          Restricts the scope to package names matching the given glob.
+                                   (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)  [string]
+  --ignore                         Ignore packages with names matching the given glob.
+                                   (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)  [string]
+  --include-filtered-dependencies  Include all transitive dependencies when running a command, regardless of --scope or --ignore.
+  --registry                       Use the specified registry for all npm client operations.  [string]
+  --sort                           Sort packages topologically (all dependencies before dependents)  [boolean] [default: true]
+  -h, --help                       Show help  [boolean]
+  -v, --version                    Show version number  [boolean]
+
+Options:
+  --canary, -c            Publish packages after every successful merge using the sha as part of the tag.
+  --cd-version            Skip the version selection prompt and increment semver 'major', 'minor', or 'patch'.  [string] [choices: "major", "minor", "patch"]
+  --conventional-commits  Use angular conventional-commit format to determine version bump and generate CHANGELOG.
+  --exact                 Specify cross-dependency version numbers exactly rather than with a caret (^).
+  --git-remote            Push git changes to the specified remote instead of 'origin'.  [string] [default: origin]
+  --yes                   Skip all confirmation prompts.
+  --message, -m           Use a custom commit message when creating the publish commit.  [string]
+  --npm-tag               Publish packages with the specified npm dist-tag  [string]
+  --repo-version          Specify repo version to publish.  [string]
+  --skip-git              Skip commiting, tagging, and pushing git changes.
+  --skip-npm              Stop before actually publishing change to npm.
+  --skip-temp-tag         Do not create a temporary tag while publishing.
+
+Invalid values:
+  Argument: cd-version, Given: "nope", Choices: "major", "minor", "patch"
+]
+`;

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -31,6 +31,21 @@ describe("lerna publish", () => {
     });
   });
 
+  test.concurrent("validates --cd-version", () => {
+    return initFixture("PublishCommand/normal").then((cwd) => {
+      const args = [
+        "publish",
+        "--skip-npm",
+        "--cd-version=nope",
+        "--yes",
+      ];
+
+      return execa(LERNA_BIN, args, { cwd }).catch((error) => {
+        expect(error).toMatchSnapshot("stdout: validates cd-version");
+      });
+    });
+  });
+
   test.concurrent("updates independent versions", () => {
     return initFixture("PublishCommand/independent").then((cwd) => {
       const args = [


### PR DESCRIPTION
Yargs can validate arguments, we should let it.

## Description
I replaced our manual argument validation for --cd-version and put yargs' [choices](https://github.com/yargs/yargs#choiceskey-choices) in it's place.

## How Has This Been Tested?
I added an integration test for it.

## Types of changes
- [x] Refactor (non-breaking change which improves maintainability)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
