### PR TITLE
Fix --hoist with no argument default

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -20,8 +20,11 @@ export const builder = {
   "hoist": {
     group: "Command Options:",
     describe: "Install external dependencies matching [glob] to the repo root",
-    type: "string",
     defaultDescription: "'**'",
+    coerce: (arg) => {
+      // `--hoist` is equivalent to `--hoist=**`.
+      return arg === true ? "**" : arg;
+    },
   },
   "nohoist": {
     group: "Command Options:",


### PR DESCRIPTION
## Description
`meow` allowed `--hoist` to have behaviour that wasn't translated accurately into `yargs`.

## Motivation and Context
Fixes #768

## How Has This Been Tested?
Local testing on the repo provided in #768

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
