### PR TITLE
Allow custom yarn mutex from lerna.json config

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -46,18 +46,19 @@ export default class BootstrapCommand extends Command {
   }
 
   initialize(callback) {
-    const { registry, npmClient } = this.options;
+    const { registry, npmClient, mutex } = this.options;
 
     this.npmConfig = {
       registry,
       npmClient,
+      mutex
     };
 
     this.batchedPackages = this.toposort
       ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages)
       : [this.filteredPackages];
 
-    if (npmClient === "yarn") {
+    if (npmClient === "yarn" && !mutex) {
       return getPort(42424).then((port) => {
         this.npmConfig.mutex = `network:${port}`;
         callback(null, true);

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -430,6 +430,31 @@ describe("BootstrapCommand", () => {
         }
       }));
     });
+
+    it("gets user defined mutex when --npm-client=yarn", (done) => {
+      const bootstrapCommand = new BootstrapCommand([], {
+        npmClient: "yarn",
+        mutex: "file:/test/this/path"
+      }, testDir);
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      bootstrapCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(NpmUtilities.installInDir.mock.calls[0][2]).toMatchObject({
+            npmClient: "yarn",
+            mutex: expect.stringMatching(/^file:\/test\/this\/path$/),
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
   });
 
   describe("with external dependencies that have already been installed", () => {


### PR DESCRIPTION
** hold on, getting this explanation in order :)
This small change adds the possibility for the user to add his own mutex setting.

## Description
The current rc of lerna defaults lerna to the use of `--mutex network:424242`. 

With this commit the user can add a 'mutex' setting to lerna.json to choose for himself what type of setting he prefers.

```
{
  "lerna": "2.0.0-rc.4",
  "packages": [
    "packages/*"
  ],
  "mutex": "file:/path/to/file",
  "npmClient": "yarn",
  "version": "independent"
}
```

A limitation with this approach seems to be that the mutex has to be called with a path that is located outside the main packages, if not, the lock is created in de package dir itself and so for every package, which off course defeats the purpose. The path either needs to be absolute or located in the parent-packages directory (or higher).

## Motivation and Context
For some people (including me) working with the default network mutex does not work on every environment after a `yarn cache clean && lerna clean`. 

Ran into trouble when trying to use it on WSL and it seems that there are some docker-users that are also affected by this problem. It's not entirely clear why these environments ignore the network mutex, but they do. WSL does not seem to ignore it if you change the mutex to use a file in stead. This commit gives the user the possibility to do so.

Issue reference:
https://github.com/lerna/lerna/issues/789
and I guess this one: 
https://github.com/yarnpkg/yarn/issues/3327

## How Has This Been Tested?
Built with the changes and if a file is set, the issue seems resolved. Ran both normal and integration tests without the issue occurring. On that note, If I run the integration tests on WSL with the current rc.4, they do not pass.

Further than that, this has not been tested in-depth with a lengthy use-case. It seems that the change I made is pretty much confined to the bootstrap command, although I cannot be entirely sure if nothing else is affected here.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
