### PR TITLE
Flag for exec to bail upon child execution error

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,14 @@ $ lerna exec -- npm view \$LERNA_PACKAGE_NAME
 $ lerna exec --concurrency 1 -- ls -la
 ```
 
+#### --bail
+
+```sh
+$ lerna exec --bail=<boolean> <command>
+```
+
+This flag signifies whether or not the `exec` command should halt execution upon encountering an error thrown by one of the spawned subprocesses. Its default value is `true`.
+
 ### import
 
 ```sh

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -14,6 +14,12 @@ export const command = "exec <command> [args..]";
 export const describe = "Run an arbitrary command in each package.";
 
 export const builder = {
+  "bail": {
+    group: "Command Options:",
+    describe: "Bail on exec execution when the command fails within a package",
+    type: "boolean",
+    default: true,
+  },
   "only-updated": {
     group: "Command Options:",
     describe: "Run command in packages that have been updated since the last release only",
@@ -77,6 +83,7 @@ export default class ExecCommand extends Command {
       env: Object.assign({}, process.env, {
         LERNA_PACKAGE_NAME: pkg.name,
       }),
+      reject: this.options.bail
     };
   }
 

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -84,6 +84,29 @@ describe("ExecCommand", () => {
       }));
     });
 
+    it("should ignore execution errors with --bail=false", (done) => {
+      const execCommand = new ExecCommand(["boom"], {
+        bail: false,
+      }, testDir);
+
+      execCommand.runValidations();
+      execCommand.runPreparations();
+
+      execCommand.runCommand(exitWithCode(0, () => {
+
+        try {
+          expect(ChildProcessUtilities.spawn).toHaveBeenCalledTimes(2);
+          expect(ChildProcessUtilities.spawn).lastCalledWith("boom", [], expect.objectContaining({
+            reject: false,
+          }), expect.any(Function));
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+
     it("should filter packages with `ignore`", (done) => {
       const execCommand = new ExecCommand(["ls"], {
         ignore: "package-1",

--- a/test/fixtures/ExecCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/ExecCommand/basic/packages/package-1/package.json
@@ -1,4 +1,7 @@
 {
   "name": "package-1",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "scripts": {
+    "fail-or-succeed": "echo \"failure!\" && exit 1"
+  }
 }

--- a/test/fixtures/ExecCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/ExecCommand/basic/packages/package-2/package.json
@@ -1,4 +1,7 @@
 {
   "name": "package-2",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "scripts": {
+    "fail-or-succeed": "echo \"success!\""
+  }
 }

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -123,29 +123,21 @@ describe("lerna exec", () => {
     expect(stdout).toMatch("success!");
   });
 
-  test.concurrent("--bail=true <cmd>", async () => {
+  test.concurrent("--no-bail <cmd>", async () => {
     const cwd = await initFixture("ExecCommand/basic");
     const args = [
       "exec",
-      "--bail=true",
+      "--no-bail",
       "--concurrency=1",
       "--",
       "npm run fail-or-succeed",
     ];
 
-    let hasError = false;
-    try {
-      await execa(LERNA_BIN, args, { cwd });
-    } catch (error) {
-      hasError = true;
-      expect(error.message).toMatch(
-        "exec Errored while executing 'npm run fail-or-succeed' in 'package-1'",
-      );
-
-      // Script should halt before any attempts on "package-2" are attempted.
-      expect(error.message).not.toMatch("package-2");
-    }
-
-    expect(hasError).toBe(true);
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stderr).toMatch(
+      "Failed at the package-1@1.0.0 fail-or-succeed script 'echo \"failure!\" && exit 1'."
+    );
+    expect(stdout).toMatch("failure!");
+    expect(stdout).toMatch("success!");
   });
 });


### PR DESCRIPTION
## Description
Currently, if a subprocess created using `lerna exec` throws an error, it will kill the entire operation. This change adds a `bail` flag, which will ignore subprocess errors for the `exec` command. The default value for `bail` is true, thereby preserving the existing functionality.

This works by passing a `reject` flag to `execa` (documented [here](https://www.npmjs.com/package/execa#reject)). When this flag is set to `false`, it will resolve its Promise instead of the default rejection behavior.

## Motivation and Context
Motivated by #323 , which outlined that there are many cases where you want to run a command that may fail on all packages, and that the failure outcome should not be cause for halting the operation for the remaining packages.

## How Has This Been Tested?
* Added a new unit test, which confirms the passing of the `reject` flag to `execa`.
* Tested the following command on a local application repository with 23 packages, to confirm they were ran on all packages:

```
lerna exec --bail=false -- npm outdated
```

* Tested the following command on the same local application repository, confirming that the execution will halt upon a single instance of `npm outdated` failing within a package:

```
lerna exec npm outdated
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
