### PR TITLE
lerna run: Don't error if no scoped packages are matched

### DIFF
--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -65,7 +65,6 @@ export default class RunCommand extends Command {
 
     if (!this.packagesWithScript.length) {
       this.logger.warn(`No packages found with the npm script '${this.script}'`);
-      return callback(null, false);
     }
 
     if (this.options.parallel || this.options.stream) {
@@ -85,8 +84,10 @@ export default class RunCommand extends Command {
       if (err) {
         callback(err);
       } else {
-        this.logger.success("run", `Ran npm script '${this.script}' in packages:`);
-        this.logger.success("", this.packagesWithScript.map((pkg) => `- ${pkg.name}`).join("\n"));
+        if (this.packagesWithScript.length) {
+          this.logger.success("run", `Ran npm script '${this.script}' in packages:`);
+          this.logger.success("", this.packagesWithScript.map((pkg) => `- ${pkg.name}`).join("\n"));
+        }
         callback(null, true);
       }
     };

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -65,6 +65,7 @@ export default class RunCommand extends Command {
 
     if (!this.packagesWithScript.length) {
       this.logger.warn(`No packages found with the npm script '${this.script}'`);
+      return callback(null, false);
     }
 
     if (this.options.parallel || this.options.stream) {
@@ -84,10 +85,8 @@ export default class RunCommand extends Command {
       if (err) {
         callback(err);
       } else {
-        if (this.packagesWithScript.length) {
-          this.logger.success("run", `Ran npm script '${this.script}' in packages:`);
-          this.logger.success("", this.packagesWithScript.map((pkg) => `- ${pkg.name}`).join("\n"));
-        }
+        this.logger.success("run", `Ran npm script '${this.script}' in packages:`);
+        this.logger.success("", this.packagesWithScript.map((pkg) => `- ${pkg.name}`).join("\n"));
         callback(null, true);
       }
     };

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -64,8 +64,7 @@ export default class RunCommand extends Command {
     }
 
     if (!this.packagesWithScript.length) {
-      callback(new Error(`No packages found with the npm script '${this.script}'`));
-      return;
+      this.logger.warn(`No packages found with the npm script '${this.script}'`);
     }
 
     if (this.options.parallel || this.options.stream) {
@@ -85,8 +84,10 @@ export default class RunCommand extends Command {
       if (err) {
         callback(err);
       } else {
-        this.logger.success("run", `Ran npm script '${this.script}' in packages:`);
-        this.logger.success("", this.packagesWithScript.map((pkg) => `- ${pkg.name}`).join("\n"));
+        if (this.packagesWithScript.length) {
+          this.logger.success("run", `Ran npm script '${this.script}' in packages:`);
+          this.logger.success("", this.packagesWithScript.map((pkg) => `- ${pkg.name}`).join("\n"));
+        }
         callback(null, true);
       }
     };

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -179,6 +179,26 @@ describe("RunCommand", () => {
       }));
     });
 
+    it("does not error when no packages match", (done) => {
+      const runCommand = new RunCommand(["missing-script"], {}, testDir);
+
+      runCommand.runValidations();
+      runCommand.runPreparations();
+
+      runCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(NpmUtilities.runScriptInDir).not.toBeCalled();
+          expect(output).not.toBeCalled();
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+
     it("runs a script in all packages with --parallel", (done) => {
       const runCommand = new RunCommand(["env"], {
         parallel: true,


### PR DESCRIPTION
## Description
Display a warning when `lerna run <script>` does not find any npm scripts to execute, rather than throw an error.

## Motivation and Context
Similar to @treshugart, we have a desire to run certain npm scripts against only changed packages. Sometimes no packages have changed, and sometimes only packages without the referenced script has changed. In most situations, this is not a failure state, and this behavior is more in line with other scoped commands (e.g. `ls`, `bootstrap`).

https://github.com/lerna/lerna/issues/859

## How Has This Been Tested?
Manual invocations of the command with scopes that do and don't contain the target npm script.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
