### PR TITLE
Allow Scoped Modules To Be Published Publicly

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -165,11 +165,21 @@ export default class NpmUtilities {
     );
   }
 
-  static publishTaggedInDir(tag, directory, registry, callback) {
+  static publishTaggedInDir(tag, directory, registry, isPrivate, callback) {
     log.silly("publishTaggedInDir", tag, path.basename(directory));
 
     const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.exec("npm", ["publish", "--tag", tag.trim()], opts, callback);
+
+    /* lernaAccess is used when publishing a scoped module publicly.
+       It is based on the private property on package.json
+     */
+    const lernaAccess = isPrivate ? "restricted" : "public";
+
+    ChildProcessUtilities.exec("npm", [
+      "publish",
+      "--tag", tag.trim(),
+      "--access", lernaAccess
+    ], opts, callback);
   }
 
   static getExecOpts(directory, registry) {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -550,9 +550,10 @@ export default class PublishCommand extends Command {
       let attempts = 0;
 
       const run = (cb) => {
+
         tracker.verbose("publishing", pkg.name);
 
-        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmRegistry, (err) => {
+        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmRegistry, pkg.private, (err) => {
           err = err && err.stack || err;
 
           if (!err ||

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -176,7 +176,7 @@ describe("NpmUtilities", () => {
       NpmUtilities.publishTaggedInDir("published-tag", directory, undefined, callback);
 
       const cmd = "npm";
-      const args = ["publish", "--tag", "published-tag"];
+      const args = ["publish", "--tag", "published-tag", "--access", "restricted"];
       const opts = { directory, registry: undefined };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
     });
@@ -193,7 +193,7 @@ describe("NpmUtilities", () => {
       NpmUtilities.publishTaggedInDir("published-tag", directory, registry, callback);
 
       const cmd = "npm";
-      const args = ["publish", "--tag", "published-tag"];
+      const args = ["publish", "--tag", "published-tag", "--access", "restricted"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
     });

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -173,7 +173,7 @@ describe("NpmUtilities", () => {
     afterEach(resetExecOpts);
 
     it("runs npm publish in a directory with --tag support", () => {
-      NpmUtilities.publishTaggedInDir("published-tag", directory, undefined, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, undefined, true, callback);
 
       const cmd = "npm";
       const args = ["publish", "--tag", "published-tag", "--access", "restricted"];
@@ -190,7 +190,7 @@ describe("NpmUtilities", () => {
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/publishTaggedInDir";
-      NpmUtilities.publishTaggedInDir("published-tag", directory, registry, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, registry, true, callback);
 
       const cmd = "npm";
       const args = ["publish", "--tag", "published-tag", "--access", "restricted"];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR enables the publishing of public npm scoped modules.

## Motivation and Context
I tried publishing a mixed repo of public and private packages under the same npm scope, and got an error due to NPM dependencies.

## How Has This Been Tested?
This has only been tested with the local repo I own, but since it's a small change it shouldn't have side-effects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
