### PR TITLE
Fix: Run yarn in non-interactive mode

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -82,6 +82,10 @@ export default class NpmUtilities {
           args.push("--mutex", config.mutex);
         }
 
+        if (cmd === "yarn") {
+          args.push("--non-interactive");
+        }
+
         log.silly("installInDir", [cmd, args]);
         ChildProcessUtilities.exec(cmd, args, opts, done);
       }).catch(done);

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -387,7 +387,7 @@ describe("NpmUtilities", () => {
           );
           expect(ChildProcessUtilities.exec).lastCalledWith(
             "yarn",
-            ["install", "--mutex", "network:12345"],
+            ["install", "--mutex", "network:12345", "--non-interactive"],
             {
               directory,
               registry: undefined,


### PR DESCRIPTION
## Description
Run `yarn` in non-interactive mode using `--non-interactive` switch. This is the same behavior as for `npm` client.

## Motivation and Context
`lerna bootstrap` command hangs when there's unknown package version and `yarn` is used as a `npmClient`. `npm` runs in non-interactive mode and just throws an error, but `yarn` tries to suggests different versions by default. This change makes `yarn` to throw an error as `npm` does.

Fixes https://github.com/lerna/lerna/issues/885

## How Has This Been Tested?
Tested in a local repository. I tried to copy minimal testing fixture into the project, but it seems that all tests mock or stub any `yarn` command calls.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
