### PR TITLE
Update dependency graph to support non-semver version values

### DIFF
--- a/src/PackageGraph.js
+++ b/src/PackageGraph.js
@@ -41,7 +41,7 @@ export default class PackageGraph {
         const depVersion = dependencies[depName];
         const packageNode = this.nodesByName[depName];
 
-        if (packageNode && semver.satisfies(packageNode.package.version, depVersion)) {
+        if (packageNode && (!semver.valid(depVersion) || semver.satisfies(packageNode.package.version, depVersion))) {
           node.dependencies.push(depName);
         }
       }


### PR DESCRIPTION
## Description
Support version values such as "file:...", "git:...", etc, by always pushing them into the graph

## Motivation and Context
I needed `exec` and `run` to execute in topological order with `file:...` dependency references.

## How Has This Been Tested?
Tested locally and now my tasks all run in the correct topological order.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I think this should have worked this way from the beginning.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I don't have time to write tests right now, sorry :/