### PR TITLE
Remove mention that Lerna v2 is currently in beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ The two primary commands in Lerna are `lerna bootstrap` and `lerna publish`.
 
 ## Getting Started
 
-> The instructions below are for Lerna 2.x which is currently in beta.
-> We recommend using it instead of 1.x for a new Lerna project. Check the [wiki](https://github.com/lerna/lerna/wiki/1.x-Docs) if you need to see the 1.x README.
-
 Let's start by installing Lerna globally with [npm](https://www.npmjs.com/).
 
 ```sh


### PR DESCRIPTION
It could be removed by now, thanks for creating such an useful tool.

## Description
Lerna is not in beta anymore, so no reason for mentioning that.

## Types of changes
Update the readme.

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
