### PR TITLE
Add `--semver-ignore` option to Bootstrap Command

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -37,6 +37,11 @@ export const builder = {
     describe: "Executable used to install dependencies (npm, yarn, pnpm, ...)",
     type: "string",
     requiresArg: true,
+  },
+  "semver-ignore": {
+    group: "Command Options:",
+    describe: "Ignore semver when determining whether to link or install from registry)",
+    type: "boolean",
   }
 };
 
@@ -525,6 +530,7 @@ export default class BootstrapCommand extends Command {
     tracker.addWork(this.filteredPackages.length);
 
     const actions = [];
+    const { semverIgnore } = this.options;
 
     this.filteredPackages.forEach((filteredPackage) => {
       // actions to run for this package
@@ -532,9 +538,12 @@ export default class BootstrapCommand extends Command {
 
       Object.keys(filteredPackage.allDependencies)
         .filter((dependency) => {
-          // filter out external dependencies and incompatible packages
+          // filter out external dependencies
           const match = this.packageGraph.get(dependency);
-          return match && filteredPackage.hasMatchingDependency(match.package);
+          // filter out incompatible packages
+          const hasMatchingDependency = match && filteredPackage.hasMatchingDependency(match.package);
+          // compatibility only matters when semverIgnore is false (default)
+          return match && (semverIgnore || hasMatchingDependency);
         })
         .forEach((dependency) => {
           // get Package of dependency

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -538,6 +538,55 @@ describe("BootstrapCommand", () => {
     });
   });
 
+  describe("mismatching version numbers", () => {
+    let testDir;
+
+    beforeEach(() => initFixture("BootstrapCommand/version-mismatch").then((dir) => {
+      testDir = dir;
+    }));
+    beforeEach(stubSymlink);
+    afterEach(resetSymlink);
+
+    it("should link when option.semverIgnore is true", (done) => {
+      const bootstrapCommand = new BootstrapCommand([], { semverIgnore: true }, testDir);
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      bootstrapCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(installedPackagesInDirectories(testDir)).toMatchSnapshot();
+          expect(symlinkedDirectories(testDir)).toMatchSnapshot();
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+    it("should link when option.semverIgnore is false", (done) => {
+      const bootstrapCommand = new BootstrapCommand([], { semverIgnore: false }, testDir);
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      bootstrapCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(installedPackagesInDirectories(testDir)).toMatchSnapshot();
+          expect(symlinkedDirectories(testDir)).toMatchSnapshot();
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+  });
+
   describe("zero packages", () => {
     let testDir;
 

--- a/test/__snapshots__/BootstrapCommand.js.snap
+++ b/test/__snapshots__/BootstrapCommand.js.snap
@@ -14,6 +14,42 @@ Object {
 }
 `;
 
+exports[`BootstrapCommand mismatching version numbers should link when option.semverIgnore is false 1`] = `
+Object {
+  "packages/package-1": Array [
+    "external@^1.0.0",
+  ],
+  "packages/package-2": Array [
+    "external@^2.0.0",
+    "package-1@^1.0.0",
+  ],
+}
+`;
+
+exports[`BootstrapCommand mismatching version numbers should link when option.semverIgnore is false 2`] = `Array []`;
+
+exports[`BootstrapCommand mismatching version numbers should link when option.semverIgnore is true 1`] = `
+Object {
+  "packages/package-1": Array [
+    "external@^1.0.0",
+  ],
+  "packages/package-2": Array [
+    "external@^2.0.0",
+    "package-1@^1.0.0",
+  ],
+}
+`;
+
+exports[`BootstrapCommand mismatching version numbers should link when option.semverIgnore is true 2`] = `
+Array [
+  Object {
+    "_src": "packages/package-1",
+    "dest": "packages/package-2/node_modules/package-1",
+    "type": "junction",
+  },
+]
+`;
+
 exports[`BootstrapCommand with at least one external dependency to install should install all dependencies 1`] = `
 Object {
   "packages/package-1": Array [

--- a/test/fixtures/BootstrapCommand/version-mismatch/lerna.json
+++ b/test/fixtures/BootstrapCommand/version-mismatch/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/version-mismatch/package.json
+++ b/test/fixtures/BootstrapCommand/version-mismatch/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/version-mismatch/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/version-mismatch/packages/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "1.0.0-alpha.0",
+  "dependencies": {
+    "external": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/version-mismatch/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/version-mismatch/packages/package-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0",
+    "external": "^2.0.0"
+  }
+}


### PR DESCRIPTION
I added an option to the BootstrapCommand: `--semver-ignore` (open to other names suggestions).

## Description
The new option tweaks the functionality of `symlinkPackages`.
The current behavior is packages that are known by name, but mismatch according to semver are installed from registry, and **not** linked.
This behavior is the default.
I added an optional boolean option to link known packages regardless of semver compatibility.

## Motivation and Context
I've tried to show my case well in the unittest provided in the PR, so have a look at that when this makes little sense to you:
It's common to make alpha / beta / next releases (prereleases). I ran into the problem that unknowingly packages were **not** linked when I expected them to. I traced the reason to version numbers like these: `3.2.0-alpha.7`.
The solution is to change the versionnumbers in the consuming packages to match exactly, but this is very cumbersome.

Furthermore I have never wanted once to **not** link known packages. I'd rather have them linked anyway and get a warning. (this is not implemented in this PR).

## How Has This Been Tested?
1. I changed lerna source directly in a project that already used lerna.
2. I added unit tests and they pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I will update my PR with documentation changes *after* I get feedback on whether the feature is likely to get merged.

2 tests seem to be skipped, but this is not in the testfile I worked on? I'm guessing this is known and not related to my PR.
