### PR TITLE
Make `lerna bootstrap` work when using local dependencies

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -33,6 +33,10 @@ export default class NpmUtilities {
     const packageJson = path.join(directory, "package.json");
     const packageJsonBkp = packageJson + ".lerna_backup";
 
+    // Grab the original package.json so that we can inject a few properties to
+    // the temporary fake replacement.
+    const originalPackage = JSON.parse(FileSystemUtilities.readFileSync(packageJson));
+
     log.silly("installInDir", "backup", packageJson);
     FileSystemUtilities.rename(packageJson, packageJsonBkp, (err) => {
       if (err) {
@@ -58,6 +62,8 @@ export default class NpmUtilities {
 
       // Construct a basic fake package.json with just the deps we need to install.
       const tempJson = {
+        name: originalPackage.name,
+        version: originalPackage.version,
         dependencies: dependencies.reduce((deps, dep) => {
           const [pkg, version] = splitVersion(dep);
           deps[pkg] = version || "*";

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -239,6 +239,10 @@ describe("NpmUtilities", () => {
       stubExecOpts();
       ChildProcessUtilities.exec.mockImplementation(callbackSuccess);
       FileSystemUtilities.rename.mockImplementation(callbackSuccess);
+      FileSystemUtilities.readFileSync.mockImplementation(() => (`{
+        "name": "foo",
+        "version": "2.1.2"
+      }`));
       writePkg.mockImplementation(() => Promise.resolve());
     });
 
@@ -258,6 +262,8 @@ describe("NpmUtilities", () => {
         if (err) return done.fail(err);
 
         try {
+          expect(FileSystemUtilities.readFileSync).lastCalledWith(
+            path.join(directory, "package.json"));
           expect(FileSystemUtilities.rename).lastCalledWith(
             path.join(directory, "package.json"),
             path.join(directory, "package.json.lerna_backup"),
@@ -276,6 +282,8 @@ describe("NpmUtilities", () => {
                 caret: "^1.0.0",
                 exact: "1.0.0",
               },
+              name: "foo",
+              version: "2.1.2",
             },
           );
           expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install"], {
@@ -311,6 +319,8 @@ describe("NpmUtilities", () => {
                 "@scoped/tagged": "next",
                 tagged: "next",
               },
+              name: "foo",
+              version: "2.1.2",
             },
           );
           expect(ChildProcessUtilities.exec.mock.calls[0][2]).toMatchObject({
@@ -343,6 +353,8 @@ describe("NpmUtilities", () => {
                 "@scoped/foo": "latest",
                 foo: "latest",
               },
+              name: "foo",
+              version: "2.1.2",
             },
           );
           expect(ChildProcessUtilities.exec).lastCalledWith(
@@ -383,6 +395,8 @@ describe("NpmUtilities", () => {
                 "@scoped/something": "github:foo/bar",
                 something: "github:foo/foo",
               },
+              name: "foo",
+              version: "2.1.2",
             },
           );
           expect(ChildProcessUtilities.exec).lastCalledWith(
@@ -424,6 +438,8 @@ describe("NpmUtilities", () => {
                 "@scoped/something": "github:foo/bar",
                 something: "github:foo/foo",
               },
+              name: "foo",
+              version: "2.1.2",
             },
           );
           expect(ChildProcessUtilities.exec).lastCalledWith(
@@ -477,6 +493,8 @@ describe("NpmUtilities", () => {
                 "@scoped/noversion": "*",
                 noversion: "*",
               },
+              name: "foo",
+              version: "2.1.2",
             },
           );
 


### PR DESCRIPTION
## Description

I use local dependencies in one of my lerna projects (e.g. `"foo": "file:../foo"`). When `lerna bootstrap` is run in this project, I get an error:
```
    lerna info Installing external dependencies
    lerna ERR! execute Error: Command failed: npm install
    lerna ERR! execute npm ERR! addLocal Could not install /<redacted>/lerna-no-name-repro
/packages/a
    lerna ERR! execute npm ERR! Darwin 15.6.0
    lerna ERR! execute npm ERR! argv "/<redacted>/.nodenv/versions/6.1.0/bin/node" "/<reda
cted>/.nodenv/versions/6.1.0/bin/npm" "install"
    lerna ERR! execute npm ERR! node v6.1.0
    lerna ERR! execute npm ERR! npm  v3.8.6
    lerna ERR! execute
    lerna ERR! execute npm ERR! No name provided in package.json
```

If I switch `npmClient` to `yarn`, I get a different error:

```
lerna info Installing external dependencies
lerna ERR! execute Error: Command failed: yarn install --mutex network:42424
lerna ERR! execute warning No license field
lerna ERR! execute error Package "a@" doesn't have a "version".
```

The reason I use local dependencies is that I have packages that are never meant to be published. They're merely there as a simple way of sharing code.

## How Has This Been Tested?
Apart from updating existing unit tests, I created a minimal repro project to test things out:
https://github.com/trotzig/lerna-no-name-repro
This repo contains (I believe) the bare minimum setup to trigger the issue. One thing I found when creating this repo was that there is a race condition somewhere. The bug will only surface if a package 'A that some other package `B depends on hasn't finished installing its node_modules before B tries to resolve its dependencies. This is why the repro repository has a seemingly unrelated dependency ("react") specified for one of the packages.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
