### PR TITLE
Add semver notes to bootstrap command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,16 @@ Let's use `babel` as an example.
 ```
 
 - Lerna checks if each dependency is also part of the Lerna repo.
-  - In this example, `babel-generator` is an internal dependency, while `source-map` is an external dependency.
-  - `source-map` is `npm install`ed like normal.
+  - In this example, `babel-generator` can be an internal dependency, while `source-map` is always an external dependency.
+  - The version of `babel-generator` in the `package.json` of `babel-core` is satisfied by `packages/babel-generator`, passing for an internal dependency.
+  - `source-map` is `npm install`ed (or `yarn`ed) like normal.
 - `packages/babel-core/node_modules/babel-generator` symlinks to `packages/babel-generator`
 - This allows nested directory imports
 
-**Note:** Circular dependencies result in circular symlinks which *may* impact your editor/IDE.
+**Notes:**
+- When a dependency version in a package is not satisfied by a package of the same name in the repo, it will be `npm install`ed (or `yarn`ed) like normal.
+- Dist-tags, like `latest`, do not satisfy [semver](https://semver.npmjs.com/) ranges.
+- Circular dependencies result in circular symlinks which *may* impact your editor/IDE.
 
 [Webstorm](https://www.jetbrains.com/webstorm/) locks up when circular symlinks are present. To prevent this, add `node_modules` to the list of ignored files and folders in `Preferences | Editor | File Types | Ignored files and folders`.
 


### PR DESCRIPTION
## Description
This explains how `bootstrap` does semver checks before using/linking internal packages in a lerna repo.

## Motivation and Context
Sometimes it makes sense to always use the latest version of an internal package, for all other packages.

Being naive, I first used the `latest` dist tag in the `package.json`s of _'all other packages'_. This is when I learnt that tags flat-out do not satisfy semver ranges. Makes sense.

## How Has This Been Tested?
Not applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
