### PR TITLE
Add json output to `ls` and `updated` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ $ lerna ls
 
 List all of the public packages in the current Lerna repo.
 
-`lerna ls` respects the `--ignore`, `--scope`, and `--json` flags (see [Flags](#flags)).
+`lerna ls` respects the `--ignore` and `--scope` flags (see [Flags](#flags)).
 
 #### --json
 

--- a/README.md
+++ b/README.md
@@ -405,6 +405,24 @@ Lerna determines the last git tag created and runs `git diff --name-only v6.8.1`
 **Note that configuration for the `publish` command _also_ affects the
 `updated` command.  For example `config.publish.ignore`**
 
+#### --json
+
+```sh
+$ lerna updated --json
+```
+
+When run with this flag, `updated` will return an array of objects in the following format:
+
+```json
+[
+  {
+    "name": "package",
+    "version": "1.0.0",
+    "private": false
+  }
+]
+```
+
 ### clean
 
 ```sh
@@ -437,7 +455,25 @@ $ lerna ls
 
 List all of the public packages in the current Lerna repo.
 
-`lerna ls` respects the `--ignore` and `--scope` flags (see [Flags](#flags)).
+`lerna ls` respects the `--ignore`, `--scope`, and `--json` flags (see [Flags](#flags)).
+
+#### --json
+
+```sh
+$ lerna ls --json
+```
+
+When run with this flag, `ls` will return an array of objects in the following format:
+
+```json
+[
+  {
+    "name": "package",
+    "version": "1.0.0",
+    "private": false
+  }
+]
+```
 
 ### run
 

--- a/src/Command.js
+++ b/src/Command.js
@@ -62,6 +62,14 @@ export const builder = {
     describe: "Set max-buffer(bytes) for Command execution",
     type: "number",
     requiresArg: true
+  },
+  "json": {
+    describe: dedent`
+      Returns output as a machine-readable json object
+      (Only for 'ls' and 'updated' commands)
+    `,
+    type: "boolean",
+    default: false
   }
 };
 
@@ -69,6 +77,11 @@ export default class Command {
   constructor(input, flags, cwd) {
     log.pause();
     log.heading = "lerna";
+
+    // Default to silent log level for JSON output
+    if (flags.json) {
+      log.level = "silent";
+    }
 
     if (flags.loglevel) {
       log.level = flags.loglevel;

--- a/src/Command.js
+++ b/src/Command.js
@@ -62,14 +62,6 @@ export const builder = {
     describe: "Set max-buffer(bytes) for Command execution",
     type: "number",
     requiresArg: true
-  },
-  "json": {
-    describe: dedent`
-      Returns output as a machine-readable json object
-      (Only for 'ls' and 'updated' commands)
-    `,
-    type: "boolean",
-    default: false
   }
 };
 
@@ -77,11 +69,6 @@ export default class Command {
   constructor(input, flags, cwd) {
     log.pause();
     log.heading = "lerna";
-
-    // Default to silent log level for JSON output
-    if (flags.json) {
-      log.level = "silent";
-    }
 
     if (flags.loglevel) {
       log.level = flags.loglevel;

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -12,7 +12,13 @@ export const command = "ls";
 
 export const describe = "List all public packages";
 
-export const builder = {};
+export const builder = {
+  "json": {
+    describe: "Show information in JSON format",
+    group: "Command Options:",
+    type: "boolean"
+  }
+};
 
 export default class LsCommand extends Command {
   get requiresGit() {

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -29,12 +29,20 @@ export default class LsCommand extends Command {
       .map((pkg) => {
         return {
           name: pkg.name,
-          version: chalk.grey(`v${pkg.version}`),
-          private: pkg.isPrivate() ? `(${chalk.red("private")})` : ""
+          version: pkg.version,
+          private: pkg.isPrivate()
         };
       });
 
-    output(columnify(formattedPackages, { showHeaders: false }));
+    if (this.options.json) {
+      output(JSON.stringify(formattedPackages, null, 2));
+    } else {
+      formattedPackages.forEach((pkg) => {
+        pkg.version = chalk.grey(`v${pkg.version}`);
+        pkg.private = pkg.private ? `(${chalk.red("private")})` : "";
+      });
+      output(columnify(formattedPackages, { showHeaders: false }));
+    }
 
     callback(null, true);
   }

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -1,9 +1,22 @@
+import _ from "lodash";
 import chalk from "chalk";
 
 import { builder as publishOptions } from "./PublishCommand";
 import Command from "../Command";
 import output from "../utils/output";
 import UpdatedPackagesCollector from "../UpdatedPackagesCollector";
+
+const updatedOptions = _.assign(
+  {},
+  publishOptions,
+  {
+    "json": {
+      describe: "Show information in JSON format",
+      group: "Command Options:",
+      type: "boolean"
+    }
+  }
+);
 
 export function handler(argv) {
   return new UpdatedCommand(argv._, argv).run();
@@ -13,7 +26,7 @@ export const command = "updated";
 
 export const describe = "Check which packages have changed since the last publish.";
 
-export const builder = (yargs) => yargs.options(publishOptions);
+export const builder = (yargs) => yargs.options(updatedOptions);
 
 export default class UpdatedCommand extends Command {
   initialize(callback) {

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -33,12 +33,23 @@ export default class UpdatedCommand extends Command {
   }
 
   execute(callback) {
-    const formattedUpdates = this.updates.map((update) => update.package).map((pkg) =>
-      `- ${pkg.name}${pkg.isPrivate() ? ` (${chalk.red("private")})` : ""}`
-    ).join("\n");
+    const updatedPackages = this.updates.map((update) => update.package).map((pkg) => {
+      return {
+        name: pkg.name,
+        version: pkg.version,
+        private: pkg.isPrivate()
+      };
+    });
 
     this.logger.info("result");
-    output(formattedUpdates);
+    if (this.options.json) {
+      output(JSON.stringify(updatedPackages, null, 2));
+    } else {
+      const formattedUpdates = updatedPackages.map((pkg) =>
+        `- ${pkg.name}${pkg.private ? ` (${chalk.red("private")})` : ""}`
+      ).join("\n");
+      output(formattedUpdates);
+    }
 
     callback(null, true);
   }

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -129,4 +129,35 @@ describe("LsCommand", () => {
       }));
     });
   });
+
+  describe("with --json", () => {
+    let testDir;
+
+    beforeEach(() => initFixture("LsCommand/basic").then((dir) => {
+      testDir = dir;
+    }));
+
+    it("should list packages as json objects", (done) => {
+      const lsCommand = new LsCommand([], {
+        json: true
+      }, testDir);
+
+      lsCommand.runValidations();
+      lsCommand.runPreparations();
+
+      lsCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+        try {
+          const outputStr = consoleOutput();
+          expect(outputStr).toMatchSnapshot();
+          // Output should be a parseable string
+          const jsonOutput = JSON.parse(outputStr);
+          expect(jsonOutput).toMatchSnapshot();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+  });
 });

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -148,10 +148,8 @@ describe("LsCommand", () => {
       lsCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
         try {
-          const outputStr = consoleOutput();
-          expect(outputStr).toMatchSnapshot();
           // Output should be a parseable string
-          const jsonOutput = JSON.parse(outputStr);
+          const jsonOutput = JSON.parse(consoleOutput());
           expect(jsonOutput).toMatchSnapshot();
           done();
         } catch (ex) {

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -353,6 +353,45 @@ describe("UpdatedCommand", () => {
       updatedCommand.runCommand(exitWithCode(1, done));
     });
   });
+
+  /** =========================================================================
+   * JSON Output
+   * ======================================================================= */
+
+  describe("with --json", () => {
+    let testDir;
+
+    beforeEach(() => initFixture("UpdatedCommand/basic").then((dir) => {
+      testDir = dir;
+    }));
+
+    it("should list changes as a json object", (done) => {
+      setupGitChanges(testDir, [
+        "packages/package-2/random-file",
+      ]);
+
+      const updatedCommand = new UpdatedCommand([], {
+        json: true
+      }, testDir);
+
+      updatedCommand.runValidations();
+      updatedCommand.runPreparations();
+
+      updatedCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+        try {
+          const outputStr = consoleOutput();
+          expect(outputStr).toMatchSnapshot();
+          // Output should be a parseable string
+          const jsonOutput = JSON.parse(outputStr);
+          expect(jsonOutput).toMatchSnapshot();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+  });
 });
 
 // TODO: remove this when we _really_ remove support for SECRET_FLAG

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -380,10 +380,8 @@ describe("UpdatedCommand", () => {
       updatedCommand.runCommand(exitWithCode(0, (err) => {
         if (err) return done.fail(err);
         try {
-          const outputStr = consoleOutput();
-          expect(outputStr).toMatchSnapshot();
           // Output should be a parseable string
-          const jsonOutput = JSON.parse(outputStr);
+          const jsonOutput = JSON.parse(consoleOutput());
           expect(jsonOutput).toMatchSnapshot();
           done();
         } catch (ex) {

--- a/test/__snapshots__/LsCommand.js.snap
+++ b/test/__snapshots__/LsCommand.js.snap
@@ -39,38 +39,6 @@ Array [
 
 exports[`LsCommand with --json should list packages as json objects 1`] = `
 Array [
-  "[
-  {
-    \\"name\\": \\"package-1\\",
-    \\"version\\": \\"1.0.0\\",
-    \\"private\\": false
-  },
-  {
-    \\"name\\": \\"package-2\\",
-    \\"version\\": \\"1.0.0\\",
-    \\"private\\": false
-  },
-  {
-    \\"name\\": \\"package-3\\",
-    \\"version\\": \\"1.0.0\\",
-    \\"private\\": false
-  },
-  {
-    \\"name\\": \\"package-4\\",
-    \\"version\\": \\"1.0.0\\",
-    \\"private\\": false
-  },
-  {
-    \\"name\\": \\"package-5\\",
-    \\"version\\": \\"1.0.0\\",
-    \\"private\\": true
-  }
-]",
-]
-`;
-
-exports[`LsCommand with --json should list packages as json objects 2`] = `
-Array [
   Object {
     "name": "package-1",
     "private": false,

--- a/test/__snapshots__/LsCommand.js.snap
+++ b/test/__snapshots__/LsCommand.js.snap
@@ -36,3 +36,65 @@ Array [
 @test/package-1 v1.0.0 ",
 ]
 `;
+
+exports[`LsCommand with --json should list packages as json objects 1`] = `
+Array [
+  "[
+  {
+    \\"name\\": \\"package-1\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"private\\": false
+  },
+  {
+    \\"name\\": \\"package-2\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"private\\": false
+  },
+  {
+    \\"name\\": \\"package-3\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"private\\": false
+  },
+  {
+    \\"name\\": \\"package-4\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"private\\": false
+  },
+  {
+    \\"name\\": \\"package-5\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"private\\": true
+  }
+]",
+]
+`;
+
+exports[`LsCommand with --json should list packages as json objects 2`] = `
+Array [
+  Object {
+    "name": "package-1",
+    "private": false,
+    "version": "1.0.0",
+  },
+  Object {
+    "name": "package-2",
+    "private": false,
+    "version": "1.0.0",
+  },
+  Object {
+    "name": "package-3",
+    "private": false,
+    "version": "1.0.0",
+  },
+  Object {
+    "name": "package-4",
+    "private": false,
+    "version": "1.0.0",
+  },
+  Object {
+    "name": "package-5",
+    "private": true,
+    "version": "1.0.0",
+  },
+]
+`;

--- a/test/__snapshots__/UpdatedCommand.js.snap
+++ b/test/__snapshots__/UpdatedCommand.js.snap
@@ -135,3 +135,35 @@ Array [
 - package-4",
 ]
 `;
+
+exports[`UpdatedCommand with --json should list changes as a json object 1`] = `
+Array [
+  "[
+  {
+    \\"name\\": \\"package-2\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"private\\": false
+  },
+  {
+    \\"name\\": \\"package-3\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"private\\": false
+  }
+]",
+]
+`;
+
+exports[`UpdatedCommand with --json should list changes as a json object 2`] = `
+Array [
+  Object {
+    "name": "package-2",
+    "private": false,
+    "version": "1.0.0",
+  },
+  Object {
+    "name": "package-3",
+    "private": false,
+    "version": "1.0.0",
+  },
+]
+`;

--- a/test/__snapshots__/UpdatedCommand.js.snap
+++ b/test/__snapshots__/UpdatedCommand.js.snap
@@ -138,23 +138,6 @@ Array [
 
 exports[`UpdatedCommand with --json should list changes as a json object 1`] = `
 Array [
-  "[
-  {
-    \\"name\\": \\"package-2\\",
-    \\"version\\": \\"1.0.0\\",
-    \\"private\\": false
-  },
-  {
-    \\"name\\": \\"package-3\\",
-    \\"version\\": \\"1.0.0\\",
-    \\"private\\": false
-  }
-]",
-]
-`;
-
-exports[`UpdatedCommand with --json should list changes as a json object 2`] = `
-Array [
   Object {
     "name": "package-2",
     "private": false,


### PR DESCRIPTION
## Description
Adds a `--json` flag, which is currently used only by `lerna ls` and `lerna updated` to produce machine-readable output.

## Motivation and Context
Inspired by the discussion in https://github.com/lerna/lerna/pull/686 and my own desire to not have our artisanally-crafted script be reliant on the plain text formatting of `lerna updated` moving forward.

## How Has This Been Tested?
Manually via invocations of the command with and without the `--json` flag, as well as new test cases.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
