### PR TITLE
Allow --since flag on publish --canary

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -39,7 +39,7 @@ export const builder = {
     describe: dedent`
       Restricts the scope to the packages that have been updated since
       the specified [ref], or if not specified, the latest tag.
-      (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)
+      (Only for 'run', 'exec', 'clean', 'ls', 'bootstrap', and 'publish --canary' commands)
     `,
     type: "string",
     requiresArg: false,

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -57,7 +57,7 @@ export default class UpdatedPackagesCollector {
     let { since } = options;
 
     if (GitUtilities.hasTags(execOpts)) {
-      if (canary) {
+      if (canary && typeof since !== "string") {
         let currentSHA;
 
         if (canary !== true) {
@@ -157,7 +157,7 @@ export default class UpdatedPackagesCollector {
       return (
         this.updatedPackages[pkg.name] ||
         (this.options[SECRET_FLAG] ? false : this.dependents[pkg.name]) ||
-        this.options.canary
+        (this.options.canary && typeof this.options.since !== "string")
       );
     }).map((pkg) => {
       this.logger.verbose("has filtered update", pkg.name);


### PR DESCRIPTION
## Description
Add check for `--since` flag on `publish --canary`

## Motivation and Context
An effort to reduce the build time for canary publish on large projects.  See #962

## How Has This Been Tested?
Tested locally using a variety of options for `--since`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
