### PR TITLE
Avoid false positives during integration test filtering

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -39,7 +39,6 @@ export default function CLI(argv, cwd) {
     .help("h").alias("h", "help")
     .version().alias("v", "version")
     .wrap(cli.terminalWidth())
-    .strict()
     .showHelpOnFail(false, "A command is required.")
     .epilogue(dedent`
       When a command fails, all logs are written to lerna-debug.log in the current working directory.

--- a/test/helpers/serializePlaceholders.js
+++ b/test/helpers/serializePlaceholders.js
@@ -6,8 +6,9 @@ const _ = require("lodash");
 const normalizeNewline = require("normalize-newline");
 const constants = require("./constants");
 
-const VERSION_REGEX = new RegExp(`v?${constants.LERNA_VERSION}`, "gm");
-// TODO: maybe less naïve regex?
+const VERSION_REGEX = new RegExp(`^(?:((?:.*?version )|\\^)|v?)${constants.LERNA_VERSION}`, "gm");
+const VERSION_REPLACEMENT = `$1${constants.__TEST_VERSION__}`;
+// TODO: maybe even less naïve regex?
 
 function needsReplacement(str) {
   return (
@@ -16,7 +17,7 @@ function needsReplacement(str) {
 }
 
 function stableVersion(str) {
-  return str.replace(VERSION_REGEX, constants.__TEST_VERSION__);
+  return str.replace(VERSION_REGEX, VERSION_REPLACEMENT);
 }
 
 const stabilizeString = _.flow([

--- a/test/integration/_setupTestFramework.js
+++ b/test/integration/_setupTestFramework.js
@@ -2,4 +2,4 @@
 "use strict";
 
 // allow CLI integration tests to run for awhile
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 70000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 180000;

--- a/test/integration/_setupTestFramework.js
+++ b/test/integration/_setupTestFramework.js
@@ -2,4 +2,4 @@
 "use strict";
 
 // allow CLI integration tests to run for awhile
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 180000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;


### PR DESCRIPTION
…that won't just match any old instance of "2.0.0"

**Caution: I also increased the timeout for the integration tests from 70s to 300s.**  I know it's probably a bad idea, but some of those tests seem to take forever on node v.8

A slightly-too-complicated regular expression.  The `.` characters present in `constants.LERNA_VERSION` will still match any character, but…

[Here's more info on the regexp I added.](https://regex101.com/r/E8GYA8/1)

I had considered bumping all the version numbers in the snapshots up into the `1000000.0.0` range, but when I thought about it some more I saw that the existing regexp here would match `1000002.0.0`.  Since there are versions from `0.0.0` through `6.0.0` in the snapshots, I figured this was the safest approach (at least until lerna gets to `6.0.1`, at which point even the original naïve regexp would do just fine.

Also removed `strict()` from `cli.js` based on conversation with @evocateur.

## Motivation and Context
Builds have been failing in Travis since 2.0.0 was tagged.

## How Has This Been Tested?
`npm run integration` && `npm run test` locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.