### PR TITLE
Patch version bump to make travis builds work again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lerna",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tool for managing JavaScript projects with multiple packages",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
This pull request is mostly to trigger Travis to get around [this issue](https://github.com/lerna/lerna/commit/4f4e99f59f8ae78d089b71b2b5350a3ab07d8242)

---

Bump `lerna` to `2.0.1` so that [this regular expression](https://github.com/lerna/lerna/blob/master/test/helpers/serializePlaceholders.js#L9) doesn't mess with the integration tests

## Description
Changed a `0` to a `1`

## Motivation and Context
Travis CI builds were failing, because a regular expression was changing snapshots used for testing.

```
    - - package-1: 1.0.0 => 2.0.0
    - - package-2: 2.0.0 => 3.0.0
    + - package-1: 1.0.0 => __TEST_VERSION__
    + - package-2: __TEST_VERSION__ => 3.0.0
      - package-3: 3.0.0 => 4.0.0
      - package-4: 4.0.0 => 5.0.0
      - package-5: 5.0.0 => 6.0.0 (private)
```

## How Has This Been Tested?
Tested locally (directly off 4f4e99f) - need to  using `npm run integration`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.