### PR TITLE
Add --parallel flag to `lerna exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,17 +458,24 @@ $ lerna run --scope my-component test
 ### exec
 
 ```sh
-$ lerna exec -- [command] # runs the command in all packages
+$ lerna exec -- <command> [..args] # runs the command in all packages
 $ lerna exec -- rm -rf ./node_modules
 $ lerna exec -- protractor conf.js
 ```
 
 Run an arbitrary command in each package.
+A double-dash (`--`) is necessary to pass dashed flags to the spawned command, but is not necessary when all the arguments are positional.
 
-`lerna exec` respects the `--concurrency`, `--scope` and `--ignore` flags (see [Flags](#flags)).
+`lerna exec` respects the `--concurrency`, `--scope`, `--ignore`, and `--parallel` flags (see [Flags](#flags)).
 
 ```sh
 $ lerna exec --scope my-component -- ls -la
+```
+
+To spawn long-running processes, pass the `--parallel` flag:
+```sh
+# transpile all modules as they change in every package
+$ lerna exec --parallel -- babel src -d lib -w
 ```
 
 You may also get the name of the current package through the environment variable `LERNA_PACKAGE_NAME`:
@@ -477,7 +484,7 @@ You may also get the name of the current package through the environment variabl
 $ lerna exec -- npm view \$LERNA_PACKAGE_NAME
 ```
 
-> Hint: The commands are spawned in parallel, using the concurrency given.
+> Hint: The commands are spawned in parallel, using the concurrency given (except with `--parallel`).
 > The output is piped through, so not deterministic.
 > If you want to run the command in one package after another, use it like this:
 
@@ -728,11 +735,18 @@ May also be configured in `lerna.json`:
 #### --stream
 
 Stream output from child processes immediately, prefixed with the originating
-package name.  This can be useful for long-running processes such as "watch"
-builds.  This allows output from different packages to be interleaved.
+package name. This allows output from different packages to be interleaved.
 
 ```sh
 $ lerna run watch --stream
+```
+
+#### --parallel
+
+Similar to `--stream`, but completely disregards concurrency and topological sorting, running a given command or script immediately in all matching packages with prefixed streaming output. This is the preferred flag for long-running processes such as `babel src -d lib -w` run over many packages.
+
+```sh
+$ lerna exec --parallel -- babel src -d lib -w
 ```
 
 #### --registry [registry]

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -37,6 +37,12 @@ export default class ChildProcessUtilities {
     const prefixedStdout = logTransformer({ tag: `${prefix}:` });
     const prefixedStderr = logTransformer({ tag: `${prefix} ERROR`, mergeMultiline: true });
 
+    // Avoid "Possible EventEmitter memory leak detected" warning due to piped stdio
+    if (children > process.stdout.listenerCount("close")) {
+      process.stdout.setMaxListeners(children);
+      process.stderr.setMaxListeners(children);
+    }
+
     spawned.stdout.pipe(prefixedStdout).pipe(process.stdout);
     spawned.stderr.pipe(prefixedStderr).pipe(process.stderr);
 

--- a/test/integration/__snapshots__/lerna-exec.test.js.snap
+++ b/test/integration/__snapshots__/lerna-exec.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`stderr: <cmd> --parallel 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info exec in 2 package(s): ls"
+`;
+
+exports[`stderr: --parallel <cmd> 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info exec in 2 package(s): ls"
+`;
+
 exports[`stderr: echo LERNA_PACKAGE_NAME 1`] = `"lerna info version __TEST_VERSION__"`;
 
 exports[`stderr: ls --ignore 1`] = `

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -64,4 +64,44 @@ describe("lerna exec", () => {
     expect(stdout).toMatchSnapshot("stdout: echo LERNA_PACKAGE_NAME");
     expect(stderr).toMatchSnapshot("stderr: echo LERNA_PACKAGE_NAME");
   });
+
+  test.concurrent("<cmd> --parallel", async () => {
+    const cwd = await initFixture("ExecCommand/basic");
+    const args = [
+      "exec",
+      "ls",
+      "--parallel",
+      // no --
+      "-C",
+    ];
+
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stderr).toMatchSnapshot("stderr: <cmd> --parallel");
+
+    // order is non-deterministic, so assert individually
+    expect(stdout).toMatch("package-1: file-1.js");
+    expect(stdout).toMatch("package-1: package.json");
+    expect(stdout).toMatch("package-2: file-2.js");
+    expect(stdout).toMatch("package-2: package.json");
+  });
+
+  test.concurrent("--parallel <cmd>", async () => {
+    const cwd = await initFixture("ExecCommand/basic");
+    const args = [
+      "exec",
+      "--parallel",
+      "ls",
+      // no --
+      "-C",
+    ];
+
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stderr).toMatchSnapshot("stderr: --parallel <cmd>");
+
+    // order is non-deterministic, so assert individually
+    expect(stdout).toMatch("package-1: file-1.js");
+    expect(stdout).toMatch("package-1: package.json");
+    expect(stdout).toMatch("package-2: file-2.js");
+    expect(stdout).toMatch("package-2: package.json");
+  });
 });


### PR DESCRIPTION
## Description
With this flag, `lerna exec` will run the command in _all_ filtered packages
in parallel, completely ignoring concurrency and topological sorting.

```sh
# transpile modules in all packages as changes occur
lerna exec -- babel src -d lib -w

# transpile watched modules only in package-foo
lerna exec --scope package-foo -- babel src -d lib -w
```

## Motivation and Context
I found this useful in a hoisted monorepo to transpile package exports that are themselves linked to private webpack entry points. Disabling the progress bar is necessary in all cases.

It is advised to constrain the scope of the command when running with this
flag, as spawning dozens of subprocesses may be harmful to your shell's
equanimity (or maximum file descriptor limit, for example). YMMV

## How Has This Been Tested?
local development in a lerna monorepo, and several integration tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.