### PR TITLE
Fixes #939 Bootstrap performance issue with --include-filtered-dependencies in large, cyclic repos

### DIFF
--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -118,7 +118,9 @@ export default class PackageUtilities {
         }
       });
 
-      dependentPackages.push(pkg);
+      if (!packageAlreadyFound(pkg.name)) {
+        dependentPackages.push(pkg);
+      }
     }
 
     return dependentPackages;

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/lerna.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/package.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-1/package.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-1/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-2": "^1.0.0",
+    "package-3": "^1.0.0",
+    "package-4": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-2/package.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-4": "^1.0.0",
+    "package-5": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-3/package.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-3/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-4": "^1.0.0",
+    "package-6": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-4/package.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-4/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-4",
+  "description": "All but one package depend on this one, including itself",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0",
+    "package-4": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-5/package.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-5/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-5",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-4": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-6/package.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-6/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-6",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-4": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-7/package.json
+++ b/test/fixtures/PackageUtilities/cycles-and-repeated-deps/packages/package-7/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-7",
+  "description": "This exists so that we have something we know we shouldnt see in the dep tree",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-4": "^1.0.0"
+  }
+}


### PR DESCRIPTION
This is a very small change to fix a performance issue when using the include-filtered-dependencies flag in a large, cyclic repository.

The old behaviour would cause packages to be returned multiple times, hence bootstrapped multiple times.

## Description
The change was just to add the extra check that you havent seen a package before you add it to the list.

## Motivation and Context
Major performance concerns in bootstrapping

## How Has This Been Tested?
I have run this in our repo (>60 packages) and have found a 33-50% decrease in bootstapping times

For one small package it went from 24s to 14s (10 packages bootstrapped -> 6 packages bootstrapped), for another it went from 214s to 145s (58 packages boostrapped -> 36 packages bootstrapped)

I've also added another test fixture with a very specifically crafted set of deps that tests three things
* A package depending on itself isn't added twice
* A package being added twice in the same stage of the expansion isn't added twice
* A package that has already been processed wont get added twice

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
