### PR TITLE
Support GPG signing of git tags

### DIFF
--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -57,7 +57,7 @@ export default class GitUtilities {
 
   static addTag(tag, opts) {
     log.silly("addTag", tag);
-    ChildProcessUtilities.execSync("git", ["tag", "-a", tag, "-m", tag], opts);
+    ChildProcessUtilities.execSync("git", ["tag", tag, "-m", tag], opts);
   }
 
   static removeTag(tag, opts) {

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -99,7 +99,7 @@ describe("GitUtilities", () => {
       const opts = { cwd: "test" };
       GitUtilities.addTag("foo", opts);
       expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "git", ["tag", "-a", "foo", "-m", "foo"], opts
+        "git", ["tag", "foo", "-m", "foo"], opts
       );
     });
   });


### PR DESCRIPTION
This PR allows Lerna to work with a user's git config to allow signing of tags.

## Description
I removed the `-a` option from the invocation of `git tag`. Since we're invoking `git tag` with `-m`, this will have no effect on the generated tag unless a user has the `tag.forceSignAnnotated` option enabled in their git config.

## Motivation and Context
This is the easy solution to #814 

## How Has This Been Tested?
All existing tests pass, both with and without `tag.forceSignAnnotated` enabled in my git config.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
