### PR TITLE
Improve support for semver prerelease identifiers when publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,13 +380,29 @@ Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous
 #### --cd-version
 
 ```sh
-$ lerna publish --cd-version (patch | major | minor)
+$ lerna publish --cd-version (patch | major | minor | prepatch | premajor | preminor | prerelease)
 # uses the next semantic version(s) value and this skips `Select a new version for...` prompt
 ```
 
 When run with this flag, `publish` will skip the version selection prompt (in independent mode) and use the next specified semantic version.
 You must still use the `--yes` flag to avoid all prompts. This is useful when build systems need
 to publish without command prompts. Works in both normal and independent modes.
+
+#### --prerelase-id, --preid
+
+```sh
+$ lerna publish --cd-version=prerelease
+# uses the next semantic prerelease version, e.g.
+# 1.0.0 => 1.0.0-0
+
+$ lerna publish --cd-version=prepatch --prerelease-id=next
+# uses the next semantic prerelease version with a specific prerelease identifier, e.g.
+# 1.0.0 => 1.0.1-next.0
+```
+
+When run with this flag, `lerna publish --cd-version` will
+increment `premajor`, `preminor`, `prepatch`, or `prerelease`
+versions using the specified [prerelease identifier](http://semver.org/#spec-item-9).
 
 #### --repo-version
 

--- a/README.md
+++ b/README.md
@@ -388,14 +388,14 @@ When run with this flag, `publish` will skip the version selection prompt (in in
 You must still use the `--yes` flag to avoid all prompts. This is useful when build systems need
 to publish without command prompts. Works in both normal and independent modes.
 
-#### --prerelase-id, --preid
+#### --preid
 
 ```sh
 $ lerna publish --cd-version=prerelease
 # uses the next semantic prerelease version, e.g.
 # 1.0.0 => 1.0.0-0
 
-$ lerna publish --cd-version=prepatch --prerelease-id=next
+$ lerna publish --cd-version=prepatch --preid=next
 # uses the next semantic prerelease version with a specific prerelease identifier, e.g.
 # 1.0.0 => 1.0.1-next.0
 ```

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous
 #### --cd-version
 
 ```sh
-$ lerna publish --cd-version (patch | major | minor | prepatch | premajor | preminor | prerelease)
+$ lerna publish --cd-version (major | minor | patch | premajor | preminor | prepatch | prerelease)
 # uses the next semantic version(s) value and this skips `Select a new version for...` prompt
 ```
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -51,11 +51,9 @@ export const builder = {
     type: "string",
     requiresArg: true,
     coerce: (choice) => {
-      try {
-        semver.inc("1.0.0", choice);
-      } catch (error) {
+      if (!cdVersionOptions.includes(choice)) {
         throw new Error(
-          "--cd-version must be semver-compatible: 'major', 'minor', 'patch', 'prerelease', etc.'"
+          `--cd-version must be one of: ${cdVersionOptionString}`
         );
       }
       return choice;

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -41,7 +41,9 @@ export const builder = {
       try {
         semver.inc("1.0.0", choice);
       } catch (error) {
-        throw new Error(`--cd-version must be semver-compatible: 'major', 'minor', 'patch', 'prerelease', etc.'`);
+        throw new Error(
+          "--cd-version must be semver-compatible: 'major', 'minor', 'patch', 'prerelease', etc.'"
+        );
       }
       return choice;
     },
@@ -81,6 +83,13 @@ export const builder = {
   "npm-tag": {
     group: "Command Options:",
     describe: "Publish packages with the specified npm dist-tag",
+    type: "string",
+    requiresArg: true,
+  },
+  "prerelease-id": {
+    group: "Command Options:",
+    describe: "Specify the prerelease identifier (major.minor.patch-pre).",
+    alias: "p",
     type: "string",
     requiresArg: true,
   },
@@ -253,7 +262,11 @@ export default class PublishCommand extends Command {
 
         this.updates.forEach((update) => {
           // TODO add semver.inc() argument for prerelease identifier
-          versions[update.package.name] = semver.inc(update.package.version, this.options.cdVersion);
+          versions[update.package.name] = semver.inc(
+            update.package.version,
+            this.options.cdVersion,
+            this.options.prereleaseId
+          );
         });
 
         return callback(null, { versions });

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -254,16 +254,16 @@ export default class PublishCommand extends Command {
   }
 
   getVersionsForUpdates(callback) {
-    if (this.options.cdVersion && !this.options.canary) {
+    const cdVersion = this.options.cdVersion;
+    if (cdVersion && !this.options.canary) {
       // If the version is independent then send versions
       if (this.repository.isIndependent()) {
         const versions = {};
 
         this.updates.forEach((update) => {
-          // TODO add semver.inc() argument for prerelease identifier
           versions[update.package.name] = semver.inc(
             update.package.version,
-            this.options.cdVersion,
+            cdVersion,
             this.options.preid
           );
         });
@@ -272,8 +272,11 @@ export default class PublishCommand extends Command {
       }
 
       // Otherwise bump the global version
-      // TODO add semver.inc() argument for prerelease identifier
-      const version = semver.inc(this.globalVersion, this.options.cdVersion);
+      const version = semver.inc(
+        this.globalVersion,
+        cdVersion,
+        this.options.preid
+      );
       return callback(null, { version });
     }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -255,7 +255,7 @@ export default class PublishCommand extends Command {
   }
 
   getVersionsForUpdates(callback) {
-    if (this.options.cdVersion) {
+    if (this.options.cdVersion && !this.options.canary) {
       // If the version is independent then send versions
       if (this.repository.isIndependent()) {
         const versions = {};

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -24,6 +24,19 @@ export const command = "publish";
 
 export const describe = "Publish packages in the current project.";
 
+const cdVersionOptions = [
+  "major",
+  "minor",
+  "patch",
+  "premajor",
+  "preminor",
+  "prepatch",
+  "prerelease",
+];
+
+const cdVersionOptionString =
+  `'${cdVersionOptions.slice(0, -1).join("', '")}', or '${cdVersionOptions[cdVersionOptions.length - 1]}'.`;
+
 export const builder = {
   "canary": {
     group: "Command Options:",
@@ -34,7 +47,7 @@ export const builder = {
   },
   "cd-version": {
     group: "Command Options:",
-    describe: "Skip the version selection prompt and increment semver 'major', 'minor', 'patch', etc.",
+    describe: `Skip the version selection prompt and increment semver: ${cdVersionOptionString}`,
     type: "string",
     requiresArg: true,
     coerce: (choice) => {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -86,10 +86,9 @@ export const builder = {
     type: "string",
     requiresArg: true,
   },
-  "prerelease-id": {
+  "preid": {
     group: "Command Options:",
     describe: "Specify the prerelease identifier (major.minor.patch-pre).",
-    alias: "preid",
     type: "string",
     requiresArg: true,
   },
@@ -265,7 +264,7 @@ export default class PublishCommand extends Command {
           versions[update.package.name] = semver.inc(
             update.package.version,
             this.options.cdVersion,
-            this.options.prereleaseId
+            this.options.preid
           );
         });
 
@@ -424,8 +423,8 @@ export default class PublishCommand extends Command {
           // TODO: allow specifying prerelease identifier as CLI option to skip the prompt
           PromptUtilities.input(`Enter a prerelease identifier ${prompt}`, {
             filter: (v) => {
-              const prereleaseId = v ? v : existingId;
-              return semver.inc(currentVersion, "prerelease", prereleaseId);
+              const preid = v || existingId;
+              return semver.inc(currentVersion, "prerelease", preid);
             },
           }, (input) => {
             callback(null, input);

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -89,7 +89,7 @@ export const builder = {
   "prerelease-id": {
     group: "Command Options:",
     describe: "Specify the prerelease identifier (major.minor.patch-pre).",
-    alias: "p",
+    alias: "preid",
     type: "string",
     requiresArg: true,
   },

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -51,7 +51,7 @@ export const builder = {
     type: "string",
     requiresArg: true,
     coerce: (choice) => {
-      if (!cdVersionOptions.includes(choice)) {
+      if (cdVersionOptions.indexOf(choice) === -1) {
         throw new Error(
           `--cd-version must be one of: ${cdVersionOptionString}`
         );

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -378,15 +378,15 @@ export default class PublishCommand extends Command {
     });
   }
 
-  getCanaryVersion(version, prerelease) {
-    if (prerelease == null || typeof prerelease !== "string") {
-      prerelease = "alpha";
+  getCanaryVersion(version, preid) {
+    if (preid == null || typeof preid !== "string") {
+      preid = "alpha";
     }
 
     const release = this.options.cdVersion || "minor";
     const nextVersion = semver.inc(version, release);
     const hash = GitUtilities.getCurrentSHA(this.execOpts).slice(0, 8);
-    return `${nextVersion}-${prerelease}.${hash}`;
+    return `${nextVersion}-${preid}.${hash}`;
   }
 
   promptVersion(packageName, currentVersion, callback) {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -365,16 +365,15 @@ export default class PublishCommand extends Command {
     });
   }
 
-  // TODO: rename `metaName` to preId or similar to match semver naming conventions
-  getCanaryVersion(version, metaName) {
-    if (metaName == null || typeof metaName !== "string") {
-      metaName = "alpha";
+  getCanaryVersion(version, prerelease) {
+    if (prerelease == null || typeof prerelease !== "string") {
+      prerelease = "alpha";
     }
 
-    // TODO: this should be the --cd-version value
-    const nextVersion = semver.inc(version, "minor");
+    const release = this.options.cdVersion || "minor";
+    const nextVersion = semver.inc(version, release);
     const hash = GitUtilities.getCurrentSHA(this.execOpts).slice(0, 8);
-    return `${nextVersion}-${metaName}.${hash}`;
+    return `${nextVersion}-${prerelease}.${hash}`;
   }
 
   promptVersion(packageName, currentVersion, callback) {

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -945,6 +945,47 @@ describe("PublishCommand", () => {
         }
       }));
     });
+
+    /** =========================================================================
+    * INDEPENDENT - CD VERSION - PRERELEASE
+    * ======================================================================= */
+
+    it("should bump to prerelease versions with --cd-version --prerelease", (done) => {
+      const publishCommand = new PublishCommand([], {
+        cdVersion: "prerelease",
+        prereleaseId: "foo",
+      }, testDir);
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      publishCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          if (pathExists.sync(path.join(testDir, "lerna-debug.log"))) {
+            // TODO: there has to be a better way to do this
+            throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
+          }
+
+          expect(updatedPackageVersions(testDir)).toMatchSnapshot("[normal --canary] bumps package versions");
+
+          expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
+            "package-1": "^1.0.1-foo.0",
+          });
+          expect(updatedPackageJSON("package-3").devDependencies).toMatchObject({
+            "package-2": "^2.0.1-foo.0",
+          });
+          expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
+            "package-1": "^0.0.0",
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
   });
 
   /** =========================================================================

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -985,6 +985,43 @@ describe("PublishCommand", () => {
         }
       }));
     });
+
+    it("should bump to prerelease versions with --cd-version prerelease (no --prerelease)", (done) => {
+      const publishCommand = new PublishCommand([], {
+        cdVersion: "prerelease",
+      }, testDir);
+
+      publishCommand.runValidations();
+      publishCommand.runPreparations();
+
+      publishCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          if (pathExists.sync(path.join(testDir, "lerna-debug.log"))) {
+            // TODO: there has to be a better way to do this
+            throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
+          }
+
+          expect(updatedPackageVersions(testDir)).toMatchSnapshot("[normal --canary] bumps package versions");
+
+          expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
+            "package-1": "^1.0.1-0",
+          });
+          expect(updatedPackageJSON("package-3").devDependencies).toMatchObject({
+            "package-2": "^2.0.1-0",
+          });
+          expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
+            "package-1": "^0.0.0",
+          });
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+
   });
 
   /** =========================================================================

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -949,10 +949,10 @@ describe("PublishCommand", () => {
     * INDEPENDENT - CD VERSION - PRERELEASE
     * ======================================================================= */
 
-    it("should bump to prerelease versions with --cd-version=prerelease --prerelease-id=foo", (done) => {
+    it("should bump to prerelease versions with --cd-version=prerelease --preid=foo", (done) => {
       const publishCommand = new PublishCommand([], {
         cdVersion: "prerelease",
-        prereleaseId: "foo",
+        preid: "foo",
       }, testDir);
 
       publishCommand.runValidations();

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -349,7 +349,7 @@ describe("PublishCommand", () => {
       }));
     });
 
-    it("should work with --canary and --cd-version", (done) => {
+    it("should work with --canary and --cd-version=patch", (done) => {
       const publishCommand = new PublishCommand([], {
         canary: "beta",
         cdVersion: "patch",
@@ -949,7 +949,7 @@ describe("PublishCommand", () => {
     * INDEPENDENT - CD VERSION - PRERELEASE
     * ======================================================================= */
 
-    it("should bump to prerelease versions with --cd-version --prerelease", (done) => {
+    it("should bump to prerelease versions with --cd-version=prerelease --prerelease-id=foo", (done) => {
       const publishCommand = new PublishCommand([], {
         cdVersion: "prerelease",
         prereleaseId: "foo",

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -234,6 +234,16 @@ Object {
 }
 `;
 
+exports[`[normal --canary] bumps package versions 5`] = `
+Object {
+  "packages/package-1": "1.0.1-0",
+  "packages/package-2": "2.0.1-0",
+  "packages/package-3": "3.0.1-0",
+  "packages/package-4": "4.0.1-0",
+  "packages/package-5": "5.0.1-0",
+}
+`;
+
 exports[`[normal --canary] npm publish --tag 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -216,11 +216,21 @@ Object {
 
 exports[`[normal --canary] bumps package versions 3`] = `
 Object {
-  "packages/package-1": "1.0.1-0",
-  "packages/package-2": "1.0.1-0",
-  "packages/package-3": "1.0.1-0",
-  "packages/package-4": "1.0.1-0",
-  "packages/package-5": "1.0.1-0",
+  "packages/package-1": "1.0.1-beta.deadbeef",
+  "packages/package-2": "1.0.1-beta.deadbeef",
+  "packages/package-3": "1.0.1-beta.deadbeef",
+  "packages/package-4": "1.0.1-beta.deadbeef",
+  "packages/package-5": "1.0.1-beta.deadbeef",
+}
+`;
+
+exports[`[normal --canary] bumps package versions 4`] = `
+Object {
+  "packages/package-1": "1.0.1-foo.0",
+  "packages/package-2": "2.0.1-foo.0",
+  "packages/package-3": "3.0.1-foo.0",
+  "packages/package-4": "4.0.1-foo.0",
+  "packages/package-5": "5.0.1-foo.0",
 }
 `;
 

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -214,6 +214,16 @@ Object {
 }
 `;
 
+exports[`[normal --canary] bumps package versions 3`] = `
+Object {
+  "packages/package-1": "1.0.1-0",
+  "packages/package-2": "1.0.1-0",
+  "packages/package-3": "1.0.1-0",
+  "packages/package-4": "1.0.1-0",
+  "packages/package-5": "1.0.1-0",
+}
+`;
+
 exports[`[normal --canary] npm publish --tag 1`] = `
 Array [
   Object {


### PR DESCRIPTION
This updates the `lerna publish` command to accept any semver-compatible release type for `--cd-version` and allows you to use `--canary` and `--cd-version` together. It fixes #915 and #567 (and #936), and conflicts with #958 😬 .

## Description
Here are the changes to the publish command:

1. Any semver-compatible release type is for the value of `--cd-version`, rather than whitelisting "major", "minor", and "patch". The value coercion only fails if `semver.inc("1.0.0", choice)` throws an error.

1. The `--preid` option can be used to specify the semver prerelease identifier (`major.minor.patch-prerelease`), e.g. with:

    ```
    lerna publish --cd-version=prerelease --preid=beta
    ```

1. The `--canary` option now works with `--cd-version` to change how everything up to the prerelease identifier is changed, so you can do this:

    ```
    lerna publish --canary --cd-version=patch
    ```

## Motivation and Context
I filed #915 while trying to tweak the way that our canary release were being automatically published by our [Primer](/primer/primer-css) CI builds. Specifically, I wanted the prerelease identifier to be `commit` rather than `alpha`, and I wanted the releases to be incremented as patches rather than major versions, so that changes to `9.0.0` would publish canary builds for `9.0.1-commit.{sha}` rather than `9.1.0-alpha.{sha}`.

We set up release candidate automation for Primer release branches, which have updated `package.json` versions in git but need to have incremented prerelease identifiers, so we would go from `9.0.1` to `9.0.1-rc.0`. This change allows you to do that with:

```
lerna publish --cd-version=prerelease --preid=rc
```

## How Has This Been Tested?
I've added publish command tests for the following cases:

* `--cd-version=prerelease --preid=foo`
* `--cd-version=prerelease` (without a prerelease identifier, which semver handles transparently)
* `--canary --cd-version=patch`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
