### PR TITLE
[Feature] Root path dir environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,12 @@ You may also get the name of the current package through the environment variabl
 $ lerna exec -- npm view \$LERNA_PACKAGE_NAME
 ```
 
+You may also run a script located in the root dir, in a complicated dir structure through the environment variable `LERNA_ROOT_PATH`:  
+
+```sh
+$ cross-env lerna exec node $LERNA_ROOT_PATH/scripts/some-script.js
+```
+
 > Hint: The commands are spawned in parallel, using the concurrency given (except with `--parallel`).
 > The output is piped through, so not deterministic.
 > If you want to run the command in one package after another, use it like this:

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ $ lerna exec -- npm view \$LERNA_PACKAGE_NAME
 You may also run a script located in the root dir, in a complicated dir structure through the environment variable `LERNA_ROOT_PATH`:  
 
 ```sh
-$ cross-env lerna exec node $LERNA_ROOT_PATH/scripts/some-script.js
+$ lerna exec -- node \$LERNA_ROOT_PATH/scripts/some-script.js
 ```
 
 > Hint: The commands are spawned in parallel, using the concurrency given (except with `--parallel`).

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -82,6 +82,7 @@ export default class ExecCommand extends Command {
       shell: true,
       env: Object.assign({}, process.env, {
         LERNA_PACKAGE_NAME: pkg.name,
+        LERNA_ROOT_PATH: process.cwd(),
       }),
       reject: this.options.bail
     };

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -82,7 +82,7 @@ export default class ExecCommand extends Command {
       shell: true,
       env: Object.assign({}, process.env, {
         LERNA_PACKAGE_NAME: pkg.name,
-        LERNA_ROOT_PATH: process.cwd(),
+        LERNA_ROOT_PATH: this.repository.rootPath,
       }),
       reject: this.options.bail
     };


### PR DESCRIPTION
# problem 
When you want to run a script located in the root dir in a complicated dir structure, when there is no fixed pattern for the distance of the sub-dir level  from the root dir.
```sh
root-dir/
 packages/
  cool-package/
  @some-scope/
    some-package/
    other-package/
 scripts/
 lerna.json
 package.json
```

```sh
/root-dir/packages/cool-package$ node ../../scripts/some-script.js
```
```sh
/root-dir/packages/@some-scope/some-package$ node ../../../scripts/some-script.js
```

```sh
/root-dir$ lerna exec node ../{???}/scripts/some-script.js
```
# solution
If there is a environment variable that contains the root path dir, it is possible to run scripts that are located in the root dir easily.

```sh
/root-dir$ cross-env lerna exec node $LERNA_ROOT_PATH/scripts/some-script.js
```