### PR TITLE
Resolve internal CLI calls with Windows-safe pattern

### DIFF
--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -11,12 +11,22 @@ const CHANGELOG_HEADER = dedent(`# Change Log
   All notable changes to this project will be documented in this file.
   See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.`);
 
+// We call these resolved CLI files in the "path/to/node path/to/cli <..args>"
+// pattern to avoid Windows hangups with shebangs (e.g., WSH can't handle it)
+const RECOMMEND_CLI = require.resolve("conventional-recommended-bump/cli");
+const CHANGELOG_CLI = require.resolve("conventional-changelog-cli/cli");
+
 export default class ConventionalCommitUtilities {
   @logger.logifySync()
   static recommendVersion(pkg, opts) {
     const recommendedBump = ChildProcessUtilities.execSync(
-      "conventional-recommended-bump",
-      ["-l", pkg.name, "--commit-path", pkg.location, "-p", "angular"],
+      process.execPath,
+      [
+        RECOMMEND_CLI,
+        "-l", pkg.name,
+        "--commit-path", pkg.location,
+        "-p", "angular",
+      ],
       opts
     );
 
@@ -36,8 +46,14 @@ export default class ConventionalCommitUtilities {
     // run conventional-changelog-cli to generate the markdown
     // for the upcoming release.
     const newEntry = ChildProcessUtilities.execSync(
-      "conventional-changelog",
-      ["-l", pkg.name, "--commit-path", pkg.location, "--pkg", pkgJsonLocation, "-p", "angular"],
+      process.execPath,
+      [
+        CHANGELOG_CLI,
+        "-l", pkg.name,
+        "--commit-path", pkg.location,
+        "--pkg", pkgJsonLocation,
+        "-p", "angular",
+      ],
       opts
     );
 

--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -12,6 +12,9 @@ function ensureEndsWithNewLine(string) {
   return ENDS_WITH_NEW_LINE.test(string) ? string : string + "\n";
 }
 
+// NOTE: if rimraf moves the location of its executable, this will need to be updated
+const RIMRAF_CLI = require.resolve("rimraf/bin");
+
 // globs only return directories with a trailing slash
 function trailingSlash(filePath) {
   return path.normalize(`${filePath}/`);
@@ -79,8 +82,11 @@ export default class FileSystemUtilities {
 
         const args = candidates.map(trailingSlash);
         args.unshift("--no-glob");
+        args.unshift(RIMRAF_CLI);
 
-        return ChildProcessUtilities.spawn("rimraf", args, {}, callback);
+        // We call this resolved CLI path in the "path/to/node path/to/cli <..args>"
+        // pattern to avoid Windows hangups with shebangs (e.g., WSH can't handle it)
+        return ChildProcessUtilities.spawn(process.execPath, args, {}, callback);
       });
   }
 

--- a/test/ConventionalCommitUtilities.js
+++ b/test/ConventionalCommitUtilities.js
@@ -31,8 +31,13 @@ describe("ConventionalCommitUtilities", () => {
 
       expect(recommendVersion).toBe("2.0.0");
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "conventional-recommended-bump",
-        ["-l", "bar", "--commit-path", "/foo/bar", "-p", "angular"],
+        process.execPath,
+        [
+          require.resolve("conventional-recommended-bump/cli"),
+          "-l", "bar",
+          "--commit-path", "/foo/bar",
+          "-p", "angular",
+        ],
         opts,
       );
     });
@@ -54,8 +59,14 @@ describe("ConventionalCommitUtilities", () => {
         path.normalize("/foo/bar/CHANGELOG.md")
       );
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "conventional-changelog",
-        ["-l", "bar", "--commit-path", "/foo/bar", "--pkg", path.normalize("/foo/bar/package.json"), "-p", "angular"],
+        process.execPath,
+        [
+          require.resolve("conventional-changelog-cli/cli"),
+          "-l", "bar",
+          "--commit-path", "/foo/bar",
+          "--pkg", path.normalize("/foo/bar/package.json"),
+          "-p", "angular",
+        ],
         opts,
       );
       expect(FileSystemUtilities.writeFileSync).lastCalledWith(

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -99,8 +99,12 @@ describe("FileSystemUtilities", () => {
       FileSystemUtilities.rimraf(["rimraf/test"], () => {
         try {
           expect(ChildProcessUtilities.spawn).lastCalledWith(
-            "rimraf",
-            ["--no-glob", path.normalize("rimraf/test/")],
+            process.execPath,
+            [
+              require.resolve("rimraf/bin"),
+              "--no-glob",
+              path.normalize("rimraf/test/"),
+            ],
             {},
             expect.any(Function)
           );

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -8,49 +8,45 @@ const lastCommitMessage = (cwd) =>
   execa.stdout("git", ["log", "-1", "--format=%B"], { cwd }).then(normalizeNewline);
 
 describe("lerna publish", () => {
-  test.concurrent("updates fixed versions", () => {
-    return initFixture("PublishCommand/normal").then((cwd) => {
-      const args = [
-        "publish",
-        "--skip-npm",
-        "--cd-version=patch",
-        "--yes",
-      ];
+  test.concurrent("updates fixed versions", async () => {
+    const cwd = await initFixture("PublishCommand/normal");
+    const args = [
+      "publish",
+      "--skip-npm",
+      "--cd-version=patch",
+      "--yes",
+    ];
 
-      return execa(LERNA_BIN, args, { cwd }).then((result) => {
-        expect(result.stdout).toMatchSnapshot("stdout: updates fixed versions");
+    const stdout = await execa.stdout(LERNA_BIN, args, { cwd });
+    expect(stdout).toMatchSnapshot("stdout: updates fixed versions");
 
-        return Promise.all([
-          loadPkgManifests(cwd),
-          lastCommitMessage(cwd),
-        ]);
-      }).then(([allPackageJsons, commitMessage]) => {
-        expect(allPackageJsons).toMatchSnapshot("packages: updates fixed versions");
-        expect(commitMessage).toMatchSnapshot("commit: updates fixed versions");
-      });
-    });
+    const [allPackageJsons, commitMessage] = await Promise.all([
+      loadPkgManifests(cwd),
+      lastCommitMessage(cwd),
+    ]);
+
+    expect(allPackageJsons).toMatchSnapshot("packages: updates fixed versions");
+    expect(commitMessage).toMatchSnapshot("commit: updates fixed versions");
   });
 
-  test.concurrent("updates independent versions", () => {
-    return initFixture("PublishCommand/independent").then((cwd) => {
-      const args = [
-        "publish",
-        "--skip-npm",
-        "--cd-version=major",
-        "--yes",
-      ];
+  test.concurrent("updates independent versions", async () => {
+    const cwd = await initFixture("PublishCommand/independent");
+    const args = [
+      "publish",
+      "--skip-npm",
+      "--cd-version=major",
+      "--yes",
+    ];
 
-      return execa(LERNA_BIN, args, { cwd }).then((result) => {
-        expect(result.stdout).toMatchSnapshot("stdout: updates independent versions");
+    const stdout = await execa.stdout(LERNA_BIN, args, { cwd });
+    expect(stdout).toMatchSnapshot("stdout: updates independent versions");
 
-        return Promise.all([
-          loadPkgManifests(cwd),
-          lastCommitMessage(cwd),
-        ]);
-      }).then(([allPackageJsons, commitMessage]) => {
-        expect(allPackageJsons).toMatchSnapshot("packages: updates independent versions");
-        expect(commitMessage).toMatchSnapshot("commit: updates independent versions");
-      });
-    });
+    const [allPackageJsons, commitMessage] = await Promise.all([
+      loadPkgManifests(cwd),
+      lastCommitMessage(cwd),
+    ]);
+
+    expect(allPackageJsons).toMatchSnapshot("packages: updates independent versions");
+    expect(commitMessage).toMatchSnapshot("commit: updates independent versions");
   });
 });


### PR DESCRIPTION
To protect Windows from itself, use explicit `node path/to/cli.js [..args]` call style. 

## Motivation and Context
The `require.resolve()` calls were removed in #759, not realizing `yarn` was going to rain on our parade very shortly. This PR builds on #770, which provides some optimizations to the `rimraf` calls independent of the local resolution issue.

#708 is fixed by this because we're not letting Windows Script Host get involved at all, instead calling the resolved CLI in the `node path/to/cli.js [..args]` pattern (which is implicitly what a shebang does, anyway).

## How Has This Been Tested?
Local testing, because yet again I am foiled by unstable test snapshots (`lerna publish --conventional-commits` almost all the way there, except for the timestamps in the changelog output and actual commit history, etc). Le sigh.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.