### PR TITLE
Fix custom version prompt

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -339,7 +339,7 @@ export default class PublishCommand extends Command {
         case "CUSTOM": {
           PromptUtilities.input("Enter a custom version", {
             filter: semver.valid,
-            validate: (v) => semver.valid(v) || "Must be a valid semver version",
+            validate: (v) => v !== null || "Must be a valid semver version",
           }, (input) => {
             callback(null, input);
           });


### PR DESCRIPTION
Fixes #757

The validate function fails when any string is returned. The return of semver.valid will be the same version string (as long as it's valid). So, a valid version will be an "error" according to the validate function. Switching to check for a non-null value coerces this to a boolean that validate is looking for. 

Note: I could have done `!!v` as well, but this is more explicit and readable, I think.