### PR TITLE
fix: always install leaves using `npm --global-style`

### DIFF
--- a/doc/hoist.md
+++ b/doc/hoist.md
@@ -23,6 +23,8 @@ When the `--hoist` flag is used:
 * Mostly-common dependencies are still hoisted, but outlier packages
   with different versions will get a normal, local `node_modules`
   installation of the necessary dependencies.
+  * In this instance, `lerna bootstrap` will always use `npm install`
+    with the `--global-style` flag, regardless of client configuration.
 * Binaries from those common packages are symlinked to individual
   package `node_modules/.bin` directories, so that `package.json`
   scripts continue to work unmodified.

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -15,7 +15,13 @@ function splitVersion(dep) {
 
 export default class NpmUtilities {
   @logger.logifyAsync()
-  static installInDir(directory, dependencies, config, callback) {
+  static installInDir(directory, dependencies, config, npmGlobalStyle, callback) {
+    // npmGlobalStyle is an optional argument
+    if (typeof npmGlobalStyle === "function") {
+      callback = npmGlobalStyle;
+      npmGlobalStyle = false;
+    }
+
     // Nothing to do if we weren't given any deps.
     if (!(dependencies && dependencies.length)) return callback();
 
@@ -54,7 +60,12 @@ export default class NpmUtilities {
         // build command, arguments, and options
         const opts = NpmUtilities.getExecOpts(directory, config.registry);
         const args = ["install"];
-        const cmd = config.npmClient || "npm";
+        let cmd = config.npmClient || "npm";
+
+        if (npmGlobalStyle) {
+          cmd = "npm";
+          args.push("--global-style");
+        }
 
         if (cmd === "yarn" && config.mutex) {
           args.push("--mutex", config.mutex);

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -428,6 +428,8 @@ export default class BootstrapCommand extends Command {
     }
 
     // Install anything that needs to go into the leaves.
+    // Use `npm install --global-style` for leaves when hoisting is enabled
+    const npmGlobalStyle = this.options.hoist;
     Object.keys(leaves)
       .map((pkgName) => ({ pkg: this.packageGraph.get(pkgName).package, deps: leaves[pkgName] }))
       .forEach(({ pkg, deps }) => {
@@ -439,6 +441,7 @@ export default class BootstrapCommand extends Command {
               pkg.location,
               deps.map(({ dependency }) => dependency),
               this.npmConfig,
+              npmGlobalStyle,
               (err) => {
                 this.progressBar.tick(pkg.name);
                 cb(err);


### PR DESCRIPTION
## Description
Use `npm install --global-style` under `lerna bootstrap --hoist` for packages which cannot be hoisted. This results in more consistently correct behavior at the cost of increased duplication of some packages.

## Motivation and Context
In the event that an explicit dependency (`dep1@X`) of a package is hoisted but other dependencies with a common sub-dependency on a different version of `dep1@Y` cannot be hoisted, npm will attempt to share that package by installing `dep1@Y` in the root of the package's `node_modules` directory. As a result, the incorrect version of `dep1` will be available to the package rather than the hoisted dependency it requires.

### Scenario
1. A package has three explicit dependencies: `dep1@2.x`, `dep2`, and `dep3`. 
2. `dep2` & `dep3` have a transitive dependency on a _different version_ of `dep1` (`dep1@1.x`)
3. `dep1@2.x` can be hoisted, but `dep2` & `dep3` cannot (either due to version mismatches or explict `--nohoist` directives).

### Current Result
```
├── node_modules
│   └── dep1@2.x
└── my-package
    └── node-modules
        ├── dep1@1.x
        ├── dep2
        └── dep3
```

### Desired result
```
├── node_modules
│   └── dep1@2.x
└── my-package
    └── node-modules
        ├── dep2
            └── dep1@1.x
        └── dep3
            └── dep1@1.x
```


### Result without hoisting
```
├── my-package
    └── node-modules
        ├── dep1@2.x
        ├── dep2
            └── dep1@1.x
        └── dep3
            └── dep1@1.x
```

See: https://github.com/lerna/lerna/issues/677

## How Has This Been Tested?
Basic test project and manual validation steps outlined here:
https://gist.github.com/ricky/ff42dd94d52f2c3e25218d6dcb0a5372

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

From the perspective of `npm` users, this probably qualifies as a non-breaking change. For `yarn` users, the client override would constitute a change in functionality.

## Checklist:
- [x] My code follows the code style of this project. (AFAICT)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I had some difficulty crafting a unit test to cover this case. With the way the mocks & fixtures are set up, it's not immediately clear how to represent the transitive dependency of an external dependency.