### PR TITLE
move from --skip-temp-tag to --temp-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,11 +731,15 @@ This is useful if you do not want to explicitly set up your registry
 configuration in all of your package.json files individually when e.g. using
 private registries.
 
-#### --skip-temp-tag
+#### --skip-temp-tag (DEPRECATED)
 
-When activated, this flag will alter the default publish process by not creating
-a temporary tag and handling the process accordingly. Instead it will immediately
-publish with the proper dist-tag as [npm it self would](https://docs.npmjs.com/cli/dist-tag).
+This flag is no longer active due to the fact that the default behavior of 
+Lerna is to publish "as-is" without a temp-tag.
+
+#### --temp-tag
+
+When activated, this flag will alter the default publish process by creating
+a temporary tag in the first place to check for [...] and later removing it.
 
 ### Wizard
 

--- a/README.md
+++ b/README.md
@@ -731,15 +731,14 @@ This is useful if you do not want to explicitly set up your registry
 configuration in all of your package.json files individually when e.g. using
 private registries.
 
-#### --skip-temp-tag (DEPRECATED)
-
-This flag is no longer active due to the fact that the default behavior of 
-Lerna is to publish "as-is" without a temp-tag.
-
 #### --temp-tag
 
-When activated, this flag will alter the default publish process by creating
-a temporary tag in the first place to check for [...] and later removing it.
+When passed, this flag will alter the default publish process by first publishing 
+all changed packages to a temporary dist-tag (`lerna-temp`) and then moving the 
+new version(s) to the default [dist-tag](https://docs.npmjs.com/cli/dist-tag) (`latest`).
+
+This is not generally necessary, as Lerna will publish packages in topological 
+order (all dependencies before dependents) by default.
 
 ### Wizard
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -86,9 +86,11 @@ export const builder = {
     group: "Command Options:",
     describe: "Stop before actually publishing change to npm."
   },
-  "skip-temp-tag": {
+  "temp-tag": {
     group: "Command Options:",
-    describe: "Do not create a temporary tag while publishing."
+    describe: "Create a temporary tag while publishing.",
+    type: "boolean",
+    default: false
   }
 };
 
@@ -521,7 +523,7 @@ export default class PublishCommand extends Command {
   npmPublishAsPrerelease(callback) {
     // if we skip temp tags we should tag with the proper value immediately
     // therefore no updates will be needed
-    const tag = this.options.skipTempTag ? this.getDistTag() : "lerna-temp";
+    const tag = !this.options.tempTag ? this.getDistTag() : "lerna-temp";
 
     this.updates.forEach((update) => {
       this.execScript(update.package, "prepublish");
@@ -568,7 +570,7 @@ export default class PublishCommand extends Command {
   }
 
   npmUpdateAsLatest(callback) {
-    if (this.options.skipTempTag) {
+    if (!this.options.tempTag) {
       return callback();
     }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -88,9 +88,7 @@ export const builder = {
   },
   "temp-tag": {
     group: "Command Options:",
-    describe: "Create a temporary tag while publishing.",
-    type: "boolean",
-    default: false
+    describe: "Create a temporary tag while publishing."
   }
 };
 
@@ -523,7 +521,7 @@ export default class PublishCommand extends Command {
   npmPublishAsPrerelease(callback) {
     // if we skip temp tags we should tag with the proper value immediately
     // therefore no updates will be needed
-    const tag = !this.options.tempTag ? this.getDistTag() : "lerna-temp";
+    const tag = this.options.tempTag ? "lerna-temp" : this.getDistTag();
 
     this.updates.forEach((update) => {
       this.execScript(update.package, "prepublish");

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -157,8 +157,6 @@ describe("PublishCommand", () => {
           expect(gitTagsAdded()).toEqual(["v1.0.1"]);
 
           expect(publishedTagInDirectories(testDir)).toMatchSnapshot("[normal] npm publish --tag");
-          expect(removedDistTagInDirectories(testDir)).toMatchSnapshot("[normal] npm dist-tag rm");
-          expect(addedDistTagInDirectories(testDir)).toMatchSnapshot("[normal] npm dist-tag add");
 
           expect(GitUtilities.pushWithTags).lastCalledWith("origin", gitTagsAdded(), execOpts(testDir));
 
@@ -229,7 +227,7 @@ describe("PublishCommand", () => {
           expect(gitTagsAdded()).toMatchSnapshot("[independent] git tags added");
           expect(GitUtilities.checkoutChanges).not.toBeCalled();
 
-          expect(addedDistTagInDirectories(testDir)).toMatchSnapshot("[independent] npm dist-tag add");
+          expect(publishedTagInDirectories(testDir)).toMatchSnapshot("[independent] npm publish --tag");
 
           expect(GitUtilities.pushWithTags).lastCalledWith("origin", gitTagsAdded(), execOpts(testDir));
 
@@ -289,8 +287,9 @@ describe("PublishCommand", () => {
           expect(GitUtilities.addTag).not.toBeCalled();
           expect(GitUtilities.checkoutChanges).lastCalledWith("packages/*/package.json", execOpts(testDir));
 
-          expect(addedDistTagInDirectories(testDir)).toMatchSnapshot("[normal --canary] npm dist-tag add");
           expect(GitUtilities.pushWithTags).not.toBeCalled();
+          expect(publishedTagInDirectories(testDir))
+            .toMatchSnapshot("[normal --canary] npm publish --tag");
 
           done();
         } catch (ex) {
@@ -345,8 +344,8 @@ describe("PublishCommand", () => {
             "package-1": "^0.0.0",
           });
 
-          expect(addedDistTagInDirectories(testDir))
-            .toMatchSnapshot("[independent --canary] npm dist-tag add");
+          expect(publishedTagInDirectories(testDir))
+            .toMatchSnapshot("[independent --canary] npm publish --tag");
 
           done();
         } catch (ex) {
@@ -389,7 +388,7 @@ describe("PublishCommand", () => {
           expect(GitUtilities.addTag).not.toBeCalled();
           expect(GitUtilities.pushWithTags).not.toBeCalled();
 
-          expect(addedDistTagInDirectories(testDir)).toMatchSnapshot("[normal --skip-git] npm dist-tag add");
+          expect(publishedTagInDirectories(testDir)).toMatchSnapshot("[normal --skip-git] npm publish --tag");
 
           done();
         } catch (ex) {
@@ -537,6 +536,8 @@ describe("PublishCommand", () => {
           }
 
           expect(publishedTagInDirectories(testDir)).toMatchSnapshot("[normal --temp-tag] npm publish --tag");
+          expect(removedDistTagInDirectories(testDir)).toMatchSnapshot("[normal --temp-tag] npm dist-tag rm");
+          expect(addedDistTagInDirectories(testDir)).toMatchSnapshot("[normal --temp-tag] npm dist-tag add");
 
           expect(GitUtilities.pushWithTags).lastCalledWith("origin", ["v1.0.1"], execOpts(testDir));
 

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -536,31 +536,7 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          const directory = path.join(testDir, "./packages/package-2");
-          const packageName = path.basename(directory);
-
-          expect(publishedTagInDirectories(testDir))
-            .toMatchSnapshot("[normal --temp-tag] npm publish --tag");
-
-          expect(NpmUtilities.checkDistTag).lastCalledWith(
-            directory,
-            packageName,
-            "lerna-temp",
-            undefined
-          );
-          expect(NpmUtilities.removeDistTag).lastCalledWith(
-            directory,
-            packageName,
-            "lerna-temp",
-            undefined
-          );
-          expect(NpmUtilities.addDistTag).lastCalledWith(
-            directory,
-            packageName,
-            "1.0.1",
-            "latest",
-            undefined
-          );
+          expect(publishedTagInDirectories(testDir)).toMatchSnapshot("[normal --temp-tag] npm publish --tag");
 
           expect(GitUtilities.pushWithTags).lastCalledWith("origin", ["v1.0.1"], execOpts(testDir));
 
@@ -600,7 +576,7 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          expect(addedDistTagInDirectories(testDir)).toMatchSnapshot("[normal --npm-tag] npm dist-tag add");
+          expect(publishedTagInDirectories(testDir)).toMatchSnapshot("[normal --npm-tag] npm publish --tag");
 
           done();
         } catch (ex) {
@@ -663,17 +639,11 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          const directory = path.join(testDir, "./packages/package-2");
-
-          expect(NpmUtilities.publishTaggedInDir).lastCalledWith(
-            "latest",
-            directory,
-            registry,
-            expect.any(Function)
-          );
           expect(NpmUtilities.checkDistTag).not.toBeCalled();
           expect(NpmUtilities.removeDistTag).not.toBeCalled();
           expect(NpmUtilities.addDistTag).not.toBeCalled();
+          expect(publishedTagInDirectories(testDir))
+            .toMatchSnapshot("[normal --registry] npm publish --tag");
 
           done();
         } catch (ex) {
@@ -1115,8 +1085,8 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          expect(addedDistTagInDirectories(testDir))
-            .toMatchSnapshot("[independent --canary --npm-tag=next --yes --exact] npm dist-tag add");
+          expect(publishedTagInDirectories(testDir))
+            .toMatchSnapshot("[independent --canary --npm-tag=next --yes --exact] npm publish --tag");
 
           done();
         } catch (ex) {

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -1,13 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`[independent --canary --npm-tag=next --yes --exact] npm dist-tag add 1`] = `
-Object {
-  "packages/package-1": "package-1@1.0.0-alpha.deadbeef next",
-  "packages/package-2": "package-2@2.0.0-alpha.deadbeef next",
-  "packages/package-3": "package-3@3.0.0-alpha.deadbeef next",
-  "packages/package-4": "package-4@4.0.0-alpha.deadbeef next",
-}
-`;
+exports[`[independent --canary --npm-tag=next --yes --exact] npm dist-tag add 1`] = `Object {}`;
 
 exports[`[independent --canary] bumps package versions 1`] = `
 Object {
@@ -18,14 +11,7 @@ Object {
 }
 `;
 
-exports[`[independent --canary] npm dist-tag add 1`] = `
-Object {
-  "packages/package-1": "package-1@1.0.0-alpha.deadbeef canary",
-  "packages/package-2": "package-2@2.0.0-alpha.deadbeef canary",
-  "packages/package-3": "package-3@3.0.0-alpha.deadbeef canary",
-  "packages/package-4": "package-4@4.0.0-alpha.deadbeef canary",
-}
-`;
+exports[`[independent --canary] npm dist-tag add 1`] = `Object {}`;
 
 exports[`[independent --cd-version] git commit message 1`] = `
 "Publish
@@ -94,14 +80,7 @@ Array [
 ]
 `;
 
-exports[`[independent] npm dist-tag add 1`] = `
-Object {
-  "packages/package-1": "package-1@1.0.1 latest",
-  "packages/package-2": "package-2@1.1.0 latest",
-  "packages/package-3": "package-3@2.0.0 latest",
-  "packages/package-4": "package-4@1.1.0 latest",
-}
-`;
+exports[`[independent] npm dist-tag add 1`] = `Object {}`;
 
 exports[`[normal --canary] bumps package versions 1`] = `
 Object {
@@ -113,14 +92,7 @@ Object {
 }
 `;
 
-exports[`[normal --canary] npm dist-tag add 1`] = `
-Object {
-  "packages/package-1": "package-1@1.0.0-alpha.deadbeef canary",
-  "packages/package-2": "package-2@1.0.0-alpha.deadbeef canary",
-  "packages/package-3": "package-3@1.0.0-alpha.deadbeef canary",
-  "packages/package-4": "package-4@1.0.0-alpha.deadbeef canary",
-}
-`;
+exports[`[normal --canary] npm dist-tag add 1`] = `Object {}`;
 
 exports[`[normal --ignore] git adds changed files 1`] = `
 Array [
@@ -134,19 +106,12 @@ exports[`[normal --ignore] npm publish --tag 1`] = `
 Array [
   Object {
     "dir": "packages/package-1",
-    "tag": "lerna-temp",
+    "tag": "latest",
   },
 ]
 `;
 
-exports[`[normal --npm-tag] npm dist-tag add 1`] = `
-Object {
-  "packages/package-1": "package-1@1.0.1 custom",
-  "packages/package-2": "package-2@1.0.1 custom",
-  "packages/package-3": "package-3@1.0.1 custom",
-  "packages/package-4": "package-4@1.0.1 custom",
-}
-`;
+exports[`[normal --npm-tag] npm dist-tag add 1`] = `Object {}`;
 
 exports[`[normal --skip-git --skip-npm] bumps package versions 1`] = `
 Object {
@@ -158,32 +123,25 @@ Object {
 }
 `;
 
-exports[`[normal --skip-git] npm dist-tag add 1`] = `
-Object {
-  "packages/package-1": "package-1@1.0.1 latest",
-  "packages/package-2": "package-2@1.0.1 latest",
-  "packages/package-3": "package-3@1.0.1 latest",
-  "packages/package-4": "package-4@1.0.1 latest",
-}
-`;
+exports[`[normal --skip-git] npm dist-tag add 1`] = `Object {}`;
 
-exports[`[normal --skip-temp-tag] npm publish --tag 1`] = `
+exports[`[normal --temp-tag] npm publish --tag 1`] = `
 Array [
   Object {
     "dir": "packages/package-1",
-    "tag": "latest",
+    "tag": "lerna-temp",
   },
   Object {
     "dir": "packages/package-3",
-    "tag": "latest",
+    "tag": "lerna-temp",
   },
   Object {
     "dir": "packages/package-4",
-    "tag": "latest",
+    "tag": "lerna-temp",
   },
   Object {
     "dir": "packages/package-2",
-    "tag": "latest",
+    "tag": "lerna-temp",
   },
 ]
 `;
@@ -209,41 +167,27 @@ Array [
 ]
 `;
 
-exports[`[normal] npm dist-tag add 1`] = `
-Object {
-  "packages/package-1": "package-1@1.0.1 latest",
-  "packages/package-2": "package-2@1.0.1 latest",
-  "packages/package-3": "package-3@1.0.1 latest",
-  "packages/package-4": "package-4@1.0.1 latest",
-}
-`;
+exports[`[normal] npm dist-tag add 1`] = `Object {}`;
 
-exports[`[normal] npm dist-tag rm 1`] = `
-Object {
-  "packages/package-1": "lerna-temp",
-  "packages/package-2": "lerna-temp",
-  "packages/package-3": "lerna-temp",
-  "packages/package-4": "lerna-temp",
-}
-`;
+exports[`[normal] npm dist-tag rm 1`] = `Object {}`;
 
 exports[`[normal] npm publish --tag 1`] = `
 Array [
   Object {
     "dir": "packages/package-1",
-    "tag": "lerna-temp",
+    "tag": "latest",
   },
   Object {
     "dir": "packages/package-3",
-    "tag": "lerna-temp",
+    "tag": "latest",
   },
   Object {
     "dir": "packages/package-4",
-    "tag": "lerna-temp",
+    "tag": "latest",
   },
   Object {
     "dir": "packages/package-2",
-    "tag": "lerna-temp",
+    "tag": "latest",
   },
 ]
 `;

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -1,6 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`[independent --canary --npm-tag=next --yes --exact] npm dist-tag add 1`] = `Object {}`;
+exports[`[independent --canary --npm-tag=next --yes --exact] npm publish --tag 1`] = `
+Array [
+  Object {
+    "dir": "packages/package-1",
+    "tag": "next",
+  },
+  Object {
+    "dir": "packages/package-3",
+    "tag": "next",
+  },
+  Object {
+    "dir": "packages/package-4",
+    "tag": "next",
+  },
+  Object {
+    "dir": "packages/package-2",
+    "tag": "next",
+  },
+]
+`;
 
 exports[`[independent --canary] bumps package versions 1`] = `
 Object {
@@ -111,7 +130,47 @@ Array [
 ]
 `;
 
-exports[`[normal --npm-tag] npm dist-tag add 1`] = `Object {}`;
+exports[`[normal --npm-tag] npm publish --tag 1`] = `
+Array [
+  Object {
+    "dir": "packages/package-1",
+    "tag": "custom",
+  },
+  Object {
+    "dir": "packages/package-3",
+    "tag": "custom",
+  },
+  Object {
+    "dir": "packages/package-4",
+    "tag": "custom",
+  },
+  Object {
+    "dir": "packages/package-2",
+    "tag": "custom",
+  },
+]
+`;
+
+exports[`[normal --registry] npm publish --tag 1`] = `
+Array [
+  Object {
+    "dir": "packages/package-1",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-3",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-4",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-2",
+    "tag": "latest",
+  },
+]
+`;
 
 exports[`[normal --skip-git --skip-npm] bumps package versions 1`] = `
 Object {

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -30,7 +30,26 @@ Object {
 }
 `;
 
-exports[`[independent --canary] npm dist-tag add 1`] = `Object {}`;
+exports[`[independent --canary] npm publish --tag 1`] = `
+Array [
+  Object {
+    "dir": "packages/package-1",
+    "tag": "canary",
+  },
+  Object {
+    "dir": "packages/package-3",
+    "tag": "canary",
+  },
+  Object {
+    "dir": "packages/package-4",
+    "tag": "canary",
+  },
+  Object {
+    "dir": "packages/package-2",
+    "tag": "canary",
+  },
+]
+`;
 
 exports[`[independent --cd-version] git commit message 1`] = `
 "Publish
@@ -99,7 +118,26 @@ Array [
 ]
 `;
 
-exports[`[independent] npm dist-tag add 1`] = `Object {}`;
+exports[`[independent] npm publish --tag 1`] = `
+Array [
+  Object {
+    "dir": "packages/package-1",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-3",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-4",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-2",
+    "tag": "latest",
+  },
+]
+`;
 
 exports[`[normal --canary] bumps package versions 1`] = `
 Object {
@@ -111,7 +149,26 @@ Object {
 }
 `;
 
-exports[`[normal --canary] npm dist-tag add 1`] = `Object {}`;
+exports[`[normal --canary] npm publish --tag 1`] = `
+Array [
+  Object {
+    "dir": "packages/package-1",
+    "tag": "canary",
+  },
+  Object {
+    "dir": "packages/package-3",
+    "tag": "canary",
+  },
+  Object {
+    "dir": "packages/package-4",
+    "tag": "canary",
+  },
+  Object {
+    "dir": "packages/package-2",
+    "tag": "canary",
+  },
+]
+`;
 
 exports[`[normal --ignore] git adds changed files 1`] = `
 Array [
@@ -182,7 +239,44 @@ Object {
 }
 `;
 
-exports[`[normal --skip-git] npm dist-tag add 1`] = `Object {}`;
+exports[`[normal --skip-git] npm publish --tag 1`] = `
+Array [
+  Object {
+    "dir": "packages/package-1",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-3",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-4",
+    "tag": "latest",
+  },
+  Object {
+    "dir": "packages/package-2",
+    "tag": "latest",
+  },
+]
+`;
+
+exports[`[normal --temp-tag] npm dist-tag add 1`] = `
+Object {
+  "packages/package-1": "package-1@1.0.1 latest",
+  "packages/package-2": "package-2@1.0.1 latest",
+  "packages/package-3": "package-3@1.0.1 latest",
+  "packages/package-4": "package-4@1.0.1 latest",
+}
+`;
+
+exports[`[normal --temp-tag] npm dist-tag rm 1`] = `
+Object {
+  "packages/package-1": "lerna-temp",
+  "packages/package-2": "lerna-temp",
+  "packages/package-3": "lerna-temp",
+  "packages/package-4": "lerna-temp",
+}
+`;
 
 exports[`[normal --temp-tag] npm publish --tag 1`] = `
 Array [
@@ -225,10 +319,6 @@ Array [
   "packages/package-5/package.json",
 ]
 `;
-
-exports[`[normal] npm dist-tag add 1`] = `Object {}`;
-
-exports[`[normal] npm dist-tag rm 1`] = `Object {}`;
 
 exports[`[normal] npm publish --tag 1`] = `
 Array [


### PR DESCRIPTION
Explicit skipping of a temp tag is no longer necessary since packages are published in topological order. Fixes #742

## Description
I removed the `--skip-temp-tag` flag from the codebase and replaced it with `--temp-tag` with a default value of `false`.

This means that if nothing is provided Lerna will not create a temp-tag.

If someone would like to create a temp-tag in the process he/she could do it by providing the `--temp-tag` flag.

## How Has This Been Tested?
Inverted the test case where temp tag creation was disabled and tested if it indeed is created when requested.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
