### PR TITLE
Prevent crash on publish when no updated packages

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -149,7 +149,7 @@ export default class PublishCommand extends Command {
 
     if (!this.updates.length) {
       this.logger.info("No updated packages to publish.");
-      callback(null, true);
+      callback(null, false);
       return;
     }
 


### PR DESCRIPTION
## Description
Currently running `lerna publish` when no packages need updating causes the command to crash unnecessarily.

This small fix causes the command to complete if no updates are found, instead of trying to continue to the next section.

This change was missing from the PR: #807 
Relates to the issue: #887 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
