### PR TITLE
Log the directories being cleaned

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -77,8 +77,8 @@ export default class Command {
     this.input = input;
     this.flags = flags;
 
-    log.verbose("input", input);
-    log.verbose("flags", filterFlags(flags));
+    log.silly("input", input);
+    log.silly("flags", filterFlags(flags));
 
     this.lernaVersion = require("../package.json").version;
     this.repository = new Repository(cwd);
@@ -297,7 +297,7 @@ export default class Command {
           log.verbose(method, "exited early");
           this._complete(null, 1, callback);
         } else {
-          log.verbose(method, "success");
+          log.silly(method, "success");
           next();
         }
       });

--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -88,7 +88,7 @@ export default class FileSystemUtilities {
         // We call this resolved CLI path in the "path/to/node path/to/cli <..args>"
         // pattern to avoid Windows hangups with shebangs (e.g., WSH can't handle it)
         return ChildProcessUtilities.spawn(process.execPath, args, {}, (err) => {
-          log.silly("rimraf", "removed", dirPath);
+          log.verbose("rimraf", "removed", dirPath);
           callback(err);
         });
       });

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -30,7 +30,8 @@ export default class GitUtilities {
       initialized = false;
     }
 
-    log.verbose("isInitialized", initialized);
+    // this does not need to be verbose
+    log.silly("isInitialized", initialized);
     return initialized;
   }
 

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -42,6 +42,8 @@ export default class CleanCommand extends Command {
     tracker.addWork(this.directoriesToDelete.length);
 
     async.parallelLimit(this.directoriesToDelete.map((dirPath) => (cb) => {
+      tracker.info("clean", "removing", dirPath);
+
       FileSystemUtilities.rimraf(dirPath, (err) => {
         tracker.completeWork(1);
         cb(err);

--- a/test/integration/__snapshots__/lerna-clean.test.js.snap
+++ b/test/integration/__snapshots__/lerna-clean.test.js.snap
@@ -2,11 +2,17 @@
 
 exports[`stderr: global --yes 1`] = `
 "lerna info version __TEST_VERSION__
+lerna info clean removing __TEST_ROOTDIR__/packages/package-1/node_modules
+lerna info clean removing __TEST_ROOTDIR__/packages/package-2/node_modules
+lerna info clean removing __TEST_ROOTDIR__/packages/package-3/node_modules
 lerna success clean finished"
 `;
 
 exports[`stderr: local npm 1`] = `
 "lerna info version __TEST_VERSION__
+lerna info clean removing __TEST_ROOTDIR__/packages/package-1/node_modules
+lerna info clean removing __TEST_ROOTDIR__/packages/package-2/node_modules
+lerna info clean removing __TEST_ROOTDIR__/packages/package-3/node_modules
 lerna success clean finished"
 `;
 

--- a/test/integration/lerna-clean.test.js
+++ b/test/integration/lerna-clean.test.js
@@ -1,9 +1,28 @@
 import execa from "execa";
 import getPort from "get-port";
 import globby from "globby";
+import normalizePath from "normalize-path";
+import path from "path";
 
 import { LERNA_BIN } from "../helpers/constants";
 import initFixture from "../helpers/initFixture";
+
+const serializeTestRoot = (match, testDir, subPath) =>
+  normalizePath(path.join("__TEST_ROOTDIR__", subPath));
+
+const normalizeStdio = (cwd) => {
+  const dirPath = new RegExp(`(${cwd})([\\S]+)`, "g");
+
+  return (result) => {
+    const stdout = result.stdout.replace(dirPath, serializeTestRoot);
+    const stderr = result.stderr.replace(dirPath, serializeTestRoot);
+
+    return Object.assign(result, {
+      stdout,
+      stderr,
+    });
+  };
+};
 
 describe("lerna clean", () => {
   test.concurrent("global", async () => {
@@ -14,7 +33,9 @@ describe("lerna clean", () => {
       "--concurrency=1",
     ];
 
-    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd })
+      .then(normalizeStdio(cwd));
+
     expect(stdout).toMatchSnapshot("stdout: global --yes");
     expect(stderr).toMatchSnapshot("stderr: global --yes");
 
@@ -27,7 +48,9 @@ describe("lerna clean", () => {
 
     await execa("npm", ["install", "--cache-min=99999"], { cwd });
 
-    const { stdout, stderr } = await execa("npm", ["run", "clean", "--silent"], { cwd });
+    const { stdout, stderr } = await execa("npm", ["run", "clean", "--silent"], { cwd })
+      .then(normalizeStdio(cwd));
+
     expect(stdout).toMatchSnapshot("stdout: local npm");
     expect(stderr).toMatchSnapshot("stderr: local npm");
 
@@ -44,7 +67,9 @@ describe("lerna clean", () => {
 
     await execa("yarn", ["install", "--no-lockfile", ...mutex], { cwd });
 
-    const { stdout, stderr } = await execa("yarn", ["clean", "--silent", ...mutex], { cwd });
+    const { stdout, stderr } = await execa("yarn", ["clean", "--silent", ...mutex], { cwd })
+      .then(normalizeStdio(cwd));
+
     expect(stdout).toMatchSnapshot("stdout: local yarn");
     expect(stderr).toMatchSnapshot("stderr: local yarn");
 

--- a/test/integration/lerna-clean.test.js
+++ b/test/integration/lerna-clean.test.js
@@ -11,7 +11,8 @@ const serializeTestRoot = (match, testDir, subPath) =>
   normalizePath(path.join("__TEST_ROOTDIR__", subPath));
 
 const normalizeStdio = (cwd) => {
-  const dirPath = new RegExp(`(${cwd})([\\S]+)`, "g");
+  // lol windows paths often look like escaped slashes, so re-re-escape them :P
+  const dirPath = new RegExp(`(${cwd.replace(/\\/g, "\\\\")})([\\S]+)`, "g");
 
   return (result) => {
     const stdout = result.stdout.replace(dirPath, serializeTestRoot);


### PR DESCRIPTION
## Description
Restore some logging to indicate actions during `lerna clean`.

## Motivation and Context
- Tunes the log level of some frequent internal calls to improve their usefulness
- Adds normalizeStdio() utility to avoid cross-platform snapshot mismatch

Fixes #788

## How Has This Been Tested?
local runs, integration test updates

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
