### PR TITLE
fix: Fix issue where Yargs default would override durable options.

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -24,8 +24,7 @@ export const builder = {
   "concurrency": {
     describe: "How many threads to use if lerna parallelises the tasks.",
     type: "number",
-    requiresArg: true,
-    default: DEFAULT_CONCURRENCY,
+    requiresArg: true
   },
   "scope": {
     describe: dedent`
@@ -56,7 +55,7 @@ export const builder = {
   "sort": {
     describe: "Sort packages topologically (all dependencies before dependents)",
     type: "boolean",
-    default: true,
+    default: undefined
   },
   "max-buffer": {
     describe: "Set max-buffer(bytes) for Command execution",
@@ -158,12 +157,21 @@ export default class Command {
         ...lernaCommandOverrides,
         // Global options from `lerna.json`
         this.repository.lernaJson,
+        // Command specific defaults
+        this.defaultOptions,
         // Deprecated legacy options in `lerna.json`
         this._legacyOptions()
       );
     }
 
     return this._options;
+  }
+
+  get defaultOptions () {
+    return {
+      concurrency: DEFAULT_CONCURRENCY,
+      sort: true
+    };
   }
 
   run() {

--- a/src/Command.js
+++ b/src/Command.js
@@ -24,7 +24,7 @@ export const builder = {
   "concurrency": {
     describe: "How many threads to use if lerna parallelises the tasks.",
     type: "number",
-    requiresArg: true
+    requiresArg: true,
   },
   "scope": {
     describe: dedent`
@@ -55,12 +55,12 @@ export const builder = {
   "sort": {
     describe: "Sort packages topologically (all dependencies before dependents)",
     type: "boolean",
-    default: undefined
+    default: undefined,
   },
   "max-buffer": {
     describe: "Set max-buffer(bytes) for Command execution",
     type: "number",
-    requiresArg: true
+    requiresArg: true,
   }
 };
 
@@ -167,10 +167,10 @@ export default class Command {
     return this._options;
   }
 
-  get defaultOptions () {
+  get defaultOptions() {
     return {
       concurrency: DEFAULT_CONCURRENCY,
-      sort: true
+      sort: true,
     };
   }
 

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -30,7 +30,7 @@ export const builder = {
   "nohoist": {
     group: "Command Options:",
     describe: "Don't hoist external dependencies matching [glob] to the repo root",
-    type: "string"
+    type: "string",
   },
   "npm-client": {
     group: "Command Options:",

--- a/src/commands/CleanCommand.js
+++ b/src/commands/CleanCommand.js
@@ -16,7 +16,7 @@ export const describe = "Remove the node_modules directory from all packages.";
 export const builder = {
   "yes": {
     group: "Command Options:",
-    describe: "Skip all confirmation prompts"
+    describe: "Skip all confirmation prompts",
   }
 };
 

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -18,23 +18,33 @@ export const builder = {
     group: "Command Options:",
     describe: "Bail on exec execution when the command fails within a package",
     type: "boolean",
-    default: true,
+    default: undefined,
   },
   "only-updated": {
     group: "Command Options:",
     describe: "Run command in packages that have been updated since the last release only",
     type: "boolean",
+    default: undefined,
   },
   "parallel": {
     group: "Command Options:",
     describe: "Run command in all packages with unlimited concurrency, streaming prefixed output",
     type: "boolean",
+    default: undefined,
   },
 };
 
 export default class ExecCommand extends Command {
   get requiresGit() {
     return false;
+  }
+
+  get defaultOptions() {
+    return Object.assign({}, super.defaultOptions, {
+      bail: true,
+      onlyUpdated: false,
+      parallel: false,
+    });
   }
 
   initialize(callback) {

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -21,7 +21,7 @@ export const describe = dedent`
 export const builder = {
   "yes": {
     group: "Command Options:",
-    describe: "Skip all confirmation prompts"
+    describe: "Skip all confirmation prompts",
   }
 };
 

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -17,15 +17,26 @@ export const describe = "Create a new Lerna repo or upgrade an existing repo to 
 
 export const builder = {
   "exact": {
-    describe: "Specify lerna dependency version in package.json without a caret (^)"
+    describe: "Specify lerna dependency version in package.json without a caret (^)",
+    type: "boolean",
+    default: undefined,
   },
   "independent": {
     describe: "Version packages independently",
-    alias: "i"
+    alias: "i",
+    type: "boolean",
+    default: undefined,
   }
 };
 
 export default class InitCommand extends Command {
+  get defaultOptions() {
+    return {
+      exact: false,
+      independent: false,
+    };
+  }
+
   // don't do any of this.
   runValidations() {}
   runPreparations() {}

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -16,13 +16,20 @@ export const builder = {
   "json": {
     describe: "Show information in JSON format",
     group: "Command Options:",
-    type: "boolean"
+    type: "boolean",
+    default: undefined
   }
 };
 
 export default class LsCommand extends Command {
   get requiresGit() {
     return false;
+  }
+
+  get defaultOptions() {
+    return Object.assign({}, super.defaultOptions, {
+      json: false,
+    });
   }
 
   initialize(callback) {

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -17,7 +17,7 @@ export const builder = {
     describe: "Show information in JSON format",
     group: "Command Options:",
     type: "boolean",
-    default: undefined
+    default: undefined,
   }
 };
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -28,7 +28,7 @@ export const builder = {
   "canary": {
     group: "Command Options:",
     describe: "Publish packages after every successful merge using the sha as part of the tag.",
-    alias: "c"
+    alias: "c",
   },
   "cd-version": {
     group: "Command Options:",
@@ -59,7 +59,7 @@ export const builder = {
     defaultDescription: "origin",
     describe: "Push git changes to the specified remote instead of 'origin'.",
     type: "string",
-    requiresArg: true
+    requiresArg: true,
   },
   "yes": {
     group: "Command Options:",
@@ -72,19 +72,19 @@ export const builder = {
     describe: "Use a custom commit message when creating the publish commit.",
     alias: "m",
     type: "string",
-    requiresArg: true
+    requiresArg: true,
   },
   "npm-tag": {
     group: "Command Options:",
     describe: "Publish packages with the specified npm dist-tag",
     type: "string",
-    requiresArg: true
+    requiresArg: true,
   },
   "repo-version": {
     group: "Command Options:",
     describe: "Specify repo version to publish.",
     type: "string",
-    requiresArg: true
+    requiresArg: true,
   },
   "skip-git": {
     group: "Command Options:",

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -44,11 +44,15 @@ export const builder = {
   },
   "conventional-commits": {
     group: "Command Options:",
-    describe: "Use angular conventional-commit format to determine version bump and generate CHANGELOG."
+    describe: "Use angular conventional-commit format to determine version bump and generate CHANGELOG.",
+    type: "boolean",
+    default: undefined,
   },
   "exact": {
     group: "Command Options:",
-    describe: "Specify cross-dependency version numbers exactly rather than with a caret (^)."
+    describe: "Specify cross-dependency version numbers exactly rather than with a caret (^).",
+    type: "boolean",
+    default: undefined,
   },
   "git-remote": {
     group: "Command Options:",
@@ -59,7 +63,9 @@ export const builder = {
   },
   "yes": {
     group: "Command Options:",
-    describe: "Skip all confirmation prompts."
+    describe: "Skip all confirmation prompts.",
+    type: "boolean",
+    default: undefined,
   },
   "message": {
     group: "Command Options:",
@@ -82,19 +88,36 @@ export const builder = {
   },
   "skip-git": {
     group: "Command Options:",
-    describe: "Skip commiting, tagging, and pushing git changes."
+    describe: "Skip commiting, tagging, and pushing git changes.",
+    type: "boolean",
+    default: undefined,
   },
   "skip-npm": {
     group: "Command Options:",
-    describe: "Stop before actually publishing change to npm."
+    describe: "Stop before actually publishing change to npm.",
+    type: "boolean",
+    default: undefined,
   },
   "temp-tag": {
     group: "Command Options:",
-    describe: "Create a temporary tag while publishing."
+    describe: "Create a temporary tag while publishing.",
+    type: "boolean",
+    default: undefined,
   }
 };
 
 export default class PublishCommand extends Command {
+  get defaultOptions() {
+    return Object.assign({}, super.defaultOptions, {
+      conventionalCommits: false,
+      exact: false,
+      skipGit: false,
+      skipNpm: false,
+      tempTag: false,
+      yes: false,
+    });
+  }
+
   initialize(callback) {
     this.gitRemote = this.options.gitRemote || "origin";
     this.gitEnabled = !(this.options.canary || this.options.skipGit);

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -19,22 +19,33 @@ export const builder = {
     group: "Command Options:",
     describe: "Stream output with lines prefixed by package.",
     type: "boolean",
+    default: undefined,
   },
   "only-updated": {
     group: "Command Options:",
     describe: "Run script in packages that have been updated since the last release only",
     type: "boolean",
+    default: undefined,
   },
   "parallel": {
     group: "Command Options:",
     describe: "Run script in all packages with unlimited concurrency, streaming prefixed output",
     type: "boolean",
+    default: undefined,
   },
 };
 
 export default class RunCommand extends Command {
   get requiresGit() {
     return false;
+  }
+
+  get defaultOptions() {
+    return Object.assign({}, super.defaultOptions, {
+      onlyUpdated: false,
+      parallel: false,
+      stream: false,
+    });
   }
 
   initialize(callback) {

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -13,7 +13,8 @@ const updatedOptions = _.assign(
     "json": {
       describe: "Show information in JSON format",
       group: "Command Options:",
-      type: "boolean"
+      type: "boolean",
+      default: undefined,
     }
   }
 );
@@ -43,6 +44,12 @@ export default class UpdatedCommand extends Command {
 
   get otherCommandConfigs() {
     return ["publish"];
+  }
+
+  get defaultOptions() {
+    return Object.assign({}, super.defaultOptions, {
+      json: false,
+    });
   }
 
   execute(callback) {

--- a/test/Command.js
+++ b/test/Command.js
@@ -195,6 +195,14 @@ describe("Command", () => {
     class TestBCommand extends Command {
     }
     class TestCCommand extends Command {
+      get defaultOptions() {
+        return {
+          testOption: "a",
+          testOption2: "a",
+          testOption3: "a",
+        };
+      }
+
       get otherCommandConfigs() {
         return ["testb"];
       }
@@ -237,6 +245,15 @@ describe("Command", () => {
         testOption: undefined, // yargs does this when --test-option is not passed
       }, testDir);
       expect(instance.options.testOption).toBe("b");
+    });
+
+    it("should merge flags with defaultOptions", () => {
+      const instance = new TestCCommand([], {
+        testOption: "b",
+      }, testDir);
+      expect(instance.options.testOption).toBe("b");
+      expect(instance.options.testOption2).toBe("c");
+      expect(instance.options.testOption3).toBe("a");
     });
   });
 

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -125,6 +125,7 @@ describe("ExecCommand", () => {
             env: expect.objectContaining({
               LERNA_PACKAGE_NAME: "package-2",
             }),
+            reject: true,
             shell: true,
           }, expect.any(Function));
 
@@ -160,6 +161,7 @@ describe("ExecCommand", () => {
             env: expect.objectContaining({
               LERNA_PACKAGE_NAME: "package-2",
             }),
+            reject: true,
             shell: true,
           }, expect.any(Function));
 


### PR DESCRIPTION
Fixes #895.

The solution to this requires that we stop using yargs defaults because we have several different ways of specifying options. If we specify yargs defaults, then they get set as flags and override any specified in the lerna.json. To get around this, we have to put defaults last in the chain by specifying them per command, as opposed to yargs which comes first in the chain as they merge user-defined options passed as flags with the corresponding defaults.

Unless I'm missing something (definitely could be), there's no way for us to insert our `lerna.json` options in between the options yargs parses and the defaults that we specify for them.

## Description

I've updated each command to:

1. Properly declare boolean options, if they weren't already specified (some weren't).
2. Ensure boolean options are specifying `undefined` as the default.
3. Move the default value that was specified before to be returned from `get defaultOptions` on the command class.

## Motivation and Context

As described in #895, options specified in the `lerna.json` wouldn't be taken if a `default` was specified to the Yargs option definition.

## How Has This Been Tested?

I've written a test to ensure that `defaultOptions` get inserted at the end of the merge chain for flags and lerna.json options.

Other than that, we'd have to test to make sure we're defining all boolean options with `undefined` defaults, or to test this behaviour with every single option that could be subject to the issue, which I'm not sure if this is a good cost-benefit. Open to thoughts on this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
