### PR TITLE
Print n/a when a package has no version key.

### DIFF
--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -44,7 +44,7 @@ export default class LsCommand extends Command {
       output(JSON.stringify(formattedPackages, null, 2));
     } else {
       formattedPackages.forEach((pkg) => {
-        pkg.version = chalk.grey(pkg.version ? `v${pkg.version}` : "n/a");
+        pkg.version = pkg.version ? chalk.grey(`v${pkg.version}`) : chalk.yellow("MISSING");
         pkg.private = pkg.private ? `(${chalk.red("private")})` : "";
       });
       output(columnify(formattedPackages, {

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -44,10 +44,17 @@ export default class LsCommand extends Command {
       output(JSON.stringify(formattedPackages, null, 2));
     } else {
       formattedPackages.forEach((pkg) => {
-        pkg.version = chalk.grey(`v${pkg.version}`);
+        pkg.version = chalk.grey(pkg.version ? `v${pkg.version}` : "n/a");
         pkg.private = pkg.private ? `(${chalk.red("private")})` : "";
       });
-      output(columnify(formattedPackages, { showHeaders: false }));
+      output(columnify(formattedPackages, {
+        showHeaders: false,
+        config: {
+          version: {
+            align: "right"
+          }
+        }
+      }));
     }
 
     callback(null, true);

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -130,6 +130,31 @@ describe("LsCommand", () => {
     });
   });
 
+  describe("with an undefined version", () => {
+    let testDir;
+
+    beforeEach(() => initFixture("LsCommand/undefined-version").then((dir) => {
+      testDir = dir;
+    }));
+
+    it("should list packages", (done) => {
+      const lsCommand = new LsCommand([], {}, testDir);
+
+      lsCommand.runValidations();
+      lsCommand.runPreparations();
+
+      lsCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+        try {
+          expect(consoleOutput()).toMatchSnapshot();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+  });
+
   describe("with --json", () => {
     let testDir;
 

--- a/test/__snapshots__/LsCommand.js.snap
+++ b/test/__snapshots__/LsCommand.js.snap
@@ -66,3 +66,9 @@ Array [
   },
 ]
 `;
+
+exports[`LsCommand with an undefined version should list packages 1`] = `
+Array [
+  "package-1 n/a ",
+]
+`;

--- a/test/__snapshots__/LsCommand.js.snap
+++ b/test/__snapshots__/LsCommand.js.snap
@@ -69,6 +69,6 @@ Array [
 
 exports[`LsCommand with an undefined version should list packages 1`] = `
 Array [
-  "package-1 n/a ",
+  "package-1 MISSING ",
 ]
 `;

--- a/test/fixtures/LsCommand/undefined-version/lerna.json
+++ b/test/fixtures/LsCommand/undefined-version/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/LsCommand/undefined-version/package.json
+++ b/test/fixtures/LsCommand/undefined-version/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/LsCommand/undefined-version/packages/package-1/package.json
+++ b/test/fixtures/LsCommand/undefined-version/packages/package-1/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "package-1"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When a package's `version` key is missing, Lerna would print `vundefined` when listing it via `lerna ls`. That's slightly jarring to see, so I replaced the string with `n/a` instead. I also right-aligned the version numbers because it looked slightly neater:

<img width="389" alt="screen shot 2017-05-30 at 21 26 17" src="https://cloud.githubusercontent.com/assets/1282980/26604354/ff7df15e-4581-11e7-8b12-22bd7db68704.png">

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The output looked ugly before. 😄 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've included a snapshot test for this behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
