### PR TITLE
Prevent log messages and progress bars from mangling prompts

### DIFF
--- a/src/PromptUtilities.js
+++ b/src/PromptUtilities.js
@@ -1,7 +1,9 @@
 import inquirer from "inquirer";
+import log from "npmlog";
 
 export default class PromptUtilities {
   static confirm(message, callback) {
+    log.pause();
     inquirer.prompt([{
       type: "expand",
       name: "confirm",
@@ -11,10 +13,14 @@ export default class PromptUtilities {
         { key: "y", name: "Yes", value: true },
         { key: "n", name: "No",  value: false }
       ]
-    }]).then((answers) => callback(answers.confirm));
+    }]).then((answers) => {
+      log.resume();
+      callback(answers.confirm);
+    });
   }
 
   static select(message, { choices, filter, validate } = {}, callback) {
+    log.pause();
     inquirer.prompt([{
       type: "list",
       name: "prompt",
@@ -23,16 +29,23 @@ export default class PromptUtilities {
       pageSize: choices.length,
       filter: filter,
       validate: validate
-    }]).then((answers) => callback(answers.prompt));
+    }]).then((answers) => {
+      log.resume();
+      callback(answers.prompt);
+    });
   }
 
   static input(message, { filter, validate } = {}, callback) {
+    log.pause();
     inquirer.prompt([{
       type: "input",
       name: "input",
       message: message,
       filter: filter,
       validate: validate
-    }]).then((answers) => callback(answers.input));
+    }]).then((answers) => {
+      log.resume();
+      callback(answers.input);
+    });
   }
 }


### PR DESCRIPTION
## Description
Pause logging and progress bars when prompts are visible, and resume both when answered.

## Motivation and Context
#779 left the prompts cut off and very hard to use. This fixes that.

## How Has This Been Tested?
Local `lerna publish` in a live repo. I like to live dangerously. 🔥 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
