### PR TITLE
Skip git repo check by default in Commands which do not rely on git

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -129,6 +129,10 @@ export default class Command {
     return this._execOpts;
   }
 
+  get requiresGit() {
+    return true;
+  }
+
   // Override this to inherit config from another command.
   // For example `updated` inherits config from `publish`.
   get otherCommandConfigs() {
@@ -175,7 +179,7 @@ export default class Command {
   }
 
   runValidations() {
-    if (!this.options.skipGitCheck && !GitUtilities.isInitialized(this.execOpts)) {
+    if (this.requiresGit && !GitUtilities.isInitialized(this.execOpts)) {
       log.error("ENOGIT", "This is not a git repository, did you already run `git init` or `lerna init`?");
       this._complete(null, 1);
       return;

--- a/src/Command.js
+++ b/src/Command.js
@@ -175,7 +175,7 @@ export default class Command {
   }
 
   runValidations() {
-    if (!this.options.skipGit && !GitUtilities.isInitialized(this.execOpts)) {
+    if (!this.options.skipGitCheck && !GitUtilities.isInitialized(this.execOpts)) {
       log.error("ENOGIT", "This is not a git repository, did you already run `git init` or `lerna init`?");
       this._complete(null, 1);
       return;

--- a/src/Command.js
+++ b/src/Command.js
@@ -175,7 +175,7 @@ export default class Command {
   }
 
   runValidations() {
-    if (!GitUtilities.isInitialized(this.execOpts)) {
+    if (!this.options.skipGit && !GitUtilities.isInitialized(this.execOpts)) {
       log.error("ENOGIT", "This is not a git repository, did you already run `git init` or `lerna init`?");
       this._complete(null, 1);
       return;

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -37,16 +37,14 @@ export const builder = {
     describe: "Executable used to install dependencies (npm, yarn, pnpm, ...)",
     type: "string",
     requiresArg: true,
-  },
-  "skip-git-check": {
-    group: "Command Options:",
-    describe: "Bypass checking for an initialized git repository in the project root.",
-    type: "boolean",
-    default: true
   }
 };
 
 export default class BootstrapCommand extends Command {
+  get requiresGit() {
+    return false;
+  }
+
   initialize(callback) {
     const { registry, npmClient } = this.options;
 

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -38,9 +38,9 @@ export const builder = {
     type: "string",
     requiresArg: true,
   },
-  "skip-git": {
+  "skip-git-check": {
     group: "Command Options:",
-    describe: "Bypass checking for a git repository in the project root.",
+    describe: "Bypass checking for an initialized git repository in the project root.",
     type: "boolean",
     default: true
   }

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -37,6 +37,12 @@ export const builder = {
     describe: "Executable used to install dependencies (npm, yarn, pnpm, ...)",
     type: "string",
     requiresArg: true,
+  },
+  "skip-git": {
+    group: "Command Options:",
+    describe: "Bypass checking for a git repository in the project root.",
+    type: "boolean",
+    default: true
   }
 };
 

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -21,6 +21,10 @@ export const builder = {
 };
 
 export default class CleanCommand extends Command {
+  get requiresGit() {
+    return false;
+  }
+
   initialize(callback) {
     this.directoriesToDelete = this.filteredPackages.map((pkg) => pkg.nodeModulesLocation);
 

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -21,6 +21,10 @@ export const builder = {
 };
 
 export default class ExecCommand extends Command {
+  get requiresGit() {
+    return false;
+  }
+
   initialize(callback) {
     this.command = this.input[0];
     this.args = this.input.slice(1);

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -15,6 +15,10 @@ export const describe = "List all public packages";
 export const builder = {};
 
 export default class LsCommand extends Command {
+  get requiresGit() {
+    return false;
+  }
+
   initialize(callback) {
     // Nothing to do...
     callback(null, true);

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -27,6 +27,10 @@ export const builder = {
 };
 
 export default class RunCommand extends Command {
+  get requiresGit() {
+    return false;
+  }
+
   initialize(callback) {
     this.script = this.input[0];
     this.args = this.input.slice(1);

--- a/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -74,3 +74,14 @@ cli package-2 OK
 package-3 cli1 OK
 package-3 cli2 package-2 OK"
 `;
+
+exports[`simple-no-git-check: stdout 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info Bootstrapping 4 packages
+lerna info lifecycle preinstall
+lerna info Installing external dependencies
+lerna info Symlinking packages and binaries
+lerna info lifecycle postinstall
+lerna info lifecycle prepublish
+lerna success Bootstrapped 4 packages"
+`;

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -46,7 +46,7 @@ describe("lerna bootstrap", () => {
       expect(stderr).toMatchSnapshot("simple-no-git-check: stdout");
     });
 
-    test.concurrent("produces error if --no-skip-git is provided and repo is not initialized", async () => {
+    test.concurrent("errors if --no-skip-git-check is provided and repo is not initialized", async () => {
       const cwd = await tempy.directoryAsync();
       await copyFixture(cwd, "BootstrapCommand/integration");
       const args = [

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -51,7 +51,7 @@ describe("lerna bootstrap", () => {
       await copyFixture(cwd, "BootstrapCommand/integration");
       const args = [
         "bootstrap",
-        "--no-skip-git"
+        "--no-skip-git-check"
       ];
       let expectedError = null;
 

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -46,23 +46,6 @@ describe("lerna bootstrap", () => {
       expect(stderr).toMatchSnapshot("simple-no-git-check: stdout");
     });
 
-    test.concurrent("errors if --no-skip-git-check is provided and repo is not initialized", async () => {
-      const cwd = await tempy.directoryAsync();
-      await copyFixture(cwd, "BootstrapCommand/integration");
-      const args = [
-        "bootstrap",
-        "--no-skip-git-check"
-      ];
-      let expectedError = null;
-
-      try {
-        await execa(LERNA_BIN, args, { cwd });
-      } catch (err) {
-        expectedError = err;
-      }
-      expect(expectedError.toString()).toContain("ENOGIT");
-    });
-
     test.concurrent("--npm-client yarn", async () => {
       const cwd = await initFixture("BootstrapCommand/integration");
       const args = [


### PR DESCRIPTION
According to Bootstrap Command's description it is not necessarily true that we need to check if the command was run in a project where there is a pre-initialized git repository. This PR tries to resolve this issue.

## Description
I added a `--skip-git-check` flag to the Bootstrap Command which is on by default resulting in a behavior described above

## Motivation and Context
#438

## How Has This Been Tested?
I added integration tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
