### PR TITLE
Restore async rimraf loops

### DIFF
--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import async from "async";
 import path from "path";
 
@@ -39,15 +38,12 @@ export default class CleanCommand extends Command {
   }
 
   execute(callback) {
-    const tracker = this.logger.newItem("execute");
+    const tracker = this.logger.newItem("clean");
     tracker.addWork(this.directoriesToDelete.length);
 
-    const chunked = _.chunk(this.directoriesToDelete, this.concurrency);
-
-    async.parallelLimit(chunked.map((directories) => (cb) => {
-      FileSystemUtilities.rimraf(directories, (err) => {
-        tracker.completeWork(directories.length);
-
+    async.parallelLimit(this.directoriesToDelete.map((dirPath) => (cb) => {
+      FileSystemUtilities.rimraf(dirPath, (err) => {
+        tracker.completeWork(1);
         cb(err);
       });
     }), this.concurrency, (err) => {

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -60,8 +60,8 @@ const ranScriptsInDirectories = (testDir) =>
 
 const removedDirectories = (testDir) =>
   FileSystemUtilities.rimraf.mock.calls.map((args) =>
-    args[0].map((dir) => normalizeRelativeDir(testDir, dir))
-  ).reduce((acc, val) => acc.concat(val), []);
+    normalizeRelativeDir(testDir, args[0])
+  );
 
 const symlinkedDirectories = (testDir) =>
   FileSystemUtilities.symlink.mock.calls.map((args) => {

--- a/test/CleanCommand.js
+++ b/test/CleanCommand.js
@@ -29,8 +29,8 @@ const stubRimraf = () => {
 
 const removedDirectories = (testDir) =>
   FileSystemUtilities.rimraf.mock.calls.map((args) =>
-    args[0].map((dir) => normalizeRelativeDir(testDir, dir))
-  ).reduce((acc, val) => acc.concat(val), []);
+    normalizeRelativeDir(testDir, args[0])
+  );
 
 describe("CleanCommand", () => {
   beforeEach(() => {

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -96,7 +96,7 @@ describe("FileSystemUtilities", () => {
 
     it("calls rimraf CLI with arguments", (done) => {
       pathExists.mockImplementation(() => Promise.resolve(true));
-      FileSystemUtilities.rimraf(["rimraf/test"], () => {
+      FileSystemUtilities.rimraf("rimraf/test", () => {
         try {
           expect(ChildProcessUtilities.spawn).lastCalledWith(
             process.execPath,
@@ -117,7 +117,7 @@ describe("FileSystemUtilities", () => {
 
     it("does not attempt to delete a non-existent directory", (done) => {
       pathExists.mockImplementation(() => Promise.resolve(false));
-      FileSystemUtilities.rimraf(["rimraf/non-existent"], () => {
+      FileSystemUtilities.rimraf("rimraf/non-existent", () => {
         try {
           expect(ChildProcessUtilities.spawn).not.toBeCalled();
           done();


### PR DESCRIPTION
## Description
Restore original async loop of deleting `node_modules` directories.

## Motivation and Context
Turns out I misunderstood the original algorithm when I made changes last week. It doesn't matter how many `node_modules` directories you pass to `rimraf`, it's still going to take a long time if you don't map them concurrently.

This partially reverts #770

## How Has This Been Tested?
Local testing, with updates to unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
