### PR TITLE
Bump glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "find-up": "^2.1.0",
     "fs-extra": "^3.0.1",
     "get-port": "^3.1.0",
-    "glob": "^7.0.6",
+    "glob": "^7.1.2",
     "globby": "^6.1.0",
     "graceful-fs": "^4.1.11",
     "inquirer": "^3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,14 +1841,14 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 


### PR DESCRIPTION
## Motivation and Context
A transitive dependency (minimatch) was updated to fix a bug in a transitive dependency (brace-expansion), so let's be extra paranoid and bump the semver range.

## How Has This Been Tested?
tests pass

## Types of changes
- [x] Internal

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
