### PR TITLE
Pass extra arguments to npmClient during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,23 @@ When run, this command will:
 2. Symlink together all Lerna `packages` that are dependencies of each other.
 3. `npm prepublish` all bootstrapped packages.
 
-`lerna bootstrap` respects the `--ignore`, `--scope` and `--include-filtered-dependencies` flags (see [Flags](#flags)).
+`lerna bootstrap` respects the `--ignore`, `--scope` and `--include-filtered-dependencies` flags (see [Flags](#flags)). 
+
+Pass extra arguments to npm client by placing them after `--`:
+
+```sh
+$ lerna bootstrap -- --production --no-optional
+```
+
+May also be configured in `lerna.json`:
+
+```js
+{
+  ...
+  "npmClient": "yarn",
+  "npmClientArgs": ["--production", "--no-optional"]
+}
+```
 
 #### How `bootstrap` works
 

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -82,6 +82,10 @@ export default class NpmUtilities {
           args.push("--mutex", config.mutex);
         }
 
+        if (config.npmClientArgs && config.npmClientArgs.length) {
+          args.push(...config.npmClientArgs);
+        }
+
         log.silly("installInDir", [cmd, args]);
         ChildProcessUtilities.exec(cmd, args, opts, done);
       }).catch(done);

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -10,10 +10,10 @@ import NpmUtilities from "../NpmUtilities";
 import PackageUtilities from "../PackageUtilities";
 
 export function handler(argv) {
-  return new BootstrapCommand(argv._, argv).run();
+  return new BootstrapCommand([...argv.args], argv).run();
 }
 
-export const command = "bootstrap";
+export const command = "bootstrap [args..]";
 
 export const describe = "Link local packages together and install remaining package dependencies";
 
@@ -46,12 +46,18 @@ export default class BootstrapCommand extends Command {
   }
 
   initialize(callback) {
-    const { registry, npmClient } = this.options;
+    const { registry, npmClient, npmClientArgs } = this.options;
 
     this.npmConfig = {
       registry,
       npmClient,
+      npmClientArgs,
     };
+
+    // lerna bootstrap ... -- <input>
+    if (this.input.length) {
+      this.npmConfig.npmClientArgs = [...(npmClientArgs || []), ...this.input];
+    }
 
     this.batchedPackages = this.toposort
       ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages)

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -560,4 +560,64 @@ describe("BootstrapCommand", () => {
       }));
     });
   });
+
+  describe("with remaining arguments", () => {
+    describe("by default", () => {
+      let testDir;
+
+      beforeEach(() => initFixture("BootstrapCommand/npm-client-args-1").then((dir) => {
+        testDir = dir;
+      }));
+
+      it("should turn it into npmClientArgs", (done) => {
+        const bootstrapCommand = new BootstrapCommand(["--production", "--no-optional"], {}, testDir);
+
+        bootstrapCommand.runValidations();
+        bootstrapCommand.runPreparations();
+
+        bootstrapCommand.runCommand(exitWithCode(0, (err) => {
+          if (err) return done.fail(err);
+
+          try {
+            expect(NpmUtilities.installInDir.mock.calls[0][2]).toMatchObject({
+              npmClientArgs: ["--production", "--no-optional"],
+            });
+
+            done();
+          } catch (ex) {
+            done.fail(ex);
+          }
+        }));
+      });
+    });
+
+    describe("and configured npmClientArgs option", () => {
+      let testDir;
+
+      beforeEach(() => initFixture("BootstrapCommand/npm-client-args-2").then((dir) => {
+        testDir = dir;
+      }));
+
+      it("should merge both together", (done) => {
+        const bootstrapCommand = new BootstrapCommand(["--no-optional"], {}, testDir);
+
+        bootstrapCommand.runValidations();
+        bootstrapCommand.runPreparations();
+
+        bootstrapCommand.runCommand(exitWithCode(0, (err) => {
+          if (err) return done.fail(err);
+
+          try {
+            expect(NpmUtilities.installInDir.mock.calls[0][2]).toMatchObject({
+              npmClientArgs: ["--production", "--no-optional"],
+            });
+
+            done();
+          } catch (ex) {
+            done.fail(ex);
+          }
+        }));
+      });
+    });
+  });
 });

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -402,6 +402,45 @@ describe("NpmUtilities", () => {
       });
     });
 
+    it("supports custom npmClientArgs", (done) => {
+      const directory = path.normalize("/test/installInDir");
+      const dependencies = [
+        "@scoped/something@github:foo/bar",
+        "something@github:foo/foo",
+      ];
+      const config = {
+        npmClientArgs: ["--production", "--no-optional"],
+      };
+
+      NpmUtilities.installInDir(directory, dependencies, config, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(writePkg.mock.calls[0][1]).toEqual(
+            {
+              dependencies: {
+                "@scoped/something": "github:foo/bar",
+                something: "github:foo/foo",
+              },
+            },
+          );
+          expect(ChildProcessUtilities.exec).lastCalledWith(
+            "npm",
+            ["install", "--production", "--no-optional"],
+            {
+              directory,
+              registry: undefined,
+            },
+            expect.any(Function)
+          );
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      });
+    });
+
     it("overrides custom npmClient when using global style", (done) => {
       const directory = path.normalize("/test/installInDir");
       const dependencies = [

--- a/test/fixtures/BootstrapCommand/npm-client-args-1/lerna.json
+++ b/test/fixtures/BootstrapCommand/npm-client-args-1/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/npm-client-args-1/npm
+++ b/test/fixtures/BootstrapCommand/npm-client-args-1/npm
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("fs").writeFileSync(require("path").resolve(__dirname, "npm-debug.log"), process.argv.slice(2));

--- a/test/fixtures/BootstrapCommand/npm-client-args-1/package.json
+++ b/test/fixtures/BootstrapCommand/npm-client-args-1/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/npm-client-args-1/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/npm-client-args-1/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "pify": "^2.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/npm-client-args-2/lerna.json
+++ b/test/fixtures/BootstrapCommand/npm-client-args-2/lerna.json
@@ -1,0 +1,5 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "npmClientArgs": ["--production"]
+}

--- a/test/fixtures/BootstrapCommand/npm-client-args-2/npm
+++ b/test/fixtures/BootstrapCommand/npm-client-args-2/npm
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("fs").writeFileSync(require("path").resolve(__dirname, "npm-debug.log"), process.argv.slice(2));

--- a/test/fixtures/BootstrapCommand/npm-client-args-2/package.json
+++ b/test/fixtures/BootstrapCommand/npm-client-args-2/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/npm-client-args-2/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/npm-client-args-2/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "pify": "^2.0.0"
+  }
+}

--- a/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -56,6 +56,10 @@ package-3 cli1 OK
 package-3 cli2 package-2 OK"
 `;
 
+exports[`passes remaining arguments + npmClientArgs to npm client 1`] = `"install,--production,--no-optional"`;
+
+exports[`passes remaining arguments to npm client 1`] = `"install,--no-optional"`;
+
 exports[`simple: stderr 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info Bootstrapping 4 packages

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -1,8 +1,10 @@
 import execa from "execa";
+import fs from "fs-extra";
 import getPort from "get-port";
 import globby from "globby";
-import tempy from "tempy";
 import normalizePath from "normalize-path";
+import path from "path";
+import tempy from "tempy";
 
 import { LERNA_BIN } from "../helpers/constants";
 import initFixture from "../helpers/initFixture";
@@ -64,6 +66,38 @@ describe("lerna bootstrap", () => {
 
       const stdout = await execa.stdout(LERNA_BIN, ["run", "test", "--", "--silent"], { cwd });
       expect(stdout).toMatchSnapshot("--npm-client yarn: stdout");
+    });
+
+    test.concurrent("passes remaining arguments to npm client", async () => {
+      const cwd = await initFixture("BootstrapCommand/npm-client-args-1");
+      const args = [
+        "bootstrap",
+        "--npm-client",
+        path.resolve(cwd, "npm"),
+        "--",
+        "--no-optional",
+      ];
+
+      await execa(LERNA_BIN, args, { cwd });
+
+      const npmDebugLog = fs.readFileSync(path.resolve(cwd, "npm-debug.log")).toString();
+      expect(npmDebugLog).toMatchSnapshot("passes remaining arguments to npm client");
+    });
+
+    test.concurrent("passes remaining arguments + npmClientArgs to npm client", async () => {
+      const cwd = await initFixture("BootstrapCommand/npm-client-args-2");
+      const args = [
+        "bootstrap",
+        "--npm-client",
+        path.resolve(cwd, "npm"),
+        "--",
+        "--no-optional",
+      ];
+
+      await execa(LERNA_BIN, args, { cwd });
+
+      const npmDebugLog = fs.readFileSync(path.resolve(cwd, "npm-debug.log")).toString();
+      expect(npmDebugLog).toMatchSnapshot("passes remaining arguments + npmClientArgs to npm client");
     });
   });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allow to pass npmClient arguments.

## Motivation and Context
https://github.com/lerna/lerna/issues/813

## How Has This Been Tested?
```sh
# npm version
{ lerna: '2.0.0-rc.4',
  npm: '3.10.10',
  ares: '1.10.1-DEV',
  http_parser: '2.7.0',
  icu: '57.1',
  modules: '48',
  node: '6.9.4',
  openssl: '1.0.2j',
  uv: '1.9.1',
  v8: '5.1.281.89',
  zlib: '1.2.8' }

# uname -a
Darwin pstrashkin-mbp 15.6.0 Darwin Kernel Version 15.6.0: Tue Apr 11 16:00:51 PDT 2017; root:xnu-3248.60.11.5.3~1/RELEASE_X86_64 x86_64
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
