### PR TITLE
Support Yarn workspaces to replace bootstrap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,21 +840,20 @@ May also be configured in `lerna.json`:
 }
 ```
 
-#### --yarnWorkspaces
+#### --use-orkspaces
 
-Can be only configured in `lerna.json`:
+Enables integration with [Yarn Workspaces](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-workspaces-install-phase-1.md) (available since yarn@0.27+).  
+The values in the array are the commands in which Lerna will delegate operation to Yarn (currently only bootstrapping).    
+If `--use-workspaces` is true then `packages` will be overridden by the value from `package.json/workspaces.`  
+May also be configured in `lerna.json`:
 
 ```js
 {
   ...
   "npmClient": "yarn",
-  "yarnWorkspaces": ["bootstrap"]
+  "use-workspaces": true
 }
 ```
-
-Enables integration with [Yarn Workspaces](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-workspaces-install-phase-1.md) (available since yarn@0.27+).  
-The values in the array are the commands in which Lerna will delegate operation to Yarn (currently only bootstrapping).    
-If `yarnWorkspaces` exists in `lerna.json` then `packages` will be overridden by the value from `package.json/workspaces.`  
 
 
 #### --stream

--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ May also be configured in `lerna.json`:
 }
 ```
 
-#### --use-orkspaces
+#### --use-workspaces
 
 Enables integration with [Yarn Workspaces](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-workspaces-install-phase-1.md) (available since yarn@0.27+).  
 The values in the array are the commands in which Lerna will delegate operation to Yarn (currently only bootstrapping).    

--- a/README.md
+++ b/README.md
@@ -840,6 +840,23 @@ May also be configured in `lerna.json`:
 }
 ```
 
+#### --yarnWorkspaces
+
+Can be only configured in `lerna.json`:
+
+```js
+{
+  ...
+  "npmClient": "yarn",
+  "yarnWorkspaces": ["bootstrap"]
+}
+```
+
+Enables integration with [Yarn Workspaces](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-workspaces-install-phase-1.md) (available since yarn@0.27+).  
+The values in the array are the commands in which Lerna will delegate operation to Yarn (currently only bootstrapping).    
+If `yarnWorkspaces` exists in `lerna.json` then `packages` will be overridden by the value from `package.json/workspaces.`  
+
+
 #### --stream
 
 Stream output from child processes immediately, prefixed with the originating

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -96,6 +96,38 @@ export default class NpmUtilities {
     });
   }
 
+  static installInDirOriginalPackageJson(directory, config, npmGlobalStyle, callback) {
+    log.silly("installInDir", path.basename(directory));
+
+    // npmGlobalStyle is an optional argument
+    if (typeof npmGlobalStyle === "function") {
+      callback = npmGlobalStyle;
+      npmGlobalStyle = false;
+    }
+
+    const packageJson = path.join(directory, "package.json");
+
+    log.silly("installInDir", packageJson);
+
+    // build command, arguments, and options
+    const opts = NpmUtilities.getExecOpts(directory, config.registry);
+    const args = ["install"];
+    let cmd = config.npmClient || "npm";
+
+    if (npmGlobalStyle) {
+      cmd = "npm";
+      args.push("--global-style");
+    }
+
+    if (cmd === "yarn" && config.mutex) {
+      args.push("--mutex", config.mutex);
+    }
+
+    log.silly("installInDir", [cmd, args]);
+    ChildProcessUtilities.exec(cmd, args, opts, callback);
+  }
+
+
   static addDistTag(directory, packageName, version, tag, registry) {
     log.silly("addDistTag", tag, version, packageName);
 

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -55,6 +55,9 @@ export default class Repository {
   }
 
   get packageConfigs() {
+    if (this.lernaJson.yarnWorkspaces) {
+      return this.packageJson.workspaces;
+    }
     return this.lernaJson.packages || [DEFAULT_PACKAGE_GLOB];
   }
 

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -55,7 +55,7 @@ export default class Repository {
   }
 
   get packageConfigs() {
-    if (this.lernaJson.yarnWorkspaces) {
+    if (this.lernaJson.useWorkspaces) {
       return this.packageJson.workspaces;
     }
     return this.lernaJson.packages || [DEFAULT_PACKAGE_GLOB];

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -92,9 +92,9 @@ export default class BootstrapCommand extends Command {
   bootstrapPackages(callback) {
     this.logger.info("", `Bootstrapping ${this.filteredPackages.length} packages`);
 
-    const { yarnWorkspaces } = this.options;
+    const { useWorkspaces } = this.options;
 
-    if (yarnWorkspaces && (yarnWorkspaces.indexOf("bootstrap") >= 0)) {
+    if (useWorkspaces) {
       this.installRootPackageOnly(callback);
     } else {
       async.series([

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -183,4 +183,29 @@ describe("LsCommand", () => {
       }));
     });
   });
+
+  describe("in a Yarn workspace", () => {
+    let testDir;
+
+    beforeEach(() => initFixture("LsCommand/yarn-workspaces").then((dir) => {
+      testDir = dir;
+    }));
+
+    it("should use package.json/workspaces setting", (done) => {
+      const lsCommand = new LsCommand([], {}, testDir);
+
+      lsCommand.runValidations();
+      lsCommand.runPreparations();
+
+      lsCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+        try {
+          expect(consoleOutput()).toMatchSnapshot();
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+  });
 });

--- a/test/__snapshots__/LsCommand.js.snap
+++ b/test/__snapshots__/LsCommand.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LsCommand in a Yarn workspace should use package.json/workspaces setting 1`] = `
+Array [
+  "package-1 v1.0.0 
+package-2 v1.0.0 ",
+]
+`;
+
 exports[`LsCommand in a basic repo does not list changes for ignored packages 1`] = `
 Array [
   "package-1 v1.0.0 ",

--- a/test/fixtures/BootstrapCommand/yarn-workspaces/.yarnrc
+++ b/test/fixtures/BootstrapCommand/yarn-workspaces/.yarnrc
@@ -1,0 +1,1 @@
+workspaces-experimental true

--- a/test/fixtures/BootstrapCommand/yarn-workspaces/lerna.json
+++ b/test/fixtures/BootstrapCommand/yarn-workspaces/lerna.json
@@ -2,5 +2,5 @@
   "lerna": "__TEST_VERSION__",
   "version": "1.0.0",
   "npmClient": "yarn",
-  "yarnWorkspaces": ["bootstrap"]
+  "useWorkspaces": true
 }

--- a/test/fixtures/BootstrapCommand/yarn-workspaces/lerna.json
+++ b/test/fixtures/BootstrapCommand/yarn-workspaces/lerna.json
@@ -1,0 +1,6 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "npmClient": "yarn",
+  "yarnWorkspaces": ["bootstrap"]
+}

--- a/test/fixtures/BootstrapCommand/yarn-workspaces/package.json
+++ b/test/fixtures/BootstrapCommand/yarn-workspaces/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "root",
+  "private": true,
+  "workspaces": [
+    "workspaces/*"
+  ]
+}

--- a/test/fixtures/BootstrapCommand/yarn-workspaces/workspaces/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/yarn-workspaces/workspaces/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "foo": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/yarn-workspaces/workspaces/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/yarn-workspaces/workspaces/package-2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/test/fixtures/LsCommand/yarn-workspaces/.yarnrc
+++ b/test/fixtures/LsCommand/yarn-workspaces/.yarnrc
@@ -1,0 +1,1 @@
+workspaces-experimental true

--- a/test/fixtures/LsCommand/yarn-workspaces/lerna.json
+++ b/test/fixtures/LsCommand/yarn-workspaces/lerna.json
@@ -2,5 +2,5 @@
   "lerna": "__TEST_VERSION__",
   "version": "1.0.0",
   "npmClient": "yarn",
-  "yarnWorkspaces": ["bootstrap"]
+  "useWorkspaces": true
 }

--- a/test/fixtures/LsCommand/yarn-workspaces/lerna.json
+++ b/test/fixtures/LsCommand/yarn-workspaces/lerna.json
@@ -1,0 +1,6 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "npmClient": "yarn",
+  "yarnWorkspaces": ["bootstrap"]
+}

--- a/test/fixtures/LsCommand/yarn-workspaces/package.json
+++ b/test/fixtures/LsCommand/yarn-workspaces/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "root",
+  "private": true,
+  "workspaces": [
+    "workspaces/*"
+  ]
+}

--- a/test/fixtures/LsCommand/yarn-workspaces/workspaces/package-1/package.json
+++ b/test/fixtures/LsCommand/yarn-workspaces/workspaces/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "foo": "^1.0.0"
+  }
+}

--- a/test/fixtures/LsCommand/yarn-workspaces/workspaces/package-2/package.json
+++ b/test/fixtures/LsCommand/yarn-workspaces/workspaces/package-2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}


### PR DESCRIPTION


## Description + Motivation and Context

Yarn has a Workspaces feature that implements Lerna's bootstrap logic in a nice "more atomic" and more native from a package manager point of view way.
The progress and all the links to the feature is here https://github.com/yarnpkg/yarn/issues/3294.

Workspaces are still considered "experimental" but we are moving forward and are ready to turn it on for a couple of projects, e.g. https://github.com/facebook/jest/pull/3906.

This PR integrates Yarn workspaces with Lerna by replacing all the bootstrap/hoisting logic with a simple call to `yarn install`.
Also it makes Lerna use package.json/workspaces field as Yarn does.

## How Has This Been Tested?

1. Manual:

- update to Yarn 0.27.2
- checkout jest with this PR https://github.com/facebook/jest/pull/3906
- run `../lerna/bin/lerna.js bootstrap`
- verify that workspace symlinks were installed in jest/node_modules
- verify that unhoistable dependencies got installed in workspaces (jest/packages/jest-runtime/node_modules/strip-bom)
- run yarn test-ci

+ added integration test

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
