### PR TITLE
All CLI options should be configurable in lerna.json

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -75,7 +75,7 @@ export default class Command {
     }
 
     this.input = input;
-    this.flags = flags;
+    this._flags = flags;
 
     log.silly("input", input);
     log.silly("flags", filterFlags(flags));
@@ -153,7 +153,7 @@ export default class Command {
       this._options = _.defaults(
         {},
         // CLI flags, which if defined overrule subsequent values
-        this.flags,
+        this._flags,
         // Namespaced command options from `lerna.json`
         ...lernaCommandOverrides,
         // Global options from `lerna.json`

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -50,7 +50,7 @@ export default class ExecCommand extends Command {
     this.logger.disableProgress();
 
     let filteredPackages = this.filteredPackages;
-    if (this.flags.onlyUpdated) {
+    if (this.options.onlyUpdated) {
       const updatedPackagesCollector = new UpdatedPackagesCollector(this);
       const packageUpdates = updatedPackagesCollector.getUpdates();
       filteredPackages = PackageUtilities.filterPackagesThatAreNotUpdated(

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -47,7 +47,7 @@ export default class RunCommand extends Command {
     }
 
     let filteredPackages = this.filteredPackages;
-    if (this.flags.onlyUpdated) {
+    if (this.options.onlyUpdated) {
       const updatedPackagesCollector = new UpdatedPackagesCollector(this);
       const packageUpdates = updatedPackagesCollector.getUpdates();
       filteredPackages = PackageUtilities.filterPackagesThatAreNotUpdated(

--- a/test/Command.js
+++ b/test/Command.js
@@ -37,13 +37,6 @@ describe("Command", () => {
     });
   });
 
-  describe(".flags", () => {
-    it("should be added to the instance", () => {
-      const command = new Command(null, { foo: "bar" });
-      expect(command.flags).toEqual({ foo: "bar" });
-    });
-  });
-
   describe(".lernaVersion", () => {
     it("should be added to the instance", () => {
       const command = new Command([], {});


### PR DESCRIPTION
## Motivation and Context
`lerna publish` was the last vestige of `this.flags.*`, providing inconsistent behaviour as @tivac detailed in #841

## How Has This Been Tested?
successful unit and integration tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
