### PR TITLE
Fix --stream run scripts in each package in parallel

### DIFF
--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -193,7 +193,7 @@ export default class PackageUtilities {
   }
 
   static runParallelBatches(batches, makeTask, concurrency, callback) {
-    async.series(batches.map((batch) => (cb) => {
+    async.parallel(batches.map((batch) => (cb) => {
       async.parallelLimit(batch.map(makeTask), concurrency, cb);
     }), callback);
   }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Shouldn't `runParallelBatches` runs `batches` in *parallel* ? :smirk:


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the `--stream` context,  `lerna run watch --stream` should run `npm run watch` on each packages and wait for the user :skull: .
How ever it appers that lerna in only running the first of them waiting for it to end before running the others... but as each `watch` are blocking script, they just never end :neckbeard: 

Looking at the name of the function `runParallelBatches`, I'm guessing that the `async.serial` here is somekind of typo in favor of  `async.parallel` , is it ?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
