### PR TITLE
Support --conventional-commits in fixed versioning mode

### DIFF
--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -81,7 +81,18 @@ export default class ConventionalCommitUtilities {
     }
 
     // run conventional-changelog-cli to generate the markdown for the upcoming release.
-    const newEntry = ChildProcessUtilities.execSync(process.execPath, args, opts);
+    let newEntry = ChildProcessUtilities.execSync(process.execPath, args, opts);
+
+    // When force publishing, it is possible that there will be no actual changes, only a version bump.
+    // Add a note to indicate that only a version bump has occurred.
+    if (!newEntry.split("\n").some((line) => line.startsWith("*"))) {
+      newEntry =  dedent(
+        `
+        ${newEntry}
+        
+        **Note:** Version bump only for package ${pkg.name} 
+        `);
+    }
 
     log.silly("updateIndependentChangelog", "writing new entry: %j", newEntry);
 

--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -18,28 +18,61 @@ const RECOMMEND_CLI = require.resolve("conventional-recommended-bump/cli");
 const CHANGELOG_CLI = require.resolve("conventional-changelog-cli/cli");
 
 export default class ConventionalCommitUtilities {
-  static recommendVersion(pkg, opts) {
-    log.silly("recommendVersion", "for %s at %s", pkg.name, pkg.location);
+  static recommendIndependentVersion(pkg, opts) {
+    const args = [
+      RECOMMEND_CLI,
+      "-l", pkg.name,
+      "--commit-path", pkg.location,
+      "-p", "angular",
+    ];
+    return ConventionalCommitUtilities.recommendVersion(pkg, opts, "recommendIndependentVersion", args);
+  }
 
-    const recommendedBump = ChildProcessUtilities.execSync(
-      process.execPath,
-      [
-        RECOMMEND_CLI,
-        "-l", pkg.name,
-        "--commit-path", pkg.location,
-        "-p", "angular",
-      ],
-      opts
-    );
+  static recommendFixedVersion(pkg, opts) {
+    const args = [
+      RECOMMEND_CLI,
+      "--commit-path", pkg.location,
+      "-p", "angular",
+    ];
+    return ConventionalCommitUtilities.recommendVersion(pkg, opts, "recommendFixedVersion", args);
+  }
 
-    log.verbose("recommendVersion", "increment %s by %s", pkg.version, recommendedBump);
+  static recommendVersion(pkg, opts, type, args) {
+    log.silly(type, "for %s at %s", pkg.name, pkg.location);
+
+    const recommendedBump = ChildProcessUtilities.execSync(process.execPath, args, opts);
+
+    log.verbose(type, "increment %s by %s", pkg.version, recommendedBump);
     return semver.inc(pkg.version, recommendedBump);
   }
 
-  static updateChangelog(pkg, opts) {
-    log.silly("updateChangelog", "for %s at %s", pkg.name, pkg.location);
-
+  static updateIndependentChangelog(pkg, opts) {
     const pkgJsonLocation = path.join(pkg.location, "package.json");
+    const args = [
+      CHANGELOG_CLI,
+      "-l", pkg.name,
+      "--commit-path", pkg.location,
+      "--pkg", pkgJsonLocation,
+      "-p", "angular",
+    ];
+    ConventionalCommitUtilities.updateChangelog(pkg, opts, "updateIndependentChangelog", args);
+  }
+
+  static updateFixedChangelog(pkg, opts) {
+    const pkgJsonLocation = path.join(pkg.location, "package.json");
+    const args = [
+      CHANGELOG_CLI,
+      "--commit-path", pkg.location,
+      "--pkg", pkgJsonLocation,
+      "-p", "angular",
+    ];
+    ConventionalCommitUtilities.updateChangelog(pkg, opts, "updateFixedChangelog", args);
+  }
+
+  static updateChangelog(pkg, opts, type, args) {
+    log.silly(type, "for %s at %s", pkg.name, pkg.location);
+
+
     const changelogLocation = ConventionalCommitUtilities.changelogLocation(pkg);
 
     let changelogContents = "";
@@ -47,33 +80,21 @@ export default class ConventionalCommitUtilities {
       changelogContents = FileSystemUtilities.readFileSync(changelogLocation);
     }
 
-    // run conventional-changelog-cli to generate the markdown
-    // for the upcoming release.
-    const newEntry = ChildProcessUtilities.execSync(
-      process.execPath,
-      [
-        CHANGELOG_CLI,
-        "-l", pkg.name,
-        "--commit-path", pkg.location,
-        "--pkg", pkgJsonLocation,
-        "-p", "angular",
-      ],
-      opts
-    );
+    // run conventional-changelog-cli to generate the markdown for the upcoming release.
+    const newEntry = ChildProcessUtilities.execSync(process.execPath, args, opts);
 
-    log.silly("updateChangelog", "writing new entry: %j", newEntry);
+    log.silly("updateIndependentChangelog", "writing new entry: %j", newEntry);
 
     // CHANGELOG entries start with <a name=, we remove
     // the header if it exists by starting at the first entry.
     if (changelogContents.indexOf("<a name=") !== -1) {
-      changelogContents = changelogContents.substring(
-        changelogContents.indexOf("<a name=")
+      changelogContents = changelogContents.substring(changelogContents.indexOf("<a name=")
       );
     }
 
     FileSystemUtilities.writeFileSync(
       changelogLocation,
-       // only allow 1 \n at end of content.
+      // only allow 1 \n at end of content.
       dedent(
         `${CHANGELOG_HEADER}
 
@@ -82,7 +103,7 @@ export default class ConventionalCommitUtilities {
         ${changelogContents}`.replace(/\n+$/, "\n"))
     );
 
-    log.verbose("updateChangelog", "wrote", changelogLocation);
+    log.verbose(type, "wrote", changelogLocation);
   }
 
   static changelogLocation(pkg) {

--- a/test/ConventionalCommitUtilities.js
+++ b/test/ConventionalCommitUtilities.js
@@ -23,23 +23,21 @@ describe("ConventionalCommitUtilities", () => {
 
       const opts = { cwd: "test" };
 
+      const args = [
+        require.resolve("conventional-recommended-bump/cli"),
+        "-l", "bar",
+        "--commit-path", "/foo/bar",
+        "-p", "angular",
+      ];
+
       const recommendVersion = ConventionalCommitUtilities.recommendVersion({
         name: "bar",
         version: "1.0.0",
         location: "/foo/bar",
-      }, opts);
+      }, opts, "", args);
 
       expect(recommendVersion).toBe("2.0.0");
-      expect(ChildProcessUtilities.execSync).lastCalledWith(
-        process.execPath,
-        [
-          require.resolve("conventional-recommended-bump/cli"),
-          "-l", "bar",
-          "--commit-path", "/foo/bar",
-          "-p", "angular",
-        ],
-        opts,
-      );
+      expect(ChildProcessUtilities.execSync).lastCalledWith(process.execPath, args, opts);
     });
   });
 
@@ -50,25 +48,21 @@ describe("ConventionalCommitUtilities", () => {
 
       const opts = { cwd: "test" };
 
+      const args = [
+        require.resolve("conventional-changelog-cli/cli"),
+        "-l", "bar",
+        "--commit-path", "/foo/bar",
+        "--pkg", path.normalize("/foo/bar/package.json"),
+        "-p", "angular",
+      ];
+
       ConventionalCommitUtilities.updateChangelog({
         name: "bar",
         location: "/foo/bar"
-      }, opts);
+      }, opts, "", args);
 
-      expect(FileSystemUtilities.existsSync).lastCalledWith(
-        path.normalize("/foo/bar/CHANGELOG.md")
-      );
-      expect(ChildProcessUtilities.execSync).lastCalledWith(
-        process.execPath,
-        [
-          require.resolve("conventional-changelog-cli/cli"),
-          "-l", "bar",
-          "--commit-path", "/foo/bar",
-          "--pkg", path.normalize("/foo/bar/package.json"),
-          "-p", "angular",
-        ],
-        opts,
-      );
+      expect(FileSystemUtilities.existsSync).lastCalledWith(path.normalize("/foo/bar/CHANGELOG.md"));
+      expect(ChildProcessUtilities.execSync).lastCalledWith(process.execPath, args, opts);
       expect(FileSystemUtilities.writeFileSync).lastCalledWith(
         path.normalize("/foo/bar/CHANGELOG.md"),
         dedent`

--- a/test/ConventionalCommitUtilities.js
+++ b/test/ConventionalCommitUtilities.js
@@ -44,7 +44,11 @@ describe("ConventionalCommitUtilities", () => {
   describe(".updateChangelog()", () => {
     it("should populate initial CHANGELOG.md if it does not exist", () => {
       FileSystemUtilities.existsSync = jest.fn(() => false);
-      ChildProcessUtilities.execSync = jest.fn(() => "<a name='change' />feat: I should be placed in the CHANGELOG");
+      ChildProcessUtilities.execSync = jest.fn(() => dedent`<a name="1.0.0"></a>
+
+                                                            ### Features
+                                                            
+                                                            * feat: I should be placed in the CHANGELOG`);
 
       const opts = { cwd: "test" };
 
@@ -71,21 +75,34 @@ describe("ConventionalCommitUtilities", () => {
           All notable changes to this project will be documented in this file.
           See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-          <a name='change' />feat: I should be placed in the CHANGELOG
-        `
-      );
+          <a name="1.0.0"></a>
+
+          ### Features
+
+          * feat: I should be placed in the CHANGELOG`);
     });
 
     it("should insert into existing CHANGELOG.md", () => {
       FileSystemUtilities.existsSync = jest.fn(() => true);
-      ChildProcessUtilities.execSync = jest.fn(() => "<a name='change2' />fix: a second commit for our CHANGELOG");
+      ChildProcessUtilities.execSync = jest.fn(() => dedent`<a name='change2' /></a>
+                                                            ## 1.0.1 (2017-08-11)(/compare/v1.0.1...v1.0.0) (2017-08-09)
+                                                            
+
+                                                            ### Bug Fixes
+                                                            
+                                                            * fix: a second commit for our CHANGELOG`);
+
       FileSystemUtilities.readFileSync = jest.fn(() => dedent`
         # Change Log
 
         All notable changes to this project will be documented in this file.
         See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-        <a name='change' />feat: I should be placed in the CHANGELOG
+        <a name="1.0.0"></a>
+
+        ### Features
+
+        * feat: I should be placed in the CHANGELOG
       `);
 
       ConventionalCommitUtilities.updateChangelog({
@@ -101,9 +118,63 @@ describe("ConventionalCommitUtilities", () => {
           All notable changes to this project will be documented in this file.
           See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-          <a name='change2' />fix: a second commit for our CHANGELOG
+          <a name='change2' /></a>
+          ## 1.0.1 (2017-08-11)(/compare/v1.0.1...v1.0.0) (2017-08-09)
+          
 
-          <a name='change' />feat: I should be placed in the CHANGELOG
+          ### Bug Fixes
+
+          * fix: a second commit for our CHANGELOG
+
+          <a name="1.0.0"></a>
+
+          ### Features
+
+          * feat: I should be placed in the CHANGELOG
+        `
+      );
+    });
+
+    it("should insert version bump message if no commits have been recorded", () => {
+      FileSystemUtilities.existsSync = jest.fn(() => true);
+      ChildProcessUtilities.execSync = jest.fn(() => dedent`<a name="1.0.1"></a>
+                                                            ## 1.0.1 (2017-08-11)(/compare/v1.0.1...v1.0.0) (2017-08-09)`);
+      FileSystemUtilities.readFileSync = jest.fn(() => dedent`
+        # Change Log
+
+        All notable changes to this project will be documented in this file.
+        See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+        <a name="1.0.0"></a>
+
+        ### Features
+
+        * add a feature aaa1111
+      `);
+
+      ConventionalCommitUtilities.updateChangelog({
+        name: "bar",
+        location: "/foo/bar/",
+      });
+
+      expect(FileSystemUtilities.writeFileSync).lastCalledWith(
+        path.normalize("/foo/bar/CHANGELOG.md"),
+        dedent`
+          # Change Log
+
+          All notable changes to this project will be documented in this file.
+          See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+          
+          <a name="1.0.1"></a>
+          ## 1.0.1 (2017-08-11)(/compare/v1.0.1...v1.0.0) (2017-08-09)
+          
+          **Note:** Version bump only for package bar
+          
+          <a name="1.0.0"></a>
+
+          ### Features
+
+          * add a feature aaa1111
         `
       );
     });

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`[fixed --conventional-commits] git adds changed files 1`] = `
+Array [
+  "lerna.json",
+  "packages/package-1/CHANGELOG.md",
+  "packages/package-1/package.json",
+  "packages/package-2/CHANGELOG.md",
+  "packages/package-2/package.json",
+  "packages/package-3/CHANGELOG.md",
+  "packages/package-3/package.json",
+  "packages/package-4/CHANGELOG.md",
+  "packages/package-4/package.json",
+  "packages/package-5/CHANGELOG.md",
+  "packages/package-5/package.json",
+]
+`;
+
+exports[`[fixed --conventional-commits] git commit message 1`] = `"v5.1.1"`;
+
 exports[`[independent --canary --npm-tag=next --yes --exact] npm publish --tag 1`] = `
 Array [
   Object {

--- a/test/fixtures/PublishCommand/normal-exact/package.json
+++ b/test/fixtures/PublishCommand/normal-exact/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "independent"
+  "name": "normal-exact"
 }

--- a/test/fixtures/PublishCommand/normal/package.json
+++ b/test/fixtures/PublishCommand/normal/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "independent"
+  "name": "normal"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds support for --conventional-commits in fixed mode. When the --conventional-commits 
 flag is used, the highest bump from the changed packages will be used as the new version. 

Eg 
package-1 1.0.0 -> feat
package-2 1.0.0 -> fix

`lerna publish --conventional-commits`

Results in package-1 and package-2 being updated to 1.1.0 

This is accomplished by only using the `"-l", pkg.name` arguments (lerna mode) to conventional-recommended-bump/conventional-changelog-cli in independent mode. 
 
The CHANGELOG.md files for each package are also created/updated on each publish. 

The order of commands in `src/commands/PublishCommand.js` has been updated to group by option type first, then independent/fixed, which improves readability. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR allows lerna to be used to publish new versions in CI more easily in fixed mode when conventional commits are followed. With something like `lerna publish --conventional-commits --force-publish=*` it will be possible to release new versions of projects managed with lerna automatically on PR merges. 

Fixes https://github.com/lerna/lerna/issues/890 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual testing in fixed mode
- Unit tests have been updated to test new code paths

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
