### PR TITLE
Add tests for npm global style option

### DIFF
--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -324,6 +324,44 @@ describe("NpmUtilities", () => {
       });
     });
 
+    it("supports npm install --global-style", (done) => {
+      const directory = path.normalize("/test/installInDir");
+      const dependencies = [
+        "@scoped/foo@latest",
+        "foo@latest",
+      ];
+      const config = {};
+      const npmGlobalStyle = true;
+
+      NpmUtilities.installInDir(directory, dependencies, config, npmGlobalStyle, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(writePkg.mock.calls[0][1]).toEqual(
+            {
+              dependencies: {
+                "@scoped/foo": "latest",
+                foo: "latest",
+              },
+            },
+          );
+          expect(ChildProcessUtilities.exec).lastCalledWith(
+            "npm",
+            ["install", "--global-style"],
+            {
+              directory,
+              registry: undefined,
+            },
+            expect.any(Function)
+          );
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      });
+    });
+
     it("supports custom npmClient", (done) => {
       const directory = path.normalize("/test/installInDir");
       const dependencies = [
@@ -350,6 +388,47 @@ describe("NpmUtilities", () => {
           expect(ChildProcessUtilities.exec).lastCalledWith(
             "yarn",
             ["install", "--mutex", "network:12345"],
+            {
+              directory,
+              registry: undefined,
+            },
+            expect.any(Function)
+          );
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      });
+    });
+
+    it("overrides custom npmClient when using global style", (done) => {
+      const directory = path.normalize("/test/installInDir");
+      const dependencies = [
+        "@scoped/something@github:foo/bar",
+        "something@github:foo/foo",
+      ];
+      const config = {
+        npmClient: "yarn",
+        mutex: "network:12345",
+      };
+      const npmGlobalStyle = true;
+
+      NpmUtilities.installInDir(directory, dependencies, config, npmGlobalStyle, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(writePkg.mock.calls[0][1]).toEqual(
+            {
+              dependencies: {
+                "@scoped/something": "github:foo/bar",
+                something: "github:foo/foo",
+              },
+            },
+          );
+          expect(ChildProcessUtilities.exec).lastCalledWith(
+            "npm",
+            ["install", "--global-style"],
             {
               directory,
               registry: undefined,

--- a/test/__snapshots__/BootstrapCommand.js.snap
+++ b/test/__snapshots__/BootstrapCommand.js.snap
@@ -75,6 +75,26 @@ Array [
 ]
 `;
 
+exports[`BootstrapCommand with hoisting should use global style to install disallowed external dependencies 1`] = `
+Object {
+  "": Array [
+    "foo@^1.0.0",
+    "@test/package-1@^0.0.0",
+  ],
+  "packages/package-3": Array [
+    "foo@0.1.12",
+  ],
+}
+`;
+
+exports[`BootstrapCommand with hoisting should use global style to install disallowed external dependencies 2`] = `
+Array [
+  "packages/package-1/node_modules/foo",
+  "packages/package-2/node_modules/foo",
+  "packages/package-4/node_modules/@test/package-1",
+]
+`;
+
 exports[`BootstrapCommand with local package dependencies should bootstrap packages 1`] = `
 Object {
   "packages/package-1": Array [


### PR DESCRIPTION
## Description
Test coverage for `npmGlobalStyle` option in `NpmUtilities.installInDir`.

## Motivation and Context
* https://github.com/lerna/lerna/pull/775
* https://github.com/lerna/lerna/commit/c590d57fa0736950ae4820932176d71ceca61587

## How Has This Been Tested?
`npm test`

## Types of changes
- [x] Test fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
