### PR TITLE
Support pre* options in --cd-version with optional --preid meta suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,13 +380,23 @@ Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous
 #### --cd-version
 
 ```sh
-$ lerna publish --cd-version (patch | major | minor)
+$ lerna publish --cd-version (patch | minor | major | prepatch | preminor | premajor | prerelease)
 # uses the next semantic version(s) value and this skips `Select a new version for...` prompt
 ```
 
 When run with this flag, `publish` will skip the version selection prompt (in independent mode) and use the next specified semantic version.
 You must still use the `--yes` flag to avoid all prompts. This is useful when build systems need
 to publish without command prompts. Works in both normal and independent modes.
+
+#### --pre-id
+
+```sh
+$ lerna publish --cd-version (prepatch | preminor | premajor | prerelease) --pre-id beta
+# prefixes the prerelease tag with given identifier
+```
+
+This flag works with connection with `--cd-version pre*` and allows to specify a meta suffix: `alpha`, `beta`, `rc`, or any other string (ex: `1.0.0` becomes `2.0.0-beta.0` after `lerna publish --cd-version premajor --preid beta`).
+By default, the current meta-suffix will be used, if any.
 
 #### --repo-version
 

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -62,6 +62,16 @@ exports[`[independent --cd-version] git commit message 1`] = `
  - package-5@5.0.1"
 `;
 
+exports[`[independent --cd-version] git commit message 2`] = `
+"Publish
+
+ - package-1@1.0.1-beta.0
+ - package-2@2.0.1-beta.0
+ - package-3@3.0.1-beta.0
+ - package-4@4.0.1-beta.0
+ - package-5@5.0.1-beta.0"
+`;
+
 exports[`[independent --conventional-commits] git adds changed files 1`] = `
 Array [
   "packages/package-1/CHANGELOG.md",


### PR DESCRIPTION


## Description
`prerelease | prepatch | preminor | premajor` options were added to `--cd-version flag`. `--preid` flag was added (used as `semver.inc`'s [third argument](https://github.com/npm/node-semver#prerelease-identifiers)).

## Motivation and Context
Fixes #567

## How Has This Been Tested?
See changes in tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
