### PR TITLE
feat(canary): Improved canary option functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ $ lerna publish --canary
 $ lerna publish --canary=beta
 ```
 
-When run with this flag, `publish` publishes packages in a more granular way (per commit). Before publishing to npm, it creates the new `version` tag by taking the current `version`, bumping it to the next /minor/ version, adding the provided meta suffix (defaults to `alpha`) and appending the current git sha (ex: `1.0.0-alpha.81e3b443`, `1.0.0-beta.81e3b443`).
+When run with this flag, `publish` publishes packages in a more granular way (per commit). Before publishing to npm, it creates the new `version` tag by taking the current `version`, bumping it to the next *minor* version, adding the provided meta suffix (defaults to `alpha`) and appending the current git sha (ex: `1.0.0` becomes `1.1.0-alpha.81e3b443`).
 
 > The intended use case for this flag is a per commit level release or nightly release.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Independent mode allows you to more specifically update versions for each packag
 
 ## Troubleshooting
 
-If you encounter any issues while using Lerna please check out our [Troubleshooting](doc/troubleshooting.md) 
+If you encounter any issues while using Lerna please check out our [Troubleshooting](doc/troubleshooting.md)
 document where you might find the answer to your problem.
 
 ## Frequently asked questions
@@ -199,7 +199,7 @@ When run, this command will:
 2. Symlink together all Lerna `packages` that are dependencies of each other.
 3. `npm prepublish` all bootstrapped packages.
 
-`lerna bootstrap` respects the `--ignore`, `--scope` and `--include-filtered-dependencies` flags (see [Flags](#flags)). 
+`lerna bootstrap` respects the `--ignore`, `--scope` and `--include-filtered-dependencies` flags (see [Flags](#flags)).
 
 Pass extra arguments to npm client by placing them after `--`:
 
@@ -302,9 +302,10 @@ This option can be used to publish a [`prerelease`](http://carrot.is/coding/npm_
 
 ```sh
 $ lerna publish --canary
+$ lerna publish --canary=beta
 ```
 
-When run with this flag, `publish` publishes packages in a more granular way (per commit). Before publishing to npm, it creates the new `version` tag by taking the current `version` and appending the current git sha (ex: `1.0.0-alpha.81e3b443`).
+When run with this flag, `publish` publishes packages in a more granular way (per commit). Before publishing to npm, it creates the new `version` tag by taking the current `version`, bumping it to the next /minor/ version, adding the provided meta suffix (defaults to `alpha`) and appending the current git sha (ex: `1.0.0-alpha.81e3b443`, `1.0.0-beta.81e3b443`).
 
 > The intended use case for this flag is a per commit level release or nightly release.
 
@@ -554,7 +555,7 @@ You may also get the name of the current package through the environment variabl
 $ lerna exec -- npm view \$LERNA_PACKAGE_NAME
 ```
 
-You may also run a script located in the root dir, in a complicated dir structure through the environment variable `LERNA_ROOT_PATH`:  
+You may also run a script located in the root dir, in a complicated dir structure through the environment variable `LERNA_ROOT_PATH`:
 
 ```sh
 $ lerna exec -- node \$LERNA_ROOT_PATH/scripts/some-script.js
@@ -782,9 +783,9 @@ Any logs of a higher level than the setting are shown.  The default is "info".
 
 #### --max-buffer [in-bytes]
 
-Set a max buffer length for each underlying process call. Useful for example 
-when someone wants to import a repo with a larger amount of commits while 
-running `lerna import`. In that case the built-in buffer length might not 
+Set a max buffer length for each underlying process call. Useful for example
+when someone wants to import a repo with a larger amount of commits while
+running `lerna import`. In that case the built-in buffer length might not
 be sufficient.
 
 #### --no-sort
@@ -867,11 +868,11 @@ private registries.
 
 #### --temp-tag
 
-When passed, this flag will alter the default publish process by first publishing 
-all changed packages to a temporary dist-tag (`lerna-temp`) and then moving the 
+When passed, this flag will alter the default publish process by first publishing
+all changed packages to a temporary dist-tag (`lerna-temp`) and then moving the
 new version(s) to the default [dist-tag](https://docs.npmjs.com/cli/dist-tag) (`latest`).
 
-This is not generally necessary, as Lerna will publish packages in topological 
+This is not generally necessary, as Lerna will publish packages in topological
 order (all dependencies before dependents) by default.
 
 ### Wizard

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -27,7 +27,7 @@ export const describe = "Publish packages in the current project.";
 export const builder = {
   "canary": {
     group: "Command Options:",
-    defaultDescription: "canary",
+    defaultDescription: "alpha",
     describe: "Publish packages after every successful merge using the sha as part of the tag.",
     alias: "c"
   },

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -29,6 +29,10 @@ export const builder = {
     group: "Command Options:",
     describe: "Publish packages after every successful merge using the sha as part of the tag.",
     alias: "c",
+    requiresArg: false,
+    coerce: (canary) => {
+      return canary === true ? "canary" : canary;
+    }
   },
   "cd-version": {
     group: "Command Options:",
@@ -267,7 +271,7 @@ export default class PublishCommand extends Command {
 
     // Non-Independent Canary Mode
     if (!this.repository.isIndependent() && this.options.canary) {
-      const version = this.globalVersion + this.getCanaryVersionSuffix();
+      const version = this.getCanaryVersion(this.globalVersion, this.options.canary);
       callback(null, { version });
 
     // Non-Independent Non-Canary Mode
@@ -283,10 +287,12 @@ export default class PublishCommand extends Command {
     // Independent Canary Mode
     } else if (this.options.canary) {
       const versions = {};
-      const canaryVersionSuffix = this.getCanaryVersionSuffix();
 
       this.updates.forEach((update) => {
-        versions[update.package.name] = update.package.version + canaryVersionSuffix;
+        versions[update.package.name] = this.getCanaryVersion(
+          update.package.version,
+          this.options.canary
+        );
       });
 
       callback(null, { versions });
@@ -321,8 +327,10 @@ export default class PublishCommand extends Command {
     }
   }
 
-  getCanaryVersionSuffix() {
-    return "-alpha." + GitUtilities.getCurrentSHA(this.execOpts).slice(0, 8);
+  getCanaryVersion(version, metaName) {
+    const minor = semver.inc(version, "minor");
+    const hash = GitUtilities.getCurrentSHA(this.execOpts).slice(0, 8);
+    return `${minor}-${metaName}.${hash}`;
   }
 
   promptVersion(packageName, currentVersion, callback) {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -27,6 +27,7 @@ export const describe = "Publish packages in the current project.";
 export const builder = {
   "canary": {
     group: "Command Options:",
+    defaultDescription: "canary",
     describe: "Publish packages after every successful merge using the sha as part of the tag.",
     alias: "c"
   },

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -28,11 +28,7 @@ export const builder = {
   "canary": {
     group: "Command Options:",
     describe: "Publish packages after every successful merge using the sha as part of the tag.",
-    alias: "c",
-    requiresArg: false,
-    coerce: (canary) => {
-      return canary === true ? "canary" : canary;
-    }
+    alias: "c"
   },
   "cd-version": {
     group: "Command Options:",
@@ -328,6 +324,10 @@ export default class PublishCommand extends Command {
   }
 
   getCanaryVersion(version, metaName) {
+    if (metaName == null || typeof metaName !== "string") {
+      metaName = "alpha";
+    }
+
     const minor = semver.inc(version, "minor");
     const hash = GitUtilities.getCurrentSHA(this.execOpts).slice(0, 8);
     return `${minor}-${metaName}.${hash}`;

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -288,10 +288,10 @@ describe("PublishCommand", () => {
           expect(updatedPackageVersions(testDir)).toMatchSnapshot("[normal --canary] bumps package versions");
 
           expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
-            "package-1": "^1.0.0-alpha.deadbeef",
+            "package-1": "^1.1.0-alpha.deadbeef",
           });
           expect(updatedPackageJSON("package-3").devDependencies).toMatchObject({
-            "package-2": "^1.0.0-alpha.deadbeef",
+            "package-2": "^1.1.0-alpha.deadbeef",
           });
           expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
             "package-1": "^0.0.0",
@@ -305,6 +305,42 @@ describe("PublishCommand", () => {
           expect(GitUtilities.pushWithTags).not.toBeCalled();
           expect(publishedTagInDirectories(testDir))
             .toMatchSnapshot("[normal --canary] npm publish --tag");
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+
+    it("should use the provided value as the meta suffix", (done) => {
+      const publishCommand = new PublishCommand([], {
+        canary: "beta"
+      }, testDir);
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      publishCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          if (pathExists.sync(path.join(testDir, "lerna-debug.log"))) {
+            // TODO: there has to be a better way to do this
+            throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
+          }
+
+          expect(updatedPackageVersions(testDir)).toMatchSnapshot("[normal --canary] bumps package versions");
+
+          expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
+            "package-1": "^1.1.0-beta.deadbeef",
+          });
+          expect(updatedPackageJSON("package-3").devDependencies).toMatchObject({
+            "package-2": "^1.1.0-beta.deadbeef",
+          });
+          expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
+            "package-1": "^0.0.0",
+          });
 
           done();
         } catch (ex) {
@@ -350,10 +386,10 @@ describe("PublishCommand", () => {
             .toMatchSnapshot("[independent --canary] bumps package versions");
 
           expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
-            "package-1": "^1.0.0-alpha.deadbeef",
+            "package-1": "^1.1.0-alpha.deadbeef",
           });
           expect(updatedPackageJSON("package-3").devDependencies).toMatchObject({
-            "package-2": "^2.0.0-alpha.deadbeef",
+            "package-2": "^2.1.0-alpha.deadbeef",
           });
           expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
             "package-1": "^0.0.0",
@@ -361,6 +397,41 @@ describe("PublishCommand", () => {
 
           expect(publishedTagInDirectories(testDir))
             .toMatchSnapshot("[independent --canary] npm publish --tag");
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+
+    it("should use the provided value as the meta suffix", (done) => {
+      const publishCommand = new PublishCommand([], {
+        independent: true,
+        canary: "beta"
+      }, testDir);
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      publishCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          if (pathExists.sync(path.join(testDir, "lerna-debug.log"))) {
+            // TODO: there has to be a better way to do this
+            throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
+          }
+
+          expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
+            "package-1": "^1.1.0-beta.deadbeef",
+          });
+          expect(updatedPackageJSON("package-3").devDependencies).toMatchObject({
+            "package-2": "^2.1.0-beta.deadbeef",
+          });
+          expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
+            "package-1": "^0.0.0",
+          });
 
           done();
         } catch (ex) {

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -23,11 +23,11 @@ Array [
 
 exports[`[independent --canary] bumps package versions 1`] = `
 Object {
-  "packages/package-1": "1.0.0-alpha.deadbeef",
-  "packages/package-2": "2.0.0-alpha.deadbeef",
-  "packages/package-3": "3.0.0-alpha.deadbeef",
-  "packages/package-4": "4.0.0-alpha.deadbeef",
-  "packages/package-5": "5.0.0-alpha.deadbeef",
+  "packages/package-1": "1.1.0-alpha.deadbeef",
+  "packages/package-2": "2.1.0-alpha.deadbeef",
+  "packages/package-3": "3.1.0-alpha.deadbeef",
+  "packages/package-4": "4.1.0-alpha.deadbeef",
+  "packages/package-5": "5.1.0-alpha.deadbeef",
 }
 `;
 
@@ -178,11 +178,21 @@ Array [
 
 exports[`[normal --canary] bumps package versions 1`] = `
 Object {
-  "packages/package-1": "1.0.0-alpha.deadbeef",
-  "packages/package-2": "1.0.0-alpha.deadbeef",
-  "packages/package-3": "1.0.0-alpha.deadbeef",
-  "packages/package-4": "1.0.0-alpha.deadbeef",
-  "packages/package-5": "1.0.0-alpha.deadbeef",
+  "packages/package-1": "1.1.0-alpha.deadbeef",
+  "packages/package-2": "1.1.0-alpha.deadbeef",
+  "packages/package-3": "1.1.0-alpha.deadbeef",
+  "packages/package-4": "1.1.0-alpha.deadbeef",
+  "packages/package-5": "1.1.0-alpha.deadbeef",
+}
+`;
+
+exports[`[normal --canary] bumps package versions 2`] = `
+Object {
+  "packages/package-1": "1.1.0-beta.deadbeef",
+  "packages/package-2": "1.1.0-beta.deadbeef",
+  "packages/package-3": "1.1.0-beta.deadbeef",
+  "packages/package-4": "1.1.0-beta.deadbeef",
+  "packages/package-5": "1.1.0-beta.deadbeef",
 }
 `;
 


### PR DESCRIPTION
## Description

This change changes the `canary` semantics and bumps the minor version, as well as overloading it allowing the user to pass a value that will be used for the meta suffix instead i.e. `--canary=beta`, which results in a `x.x.x-beta.<sha>` version tag.

This is especially useful in CI scenarios where you want to publish an `alpha`, `beta`, and/or `rc` version depending on the branch you're building i.e. `1.1.0-beta.e5fg52` for the `develop` branch.

BREAKING CHANGE: Now bumps to the next `minor` version instead of using current version, as per `GitVersion` and other such tools. This prevents issues the alphabetical ordering outlined in #277 

## Motivation and Context
Currently the `canary` option has a few limitations:
* Hard codes an `alpha` meta suffix on the resulting version
* Uses the current version, not the next minor version which causes [issues (#277)](https://github.com/lerna/lerna/issues/277)

## How Has This Been Tested?
Locally tested, functions as it did if no value is passed to the `canary` operator, except for the minor version bump as explained above

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
