### PR TITLE
Add --parallel flag to `lerna run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,18 +442,26 @@ List all of the public packages in the current Lerna repo.
 ### run
 
 ```sh
-$ lerna run [script] # runs npm run my-script in all packages that have it
+$ lerna run <script> -- [..args] # runs npm run my-script in all packages that have it
 $ lerna run test
 $ lerna run build
+
+# watch all packages and transpile on change, streaming prefixed output
+$ lerna run --parallel watch
 ```
 
-Run an [npm script](https://docs.npmjs.com/misc/scripts) in each package that contains that script.
+Run an [npm script](https://docs.npmjs.com/misc/scripts) in each package that contains that script. A double-dash (`--`) is necessary to pass dashed arguments to the script execution.
 
-`lerna run` respects the `--concurrency`, `--scope` and `ignore` flags (see [Flags](#flags)).
+`lerna run` respects the `--concurrency`, `--scope`, `--ignore`, `--stream`, and `--parallel` flags (see [Flags](#flags)).
 
 ```sh
 $ lerna run --scope my-component test
 ```
+
+> Note: It is advised to constrain the scope of this command (and `lerna exec`,
+> below) when using the `--parallel` flag, as spawning dozens of subprocesses
+> may be harmful to your shell's equanimity (or maximum file descriptor limit,
+> for example). YMMV
 
 ### exec
 

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -146,6 +146,28 @@ describe("RunCommand", () => {
         }));
       });
     });
+
+    it("runs a script in all packages with --parallel", (done) => {
+      const runCommand = new RunCommand(["env"], {
+        parallel: true,
+      }, testDir);
+
+      runCommand.runValidations();
+      runCommand.runPreparations();
+
+      runCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(ranInPackagesStreaming(testDir))
+            .toMatchSnapshot("run <script> --parallel");
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
   });
 
   describe("with --include-filtered-dependencies", () => {

--- a/test/__snapshots__/RunCommand.js.snap
+++ b/test/__snapshots__/RunCommand.js.snap
@@ -6,6 +6,15 @@ Array [
 ]
 `;
 
+exports[`run <script> --parallel 1`] = `
+Array [
+  "packages/package-1 env",
+  "packages/package-2 env",
+  "packages/package-3 env",
+  "packages/package-4 env",
+]
+`;
+
 exports[`run <script> --scope @test/package-2 --include-filtered-dependencies 1`] = `
 Array [
   "packages/package-1 my-script",

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-1/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-1/package.json
@@ -1,6 +1,9 @@
 {
   "name": "package-1",
   "version": "1.0.0",
+  "devDependencies": {
+    "package-3": "^1.0.0"
+  },
   "scripts": {
     "test": "echo package-1"
   }

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-2/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-2/package.json
@@ -2,6 +2,9 @@
   "name": "package-2",
   "version": "1.0.0",
   "dependencies": {
-    "package-1": "^1.0.0"
+    "package-3": "^1.0.0"
+  },
+  "scripts": {
+    "test": "echo package-2"
   }
 }

--- a/test/fixtures/RunCommand/integration-lifecycle/packages/package-3/package.json
+++ b/test/fixtures/RunCommand/integration-lifecycle/packages/package-3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "package-3",
   "version": "1.0.0",
-  "devDependencies": {
-    "package-2": "^1.0.0"
+  "scripts": {
+    "test": "echo package-3"
   }
 }

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`stderr: my-script --parallel 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info run in 2 package(s): npm run my-script --silent
+lerna success run Ran npm script 'my-script' in packages:
+lerna success - package-1
+lerna success - package-3"
+`;
+
 exports[`stderr: my-script --scope 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info scope package-1
@@ -14,6 +22,32 @@ lerna success run Ran npm script 'test' in packages:
 lerna success - package-4"
 `;
 
+exports[`stderr: test --parallel 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info run in 4 package(s): npm run test --silent
+lerna success run Ran npm script 'test' in packages:
+lerna success - package-1
+lerna success - package-2
+lerna success - package-3
+lerna success - package-4"
+`;
+
+exports[`stderr: test --stream 1`] = `
+"lerna info version __TEST_VERSION__
+lerna success run Ran npm script 'test' in packages:
+lerna success - package-1
+lerna success - package-2
+lerna success - package-3
+lerna success - package-4"
+`;
+
 exports[`stdout: my-script --scope 1`] = `"package-1"`;
 
 exports[`stdout: test --ignore 1`] = `"package-4"`;
+
+exports[`stdout: test --stream 1`] = `
+"package-3: package-3
+package-4: package-4
+package-1: package-1
+package-2: package-2"
+`;

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -3,6 +3,11 @@ import execa from "execa";
 import { LERNA_BIN } from "../helpers/constants";
 import initFixture from "../helpers/initFixture";
 
+/**
+ * NOTE: We do not test the "missing test script" case here
+ * because Windows makes the snapshots impossible to stabilize.
+**/
+
 describe("lerna run", () => {
   test.concurrent("my-script --scope", async () => {
     const cwd = await initFixture("RunCommand/basic");
@@ -33,5 +38,58 @@ describe("lerna run", () => {
     const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
     expect(stdout).toMatchSnapshot("stdout: test --ignore");
     expect(stderr).toMatchSnapshot("stderr: test --ignore");
+  });
+
+  test.concurrent("test --stream", async () => {
+    const cwd = await initFixture("RunCommand/integration-lifecycle");
+    const args = [
+      "run",
+      "--stream",
+      "test",
+      "--concurrency=1",
+      // args below tell npm to be quiet
+      "--", "--silent",
+    ];
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stdout).toMatchSnapshot("stdout: test --stream");
+    expect(stderr).toMatchSnapshot("stderr: test --stream");
+  });
+
+  test.concurrent("test --parallel", async () => {
+    const cwd = await initFixture("RunCommand/integration-lifecycle");
+    const args = [
+      "run",
+      "test",
+      "--parallel",
+      // args below tell npm to be quiet
+      "--", "--silent",
+    ];
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stderr).toMatchSnapshot("stderr: test --parallel");
+
+    // order is non-deterministic, so assert each item seperately
+    expect(stdout).toMatch("package-1: package-1");
+    expect(stdout).toMatch("package-2: package-2");
+    expect(stdout).toMatch("package-3: package-3");
+    expect(stdout).toMatch("package-4: package-4");
+  });
+
+  test.concurrent("my-script --parallel", async () => {
+    const cwd = await initFixture("RunCommand/basic");
+    const args = [
+      "run",
+      "--parallel",
+      "my-script",
+      // args below tell npm to be quiet
+      "--", "--silent",
+    ];
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stderr).toMatchSnapshot("stderr: my-script --parallel");
+
+    // order is non-deterministic, so assert each item seperately
+    expect(stdout).toMatch("package-1: package-1");
+    expect(stdout).not.toMatch("package-2");
+    expect(stdout).toMatch("package-3: package-3");
+    expect(stdout).not.toMatch("package-4");
   });
 });


### PR DESCRIPTION
## Description
Provide a new flag, `--parallel`, to facilitate easier and less error-prone spawning of long-running watchers from npm scripts (e.g., `lerna run watch`).

## Motivation and Context
This allows simpler invocation of `watch` scripts, with the caveat that concurrency and topological sorting are _completely_ ignored. This is generally the intention when calling `lerna run watch` and other similar script targets, hence the additional flag.

```sh
# the following commands are equivalent
$ lerna run watch --concurrency=1000 --stream
$ lerna run watch --parallel
```

Package filtering (`--scope` and `--ignore`) is still available when this new flag is being used, and it is advised to narrow the scope of parallel execution when you have more than a dozen packages or so (YMMV).

## How Has This Been Tested?
local monorepo dev and copious unit and integration tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
