### PR TITLE
Fix unit tests failures on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "normalize-newline": "^3.0.0",
     "normalize-path": "^2.1.1",
     "replacestream": "^4.0.2",
-    "tempy": "^0.1.0"
+    "tempy": "^0.1.0",
+    "touch": "^3.1.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/test/Command.js
+++ b/test/Command.js
@@ -1,4 +1,6 @@
 import log from "npmlog";
+import touch from "touch";
+import path from "path";
 
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import FileSystemUtilities from "../src/FileSystemUtilities";
@@ -187,6 +189,9 @@ describe("Command", () => {
       class TestCommand extends Command {}
 
       function cli(cmd, ...args) {
+        if (cmd === "touch") {
+          return touch.sync(path.join(testDir, args[0]));
+        }
         return execa.sync(cmd, args, { cwd: testDir }).stdout.toString("utf-8");
       }
 

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -3,6 +3,7 @@ import execa from "execa";
 import log from "npmlog";
 import normalizeNewline from "normalize-newline";
 import path from "path";
+import touch from "touch";
 
 // mocked or stubbed modules
 import output from "../src/utils/output";
@@ -31,7 +32,7 @@ const gitTag = (opts) => execa.sync("git", ["tag", "v1.0.0"], opts);
 const gitAdd = (opts) => execa.sync("git", ["add", "-A"], opts);
 const gitCommit = (opts) => execa.sync("git", ["commit", "-m", "Commit"], opts);
 const touchFile = (opts) => (filePath) =>
-    execa.sync("touch", [path.join(opts.cwd, filePath)], opts);
+    touch.sync(path.join(opts.cwd, filePath));
 
 const setupGitChanges = (testDir, filePaths) => {
   const opts = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2827,6 +2827,12 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
+
 nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -3724,6 +3730,12 @@ tmpl@1.0.x:
 to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
+
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  dependencies:
+    nopt "~1.0.10"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed unit test failures on Windows by replacing native touch commands with a node touch implementation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The unit tests that invoke the touch command fail on Windows, as Windows does not have a native touch command. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`npm run test` on Windows 10

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
