### PR TITLE
Add --max-buffer flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,13 @@ What level of logs to report.  On failure, all logs are written to lerna-debug.l
 
 Any logs of a higher level than the setting are shown.  The default is "info".
 
+#### --max-buffer [in-bytes]
+
+Set a max buffer length for each underlying process call. Useful for example 
+when someone wants to import a repo with a larger amount of commits while 
+running `lerna import`. In that case the built-in buffer length might not 
+be sufficient.
+
 #### --no-sort
 
 By default, all tasks execute on packages in topologically sorted order as to respect the dependency relationships of the packages in question. Cycles are broken on a best-effort basis in a way not guaranteed to be consistent across Lerna invocations.

--- a/src/Command.js
+++ b/src/Command.js
@@ -58,6 +58,11 @@ export const builder = {
     type: "boolean",
     default: true,
   },
+  "max-buffer": {
+    describe: "Set max-buffer(bytes) for Command execution",
+    type: "number",
+    requiresArg: true
+  }
 };
 
 export default class Command {
@@ -115,6 +120,9 @@ export default class Command {
       this._execOpts = {
         cwd: this.repository.rootPath,
       };
+      if (this.options.maxBuffer) {
+        this._execOpts.maxBuffer = this.options.maxBuffer;
+      }
     }
 
     return this._execOpts;
@@ -166,7 +174,10 @@ export default class Command {
   }
 
   runValidations() {
-    if (!GitUtilities.isInitialized(this.repository.rootPath)) {
+    const opts = Object.assign({}, this.execOpts, {
+      cwd: this.repository.rootPath
+    });
+    if (!GitUtilities.isInitialized(opts)) {
       log.error("ENOGIT", "This is not a git repository, did you already run `git init` or `lerna init`?");
       this._complete(null, 1);
       return;

--- a/src/Command.js
+++ b/src/Command.js
@@ -120,6 +120,7 @@ export default class Command {
       this._execOpts = {
         cwd: this.repository.rootPath,
       };
+
       if (this.options.maxBuffer) {
         this._execOpts.maxBuffer = this.options.maxBuffer;
       }
@@ -174,10 +175,7 @@ export default class Command {
   }
 
   runValidations() {
-    const opts = Object.assign({}, this.execOpts, {
-      cwd: this.repository.rootPath
-    });
-    if (!GitUtilities.isInitialized(opts)) {
+    if (!GitUtilities.isInitialized(this.execOpts)) {
       log.error("ENOGIT", "This is not a git repository, did you already run `git init` or `lerna init`?");
       this._complete(null, 1);
       return;

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -36,6 +36,10 @@ export default class ImportCommand extends Command {
     const externalRepoPath = path.resolve(inputPath);
     const externalRepoBase = path.basename(externalRepoPath);
 
+    this.externalExecOpts = Object.assign({}, this.execOpts, {
+      cwd: externalRepoPath
+    });
+
     try {
       const stats = FileSystemUtilities.statSync(externalRepoPath);
 
@@ -63,10 +67,6 @@ export default class ImportCommand extends Command {
     if (FileSystemUtilities.existsSync(path.resolve(this.repository.rootPath, this.targetDir))) {
       return callback(new Error(`Target directory already exists "${this.targetDir}"`));
     }
-
-    this.externalExecOpts = {
-      cwd: externalRepoPath
-    };
 
     this.commits = this.externalExecSync("git", ["log", "--format=%h"]).split("\n").reverse();
     // this.commits = this.externalExecSync("git", [

--- a/test/Command.js
+++ b/test/Command.js
@@ -95,6 +95,21 @@ describe("Command", () => {
     });
   });
 
+  describe(".execOpts", () => {
+    const ONE_HUNDRED_MEGABYTES = 1000 * 1000 * 100;
+    const REPO_PATH = process.cwd();
+
+    it("has maxBuffer", () => {
+      const command = new Command([], { maxBuffer: ONE_HUNDRED_MEGABYTES });
+      expect(command.execOpts.maxBuffer).toBe(ONE_HUNDRED_MEGABYTES);
+    });
+
+    it("has repo path", () => {
+      const command = new Command([], {}, REPO_PATH);
+      expect(command.execOpts.cwd).toBe(REPO_PATH);
+    });
+  });
+
   describe(".run()", () => {
     let testDir;
 


### PR DESCRIPTION
Add a new flag `---max-buffer` to solve spawn issues.

Fixes: #479

## Description
Added flag with docs, and a new test. I did not add a new test to every command because the buffer issue only surfaced while devs were using the `import` command.

## How Has This Been Tested?
With a new unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
