### PR TITLE
Swallow promise rejection in registerChild as it is handled via callback

### DIFF
--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -81,7 +81,7 @@ function registerChild(child) {
     if (children === 0) {
       emitter.emit("empty");
     }
-  });
+  }).catch(() => {});
 }
 
 function _spawn(command, args, opts, callback) {

--- a/test/ChildProcessUtilities.js
+++ b/test/ChildProcessUtilities.js
@@ -34,9 +34,6 @@ describe("ChildProcessUtilities", () => {
     });
 
     it("passes an error object to callback when stdout maxBuffer exceeded", (done) => {
-      // this is expected
-      process.once("unhandledRejection", () => {});
-
       ChildProcessUtilities.exec("echo", ["wat"], { maxBuffer: 1 }, (stderr, stdout) => {
         try {
           expect(String(stderr)).toBe("Error: stdout maxBuffer exceeded");
@@ -55,9 +52,6 @@ describe("ChildProcessUtilities", () => {
     });
 
     it("passes error object to callback", (done) => {
-      // this is also expected
-      process.once("unhandledRejection", () => {});
-
       ChildProcessUtilities.exec("nowImTheModelOfAModernMajorGeneral", [], {}, (err) => {
         try {
           expect(err.message).toMatch(/\bnowImTheModelOfAModernMajorGeneral\b/);
@@ -70,9 +64,6 @@ describe("ChildProcessUtilities", () => {
 
     it("passes Promise rejection through", () => {
       return ChildProcessUtilities.exec("theVeneratedVirginianVeteranWhoseMenAreAll", []).catch((err) => {
-        // this is also expected, despite being in a weird place
-        process.once("unhandledRejection", () => {});
-
         expect(err.message).toMatch(/\btheVeneratedVirginianVeteranWhoseMenAreAll\b/);
       });
     });


### PR DESCRIPTION
## Description
`ChildProcessUtilities.registerChild()` attaches itself to an `execa` thenable, but then there is no catch, so if command executed fails, there is an `unhandledRejection`. Given `execa` promise is returned/handled via callback, it's ok to swallow error.

## Motivation and Context
Not clean - using `lerna` api for an extension and get unhandled rejections in tests:)

## How Has This Been Tested?
Cleaned-up tests, I could add regression test though.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
