### PR TITLE
[Feature] Support <folder> option on npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,8 @@ Running `lerna` without arguments will show all commands/options.
       "ignore": "component-*"
     }
   },
-  "packages": ["packages/*"]
+  "packages": ["packages/*"],
+  "publishDir": "lib/"
 }
 ```
 
@@ -604,6 +605,7 @@ Running `lerna` without arguments will show all commands/options.
 - `commands.bootstrap.ignore`: an array of globs that won't be bootstrapped when running the `lerna bootstrap` command.
 - `commands.bootstrap.scope`: an array of globs that restricts which packages will be bootstrapped when running the `lerna bootstrap` command.
 - `packages`: Array of globs to use as package locations.
+- `publishDir`: Relative path in each package that [`npm publish`](https://docs.npmjs.com/cli/publish) will run in. This folder must contain a `package.json`.
 
 
 ### Common `devDependencies`

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -125,11 +125,11 @@ export default class NpmUtilities {
     );
   }
 
-  static publishTaggedInDir(tag, directory, registry, callback) {
+  static publishTaggedInDir(tag, directory, registry, publishDir = ".", callback) {
     log.silly("publishTaggedInDir", tag, path.basename(directory));
 
     const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.exec("npm", ["publish", "--tag", tag.trim()], opts, callback);
+    ChildProcessUtilities.exec("npm", ["publish", publishDir,  "--tag", tag.trim()], opts, callback);
   }
 
   static getExecOpts(directory, registry) {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -520,31 +520,32 @@ export default class PublishCommand extends Command {
       const run = (cb) => {
         tracker.verbose("publishing", pkg.name);
 
-        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmRegistry, (err) => {
-          err = err && err.stack || err;
+        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmRegistry, this.options.publishDir,
+          (err) => {
+            err = err && err.stack || err;
 
-          if (!err ||
-            // publishing over an existing package which is likely due to a timeout or something
-            err.indexOf("You cannot publish over the previously published version") > -1
-          ) {
-            tracker.info("published", pkg.name);
-            tracker.completeWork(1);
-            this.execScript(pkg, "postpublish");
-            cb();
-            return;
-          }
+            if (!err ||
+              // publishing over an existing package which is likely due to a timeout or something
+              err.indexOf("You cannot publish over the previously published version") > -1
+            ) {
+              tracker.info("published", pkg.name);
+              tracker.completeWork(1);
+              this.execScript(pkg, "postpublish");
+              cb();
+              return;
+            }
 
-          attempts++;
+            attempts++;
 
-          if (attempts < 5) {
-            this.logger.error("publish", "Retrying failed publish:", pkg.name);
-            this.logger.verbose("publish error", err);
-            run(cb);
-          } else {
-            this.logger.error("publish", "Ran out of retries while publishing", pkg.name, err);
-            cb(err);
-          }
-        });
+            if (attempts < 5) {
+              this.logger.error("publish", "Retrying failed publish:", pkg.name);
+              this.logger.verbose("publish error", err);
+              run(cb);
+            } else {
+              this.logger.error("publish", "Ran out of retries while publishing", pkg.name, err);
+              cb(err);
+            }
+          });
       };
 
       return run;

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -173,10 +173,10 @@ describe("NpmUtilities", () => {
     afterEach(resetExecOpts);
 
     it("runs npm publish in a directory with --tag support", () => {
-      NpmUtilities.publishTaggedInDir("published-tag", directory, undefined, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, undefined, undefined, callback);
 
       const cmd = "npm";
-      const args = ["publish", "--tag", "published-tag"];
+      const args = ["publish", ".", "--tag", "published-tag"];
       const opts = { directory, registry: undefined };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
     });
@@ -184,17 +184,27 @@ describe("NpmUtilities", () => {
     it("trims trailing whitespace in tag parameter", () => {
       NpmUtilities.publishTaggedInDir("trailing-tag  ", directory, callback);
 
-      const actualtag = ChildProcessUtilities.exec.mock.calls[0][1][2];
+      const actualtag = ChildProcessUtilities.exec.mock.calls[0][1][3];
       expect(actualtag).toBe("trailing-tag");
     });
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/publishTaggedInDir";
-      NpmUtilities.publishTaggedInDir("published-tag", directory, registry, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, registry, undefined, callback);
 
       const cmd = "npm";
-      const args = ["publish", "--tag", "published-tag"];
+      const args = ["publish", ".", "--tag", "published-tag"];
       const opts = { directory, registry };
+      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
+    });
+
+    it("publishes a folder", () => {
+      const publishDir = "lib";
+      NpmUtilities.publishTaggedInDir("published-tag", directory, undefined, publishDir, callback);
+
+      const cmd = "npm";
+      const args = ["publish", "lib", "--tag", "published-tag"];
+      const opts = { directory };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously listed as wont fix in #91, but the npm command allows publishing from a specific directory which allows easier organisation for 'flat' module structures.
So this PR exposes the folder option to align with [npm publish](https://docs.npmjs.com/cli/publish) options.

This change is non-breaking.

Unsure if this aligns with how the maintainers want to proceed with this tool, thought this would be a good starting point.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Align with npm options, simplify package structures.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally through npm link in another lerna repo. Appropriate errors are thrown if `publishDir` doesnt contain a package.json, won't fail silently.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
