### PR TITLE
Add --since flag to all commands that accept --scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,19 +687,27 @@ $ lerna run --scope toolbar-* test
 
 #### --since [ref]
 
-When executing a script or command, only run the script or command on packages that have been updated since the specified `ref`. If `ref` is not specified, it defaults to the latest tag.
+When executing a script or command, scope the operation to packages that have been updated since the specified `ref`. If `ref` is not specified, it defaults to the latest tag.
+
+List the contents of packages that have changed since the latest tag:
 
 ```sh
 $ lerna exec --since -- ls -la
 ```
 
+Run the tests for all packages that have changed since `master`:
+
 ```
 $ lerna run test --since master
 ```
 
+List all packages that have changed since `some-branch`:
+
 ```
 $ lerna ls --since some-branch
 ```
+
+*This can be particularly useful when used in CI, if you can obtain the target branch a PR will be going into, because you can use that as the `ref` to the `--since` option. This works well for PRs going into master as well as feature branches.*
 
 #### --ignore [glob]
 

--- a/README.md
+++ b/README.md
@@ -675,6 +675,22 @@ $ lerna exec --scope my-component -- ls -la
 $ lerna run --scope toolbar-* test
 ```
 
+#### --since [ref]
+
+When executing a script or command, only run the script or command on packages that have been updated since the specified `ref`. If `ref` is not specified, it defaults to the latest tag.
+
+```sh
+$ lerna exec --since -- ls -la
+```
+
+```
+$ lerna run test --since master
+```
+
+```
+$ lerna ls --since some-branch
+```
+
 #### --ignore [glob]
 
 Excludes a subset of packages when running a command.
@@ -720,20 +736,6 @@ $ lerna bootstrap --scope my-component --include-filtered-dependencies
 $ lerna bootstrap --scope "package-*" --ignore "package-util-*" --include-filtered-dependencies
 # all package-util's will be ignored unless they are depended upon by a
 # package matched by "package-*"
-```
-
-#### --only-updated
-
-When executing a script or command, only run the script or command on packages that have been updated since the last release.
-
-A package is considered "updated" using the same rules as `lerna updated`.
-
-```sh
-$ lerna exec --only-updated -- ls -la
-```
-
-```
-$ lerna run --only-updated test
 ```
 
 #### --loglevel [silent|error|warn|success|info|verbose|silly]

--- a/src/Command.js
+++ b/src/Command.js
@@ -38,7 +38,8 @@ export const builder = {
   },
   "since": {
     describe: dedent`
-      Restricts the scope to the packages that have been updated since the last release (tag).
+      Restricts the scope to the packages that have been updated since
+      the specified [ref], or if not specified, the latest tag.
       (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)
     `,
     type: "string",

--- a/src/Command.js
+++ b/src/Command.js
@@ -9,6 +9,7 @@ import PackageUtilities from "./PackageUtilities";
 import Repository from "./Repository";
 import filterFlags from "./utils/filterFlags";
 import writeLogFile from "./utils/writeLogFile";
+import UpdatedPackagesCollector from "./UpdatedPackagesCollector";
 
 // handle log.success()
 log.addLevel("success", 3001, { fg: "green", bold: true });
@@ -35,6 +36,14 @@ export const builder = {
     type: "string",
     requiresArg: true,
   },
+  "since": {
+    describe: dedent`
+      Restricts the scope to the packages that have been updated since the last release (tag).
+      (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)
+    `,
+    type: "string",
+    requiresArg: false,
+  },
   "ignore": {
     describe: dedent`
       Ignore packages with names matching the given glob.
@@ -45,7 +54,7 @@ export const builder = {
   },
   "include-filtered-dependencies": {
     describe: dedent`
-      Include all transitive dependencies when running a command, regardless of --scope or --ignore.
+      Include all transitive dependencies when running a command, regardless of --scope, --since or --ignore.
     `,
   },
   "registry": {
@@ -251,7 +260,7 @@ export default class Command {
   }
 
   runPreparations() {
-    const { scope, ignore, registry } = this.options;
+    const { scope, ignore, registry, since } = this.options;
 
     if (scope) {
       log.info("scope", scope);
@@ -270,6 +279,13 @@ export default class Command {
       this.packages = this.repository.packages;
       this.packageGraph = this.repository.packageGraph;
       this.filteredPackages = PackageUtilities.filterPackages(this.packages, { scope, ignore });
+
+      // The UpdatedPackgaesCollector requires that filteredPackages be present prior to checking for
+      // updates. That's okay because it further filters based on what's already been filtered.
+      if (typeof since === "string") {
+        const updated = new UpdatedPackagesCollector(this).getUpdates().map((update) => update.package.name);
+        this.filteredPackages = this.filteredPackages.filter((pkg) => updated.indexOf(pkg.name) > -1);
+      }
 
       if (this.options.includeFilteredDependencies) {
         this.filteredPackages = PackageUtilities.addDependencies(this.filteredPackages, this.packageGraph);

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -4,7 +4,6 @@ import Command from "../Command";
 import NpmUtilities from "../NpmUtilities";
 import output from "../utils/output";
 import PackageUtilities from "../PackageUtilities";
-import UpdatedPackagesCollector from "../UpdatedPackagesCollector";
 
 export function handler(argv) {
   return new RunCommand([argv.script, ...argv.args], argv).run();
@@ -18,11 +17,6 @@ export const builder = {
   "stream": {
     group: "Command Options:",
     describe: "Stream output with lines prefixed by package.",
-    type: "boolean",
-  },
-  "only-updated": {
-    group: "Command Options:",
-    describe: "Run script in packages that have been updated since the last release only",
     type: "boolean",
   },
   "parallel": {
@@ -46,15 +40,7 @@ export default class RunCommand extends Command {
       return;
     }
 
-    let filteredPackages = this.filteredPackages;
-    if (this.flags.onlyUpdated) {
-      const updatedPackagesCollector = new UpdatedPackagesCollector(this);
-      const packageUpdates = updatedPackagesCollector.getUpdates();
-      filteredPackages = PackageUtilities.filterPackagesThatAreNotUpdated(
-        filteredPackages,
-        packageUpdates
-      );
-    }
+    const { filteredPackages } = this;
 
     if (this.script === "test" || this.script === "env") {
       this.packagesWithScript = filteredPackages;

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -135,7 +135,7 @@ describe("ExecCommand", () => {
       }));
     });
 
-    it("should filter packages that are not updated with --only-updated", (done) => {
+    it("should filter packages that are not updated with --since", (done) => {
       UpdatedPackagesCollector.prototype.getUpdates = jest.fn(() => [{
         package: {
           name: "package-2",
@@ -144,7 +144,7 @@ describe("ExecCommand", () => {
       }]);
 
       const execCommand = new ExecCommand(["ls"], {
-        onlyUpdated: true,
+        since: "",
       }, testDir);
 
       execCommand.runValidations();

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -149,7 +149,7 @@ describe("RunCommand", () => {
       });
     });
 
-    it("should filter packages that are not updated with --only-updated", (done) => {
+    it("should filter packages that are not updated with --since", (done) => {
       UpdatedPackagesCollector.prototype.getUpdates = jest.fn(() => [{
         package: {
           name: "package-3",
@@ -159,7 +159,7 @@ describe("RunCommand", () => {
       }]);
 
       const runCommand = new RunCommand(["my-script"], {
-        onlyUpdated: true,
+        since: "",
       }, testDir);
 
       runCommand.runValidations();
@@ -170,7 +170,7 @@ describe("RunCommand", () => {
 
         try {
           expect(ranInPackages(testDir))
-            .toMatchSnapshot("run <script> --only-updated");
+            .toMatchSnapshot("run <script> --since");
 
           done();
         } catch (ex) {

--- a/test/__snapshots__/RunCommand.js.snap
+++ b/test/__snapshots__/RunCommand.js.snap
@@ -6,12 +6,6 @@ Array [
 ]
 `;
 
-exports[`run <script> --only-updated 1`] = `
-Array [
-  "packages/package-3 my-script",
-]
-`;
-
 exports[`run <script> --parallel 1`] = `
 Array [
   "packages/package-1 env",
@@ -31,6 +25,12 @@ Array [
 exports[`run <script> --scope package-1 1`] = `
 Array [
   "packages/package-1 my-script",
+]
+`;
+
+exports[`run <script> --since 1`] = `
+Array [
+  "packages/package-3 my-script",
 ]
 `;
 

--- a/test/__snapshots__/UpdatedCommand.js.snap
+++ b/test/__snapshots__/UpdatedCommand.js.snap
@@ -3,7 +3,6 @@
 exports[`UpdatedCommand basic should list all packages when no tag is found 1`] = `
 Array [
   "Checking for updated packages...",
-  "No tags found!",
   "Comparing with initial commit.",
 ]
 `;
@@ -21,7 +20,7 @@ Array [
 exports[`UpdatedCommand basic should list changes 1`] = `
 Array [
   "Checking for updated packages...",
-  "Comparing with tag v1.0.0",
+  "Comparing with v1.0.0.",
 ]
 `;
 
@@ -35,7 +34,7 @@ Array [
 exports[`UpdatedCommand basic should list changes for explicitly changed packages 1`] = `
 Array [
   "Checking for updated packages...",
-  "Comparing with tag v1.0.0",
+  "Comparing with v1.0.0.",
 ]
 `;
 
@@ -48,7 +47,7 @@ Array [
 exports[`UpdatedCommand basic should list changes in private packages 1`] = `
 Array [
   "Checking for updated packages...",
-  "Comparing with tag v1.0.0",
+  "Comparing with v1.0.0.",
 ]
 `;
 
@@ -61,7 +60,7 @@ Array [
 exports[`UpdatedCommand basic should list changes with --force-publish * 1`] = `
 Array [
   "Checking for updated packages...",
-  "Comparing with tag v1.0.0",
+  "Comparing with v1.0.0.",
 ]
 `;
 
@@ -78,7 +77,7 @@ Array [
 exports[`UpdatedCommand basic should list changes with --force-publish [package,package] 1`] = `
 Array [
   "Checking for updated packages...",
-  "Comparing with tag v1.0.0",
+  "Comparing with v1.0.0.",
 ]
 `;
 
@@ -94,7 +93,7 @@ exports[`UpdatedCommand basic should list changes without ignored files 1`] = `
 Array [
   "[ 'ignored-file' ]",
   "Checking for updated packages...",
-  "Comparing with tag v1.0.0",
+  "Comparing with v1.0.0.",
 ]
 `;
 

--- a/test/fixtures/UpdatedCommand/basic/packages/package-5/package.json
+++ b/test/fixtures/UpdatedCommand/basic/packages/package-5/package.json
@@ -1,7 +1,7 @@
 {
   "name": "package-5",
   "version": "1.0.0",
-  "private": "true",
+  "private": true,
   "dependencies": {
     "package-1": "^1.0.0"
   }

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -87,7 +87,7 @@ exports[`stderr: exists with a exit code 0 when there are no updates 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info current version 1.0.0
 lerna info Checking for updated packages...
-lerna info Comparing with tag v1.0.0
+lerna info Comparing with v1.0.0.
 lerna info No updated packages to publish. "
 `;
 
@@ -95,7 +95,6 @@ exports[`stderr: updates fixed versions 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info current version 1.0.0
 lerna info Checking for updated packages...
-lerna WARN No tags found!
 lerna info Comparing with initial commit.
 lerna info auto-confirmed "
 `;
@@ -104,7 +103,6 @@ exports[`stderr: updates independent versions 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info versioning independent
 lerna info Checking for updated packages...
-lerna WARN No tags found!
 lerna info Comparing with initial commit.
 lerna info auto-confirmed "
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The `--since` option applies to all commands that accept `--scope`.

By default `--since` will scope the command to all packages that have been updated since the latest tag. If a ref is passed (i.e. `--since ref`), then it will scope the command to all packages that have been updated since the specified ref.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently we have a fairly large repo of packages (currently 68) and the builds take quite awhile to complete because when CI runs, it uses `lerna run` and that executes on all packages. This means our build only gets slower as we add more packages.

Since we only care about packages that have actually changed, we can theoretically use `--scope` to filter the packages that should be run. However, in practice, this isn't very simple because we have to figure out which packages have been updated in the branch and then pass them off to this argument. This means we have to create a separate command outside of Lerna that then proxies `lerna run --scope`.

The problem with creating a separate script means that we're no longer directly using Lerna. Any new scripts we add to packages must now be run through this separate script and it creates what seems like unnecessary indirection when Lerna already has the facilities to do this internally. We felt the most elegant way would be to create a flag like `--scope` that follows the same naming convention and can even be used in conjunction with it, but that allows the caller to also specify a ref to scope the filtered packages to. If a ref isn't provided, it defaults to the latest tag, as it already does internally.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The changes were tested at the main `Command` level in the `.runValidations()` test by adding a section for `.filteredPackages`. I felt this was the best place for a few reasons:

- It can apply to most commands and packages are filtered in the base `Command` class.
- It seemed like there were other places the behaviour of `--scope` was integration tested, but I'm not sure if that would have been too much duplication for the testing of this since it would be testing pretty much the same thing every time. This also keeps the surface area of the changes smaller.

There was one change to the `Command` test file which was required in order to get the expected packages after updating the fixtures. It appears that whole modules were being mocked via Jest but not actually being used because the mocks that were being used were being manually done later in the file in `*Each()` blocks. I ended up just removing the global mocks and everything worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Related issues

No original issue was provided but this also:

- fixes #847
- fixes #855
