### PR TITLE
Allow anonymous package

### DIFF
--- a/src/Package.js
+++ b/src/Package.js
@@ -13,6 +13,7 @@ export default class Package {
   }
 
   get name() {
+    // Anonymous packages will appear in the log messages as directory paths.
     return this._package.name || this._location;
   }
 

--- a/src/Package.js
+++ b/src/Package.js
@@ -13,7 +13,7 @@ export default class Package {
   }
 
   get name() {
-    return this._package.name;
+    return this._package.name || this._location;
   }
 
   get location() {
@@ -58,6 +58,10 @@ export default class Package {
 
   get scripts() {
     return this._package.scripts || {};
+  }
+
+  hasName() {
+    return !!this._package.name;
   }
 
   isPrivate() {

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -32,6 +32,7 @@ export default class LsCommand extends Command {
 
   execute(callback) {
     const formattedPackages = this.filteredPackages
+      .filter((pkg) => pkg.hasName())
       .map((pkg) => {
         return {
           name: pkg.name,

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -112,7 +112,7 @@ export default class PublishCommand extends Command {
 
     this.packagesToPublish = this.updates
       .map((update) => update.package)
-      .filter((pkg) => !pkg.isPrivate());
+      .filter((pkg) => !pkg.isPrivate() && pkg.hasName());
 
     this.packagesToPublishCount = this.packagesToPublish.length;
     this.batchedPackagesToPublish = this.toposort

--- a/test/fixtures/BootstrapCommand/anonymous/lerna.json
+++ b/test/fixtures/BootstrapCommand/anonymous/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/anonymous/package.json
+++ b/test/fixtures/BootstrapCommand/anonymous/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "anonymous"
+}

--- a/test/fixtures/BootstrapCommand/anonymous/packages/anonymous/package.json
+++ b/test/fixtures/BootstrapCommand/anonymous/packages/anonymous/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@test/package-1": "^1.0.0",
+    "@test/package-2": "^1.0.0",
+    "package-3": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/anonymous/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/anonymous/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "foo": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/anonymous/packages/package-2/cli.js
+++ b/test/fixtures/BootstrapCommand/anonymous/packages/package-2/cli.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/anonymous/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/anonymous/packages/package-2/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/package-2",
+  "version": "1.0.0",
+  "bin": "cli.js",
+  "dependencies": {
+    "@test/package-1": "^1.0.0",
+    "foo": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/anonymous/packages/package-3/cli1.js
+++ b/test/fixtures/BootstrapCommand/anonymous/packages/package-3/cli1.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/anonymous/packages/package-3/cli2.js
+++ b/test/fixtures/BootstrapCommand/anonymous/packages/package-3/cli2.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/BootstrapCommand/anonymous/packages/package-3/package.json
+++ b/test/fixtures/BootstrapCommand/anonymous/packages/package-3/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "bin": {
+    "package3cli1": "cli1.js",
+    "package3cli2": "cli2.js"
+  },
+  "devDependencies": {
+    "@test/package-1": "^1.0.0",
+    "@test/package-2": "^1.0.0",
+    "foo": "0.1.12"
+  }
+}

--- a/test/fixtures/BootstrapCommand/anonymous/packages/package-4/package.json
+++ b/test/fixtures/BootstrapCommand/anonymous/packages/package-4/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/package-1": "^0.0.0",
+    "package-3": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/anonymous/lerna.json
+++ b/test/fixtures/PublishCommand/anonymous/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/anonymous/package.json
+++ b/test/fixtures/PublishCommand/anonymous/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "anonymous"
+}

--- a/test/fixtures/PublishCommand/anonymous/packages/anonoymous/package.json
+++ b/test/fixtures/PublishCommand/anonymous/packages/anonoymous/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "package-1": "^1.0.0",
+    "package-2": "^1.0.0",
+    "package-3": "^1.0.0",
+    "package-4": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/anonymous/packages/package-1/package.json
+++ b/test/fixtures/PublishCommand/anonymous/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/anonymous/packages/package-2/package.json
+++ b/test/fixtures/PublishCommand/anonymous/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/anonymous/packages/package-3/package.json
+++ b/test/fixtures/PublishCommand/anonymous/packages/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "devDependencies": {
+    "package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/anonymous/packages/package-4/package.json
+++ b/test/fixtures/PublishCommand/anonymous/packages/package-4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^0.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/anonymous/packages/package-5/package.json
+++ b/test/fixtures/PublishCommand/anonymous/packages/package-5/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-5",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  },
+  "private": true,
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Description

Allow anonymous packages to be bootstrapped.

## Motivation and Context

It is often useful to create packages without name for functional testing where you may have many environments to test, naming these packages is unnecessary as they won't be published anywhere.

Fixes [#848](https://github.com/lerna/lerna/issues/848).

## How Has This Been Tested?

On a local repo, lerna almost supported this feature out of the box, all that I needed to do was filter the anonymous package from the commands.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
