### PR TITLE
Platform independent integration tests

### DIFF
--- a/test/fixtures/BootstrapCommand/integration-lifecycle/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/integration-lifecycle/package-1/package.json
@@ -8,5 +8,8 @@
   },
   "dependencies": {
     "pify": "^2.0.0"
+  },
+  "devDependencies": {
+    "cash-cp": "^0.2.0"
   }
 }

--- a/test/fixtures/BootstrapCommand/integration/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/integration/package-1/package.json
@@ -8,5 +8,8 @@
   },
   "dependencies": {
     "pify": "^2.0.0"
+  },
+  "devDependencies": {
+    "cash-cp": "^0.2.0"
   }
 }

--- a/test/fixtures/ExecCommand/exec-test
+++ b/test/fixtures/ExecCommand/exec-test
@@ -1,0 +1,1 @@
+node $EXEC_TEST/exec-test.js $*

--- a/test/fixtures/ExecCommand/exec-test.bat
+++ b/test/fixtures/ExecCommand/exec-test.bat
@@ -1,0 +1,2 @@
+@echo off
+node %EXEC_TEST%\exec-test.js %*

--- a/test/fixtures/ExecCommand/exec-test.js
+++ b/test/fixtures/ExecCommand/exec-test.js
@@ -1,0 +1,24 @@
+/**
+ * Prints out the package name and any passed args, followed by
+ * all the files in this directory
+ * eg
+ * package-1 -1
+ * file1.js
+ * package.json
+ */
+const path = require("path");
+const fs = require("fs");
+const cwd = process.cwd();
+const parsedCwd = path.parse(cwd);
+
+// The first two elements in process.argv are the path to node and this script, don't include them
+// as they will be different on each platform/device
+const passedArgs = process.argv.splice(2).join(" ");
+
+// List all files in the current directory and filter out the exec-test* files
+// to focus on the files under test
+const files = fs.readdirSync(cwd).filter((file) => file.indexOf("exec-test") === -1).join("\n");
+
+console.log(`${parsedCwd.base} ${passedArgs}`);
+console.log(files);
+

--- a/test/helpers/initExecTest.js
+++ b/test/helpers/initExecTest.js
@@ -1,0 +1,11 @@
+import path from "path";
+
+export default initExecTest;
+
+function initExecTest(fixtureDir) {
+  const execTestDir = path.resolve(__dirname, `../fixtures/${fixtureDir}`);
+  return {
+    PATH: `${execTestDir}${path.delimiter}${process.env.PATH}`,
+    EXEC_TEST: execTestDir
+  };
+}

--- a/test/integration/__snapshots__/lerna-exec.test.js.snap
+++ b/test/integration/__snapshots__/lerna-exec.test.js.snap
@@ -2,22 +2,22 @@
 
 exports[`stderr: <cmd> --parallel 1`] = `
 "lerna info version __TEST_VERSION__
-lerna info exec in 2 package(s): ls"
+lerna info exec in 2 package(s): exec-test"
 `;
 
 exports[`stderr: --parallel <cmd> 1`] = `
 "lerna info version __TEST_VERSION__
-lerna info exec in 2 package(s): ls"
+lerna info exec in 2 package(s): exec-test"
 `;
 
 exports[`stderr: echo LERNA_PACKAGE_NAME 1`] = `"lerna info version __TEST_VERSION__"`;
 
-exports[`stderr: ls --ignore 1`] = `
+exports[`stderr: exec-test --ignore 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info ignore package-1"
 `;
 
-exports[`stderr: ls --scope 1`] = `
+exports[`stderr: exec-test --scope 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info scope package-1"
 `;
@@ -29,19 +29,23 @@ exports[`stdout: echo LERNA_PACKAGE_NAME 1`] = `
 package-2"
 `;
 
-exports[`stdout: ls --ignore 1`] = `
-"file-2.js
+exports[`stdout: exec-test --ignore 1`] = `
+"package-2 -1
+file-2.js
 package.json"
 `;
 
-exports[`stdout: ls --scope 1`] = `
-"file-1.js
+exports[`stdout: exec-test --scope 1`] = `
+"package-1 
+file-1.js
 package.json"
 `;
 
 exports[`stdout: without -- 1`] = `
-"file-1.js
+"package-1 
+file-1.js
 package.json
+package-2 
 file-2.js
 package.json"
 `;

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -2,38 +2,40 @@ import execa from "execa";
 
 import { LERNA_BIN } from "../helpers/constants";
 import initFixture from "../helpers/initFixture";
+import initExecTest from "../helpers/initExecTest";
 
 describe("lerna exec", () => {
-  test.concurrent("--ignore <pkg> ls -- -1", async () => {
+  const env = initExecTest("ExecCommand");
+  test.concurrent("--ignore <pkg> exec-test -- -1", async () => {
     const cwd = await initFixture("ExecCommand/basic");
     const args = [
       "exec",
       "--ignore=package-1",
-      "ls",
+      "exec-test",
       "--concurrency=1",
       "--",
-      // args to ls
+      // args to exec-test
       "-1",
     ];
 
-    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
-    expect(stdout).toMatchSnapshot("stdout: ls --ignore");
-    expect(stderr).toMatchSnapshot("stderr: ls --ignore");
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd, env });
+    expect(stdout).toMatchSnapshot("stdout: exec-test --ignore");
+    expect(stderr).toMatchSnapshot("stderr: exec-test --ignore");
   });
 
-  test.concurrent("ls --scope <pkg>", async () => {
+  test.concurrent("exec-test --scope <pkg>", async () => {
     const cwd = await initFixture("ExecCommand/basic");
     const args = [
       "exec",
       "--concurrency=1",
-      "ls",
+      "exec-test",
       "--scope=package-1",
-      // no args to ls
+      // no args to exec-test
     ];
 
-    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
-    expect(stdout).toMatchSnapshot("stdout: ls --scope");
-    expect(stderr).toMatchSnapshot("stderr: ls --scope");
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd, env });
+    expect(stdout).toMatchSnapshot("stdout: exec-test --scope");
+    expect(stderr).toMatchSnapshot("stderr: exec-test --scope");
   });
 
   test.concurrent("without --", async () => {
@@ -41,12 +43,12 @@ describe("lerna exec", () => {
     const args = [
       "--concurrency=1",
       "exec",
-      "ls",
+      "exec-test",
       // no --
       "-C",
     ];
 
-    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd, env });
     expect(stdout).toMatchSnapshot("stdout: without --");
     expect(stderr).toMatchSnapshot("stderr: without --");
   });
@@ -69,13 +71,13 @@ describe("lerna exec", () => {
     const cwd = await initFixture("ExecCommand/basic");
     const args = [
       "exec",
-      "ls",
+      "exec-test",
       "--parallel",
       // no --
       "-C",
     ];
 
-    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd, env });
     expect(stderr).toMatchSnapshot("stderr: <cmd> --parallel");
 
     // order is non-deterministic, so assert individually
@@ -90,12 +92,12 @@ describe("lerna exec", () => {
     const args = [
       "exec",
       "--parallel",
-      "ls",
+      "exec-test",
       // no --
       "-C",
     ];
 
-    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd, env });
     expect(stderr).toMatchSnapshot("stderr: --parallel <cmd>");
 
     // order is non-deterministic, so assert individually


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the integration tests to support running on both Windows and Linux environments by removing the need to have `ls` and `cp` commands available. 

For the exec tests `ls` has been replaced with a shell script/windows batch file, that calls `node  exec-test.js`  `exec-test.js` just lists the current package, any args supplied and all the files in the package. 

With this approach, it is easier to verify if `lerna exec`  is respecting the command line flags.

For example, If passing args with `--` was broken, the output would clearly show the args that are/aren't passed to each package: `lerna exec exec-test -- -1 ` 

broken:
```
package-1 -1
file-1.js
package.json
package-2
file-2.js
package.json
```
working:
```
package-1 -1
file-1.js
package.json
package-2 -1
file-2.js
package.json
```

For the bootstrap tests, a node based [cp](https://www.npmjs.com/package/cash-cp) has been used. 

Also the publish test snapshot has been updated to pass the build

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The integration tests currently make use of `cp` and `ls`, which are not available on Windows. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run integration` on Windows 10 and a Ubuntu VM

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
