### PR TITLE
Preserve tag summary with `lerna publish --message`

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,12 +388,22 @@ Useful for bypassing the user input prompt if you already know which version to 
 #### --message, -m [msg]
 
 ```sh
-$ lerna publish -m "chore: Publish"
+$ lerna publish -m "chore: Publish %s"
+# commit message = "chore: Publish v1.0.0"
+
+$ lerna publish -m "chore: Publish" --independent
+# commit message = "chore: Publish
+#
+# - package-1@3.0.1
+# - package-2@1.5.4"
 ```
 
 When run with this flag, `publish` will use the provided message when committing the version updates
 for publication. Useful for integrating lerna into projects that expect commit messages to adhere
 to certain guidelines, such as projects which use [commitizen](https://github.com/commitizen/cz-cli) and/or [semantic-release](https://github.com/semantic-release/semantic-release).
+
+If the message contains `%s`, it will be replaced with the new global version version number prefixed with a "v".
+Note that this only applies when using the default "fixed" versioning mode, as there is no "global" version when using `--independent`.
 
 ### updated
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -483,7 +483,7 @@ export default class PublishCommand extends Command {
 
   gitCommitAndTagVersion(version) {
     const tag = "v" + version;
-    const message = this.options.message || tag;
+    const message = this.options.message && this.options.message.replace(/%s/g, tag) || tag;
 
     GitUtilities.commit(message, this.execOpts);
     GitUtilities.addTag(tag, this.execOpts);

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -472,8 +472,8 @@ export default class PublishCommand extends Command {
     const tags = this.updates.map(({ package: { name } }) =>
       `${name}@${this.updatesVersions[name]}`
     );
-    const message = this.options.message ||
-      tags.reduce((msg, tag) => msg + `${EOL} - ${tag}`, `Publish${EOL}`);
+    const subject = this.options.message || "Publish";
+    const message = tags.reduce((msg, tag) => msg + `${EOL} - ${tag}`, `${subject}${EOL}`);
 
     GitUtilities.commit(message, this.execOpts);
     tags.forEach((tag) => GitUtilities.addTag(tag, this.execOpts));

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -924,7 +924,7 @@ describe("PublishCommand", () => {
 
     it("commits changes with a custom message", (done) => {
       const publishCommand = new PublishCommand([], {
-        message: "A custom publish message"
+        message: "chore: Release %s :rocket:"
       }, testDir);
 
       publishCommand.runValidations();
@@ -939,7 +939,7 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          expect(GitUtilities.commit).lastCalledWith("A custom publish message", execOpts(testDir));
+          expect(GitUtilities.commit).lastCalledWith("chore: Release v1.0.1 :rocket:", execOpts(testDir));
 
           done();
         } catch (ex) {

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -963,7 +963,7 @@ describe("PublishCommand", () => {
     it("commits changes with a custom message", (done) => {
       const publishCommand = new PublishCommand([], {
         independent: true,
-        message: "A custom publish message"
+        message: "chore: Custom publish message"
       }, testDir);
 
       publishCommand.runValidations();
@@ -978,7 +978,11 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          expect(GitUtilities.commit).lastCalledWith("A custom publish message", execOpts(testDir));
+          expect(GitUtilities.commit).lastCalledWith(
+            expect.stringContaining("chore:"),
+            execOpts(testDir)
+          );
+          expect(gitCommitMessage()).toMatchSnapshot("[independent --message] git commit message");
 
           done();
         } catch (ex) {

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -82,6 +82,15 @@ exports[`[independent --conventional-commits] git commit message 1`] = `
  - package-4@1.1.0"
 `;
 
+exports[`[independent --message] git commit message 1`] = `
+"chore: Custom publish message
+
+ - package-1@1.0.1
+ - package-2@1.0.1
+ - package-3@1.0.1
+ - package-4@1.0.1"
+`;
+
 exports[`[independent] bumps package versions 1`] = `
 Object {
   "packages/package-1": "1.0.1",


### PR DESCRIPTION
## Description
This allows `--message` to only override the subject in `--independent` publishes and interpolates the global version in a `%s` placeholder for "fixed" publishes.

## Motivation and Context
@tivac pointed out in #842 that #460's intent (as captured by @emmenko) wasn't entirely accomplished, and it's really handy to be able to override the pedestrian-yet-serviceable "Publish" default subject.

## How Has This Been Tested?
Real live publish from my localhost with updated code, as well as updated tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
