### PR TITLE
Run "prepare" lifecycle script during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ When run, this command will:
 
 1. `npm install` all external dependencies of each package.
 2. Symlink together all Lerna `packages` that are dependencies of each other.
-3. `npm prepublish` all bootstrapped packages.
+3. `npm run prepublish` in all bootstrapped packages.
+4. `npm run prepare` in all bootstrapped packages.
 
 `lerna bootstrap` respects the `--ignore`, `--scope` and `--include-filtered-dependencies` flags (see [Flags](#flags)).
 

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -107,7 +107,9 @@ export default class BootstrapCommand extends Command {
         // postinstall bootstrapped packages
         (cb) => this.postinstallPackages(cb),
         // prepublish bootstrapped packages
-        (cb) => this.prepublishPackages(cb)
+        (cb) => this.prepublishPackages(cb),
+        // prepare bootstrapped packages
+        (cb) => this.preparePackages(cb)
       ], callback);
     }
 
@@ -173,6 +175,15 @@ export default class BootstrapCommand extends Command {
   prepublishPackages(callback) {
     this.logger.info("lifecycle", "prepublish");
     this.runScriptInPackages("prepublish", callback);
+  }
+
+  /**
+   * Run the "prepublish" NPM script in all bootstrapped packages
+   * @param callback
+   */
+  preparePackages(callback) {
+    this.logger.info("lifecycle", "prepare");
+    this.runScriptInPackages("prepare", callback);
   }
 
   /**

--- a/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -16,6 +16,7 @@ lerna info Installing external dependencies
 lerna info Symlinking packages and binaries
 lerna info lifecycle postinstall
 lerna info lifecycle prepublish
+lerna info lifecycle prepare
 lerna success Bootstrapped 4 packages"
 `;
 
@@ -36,6 +37,7 @@ lerna info Installing external dependencies
 lerna info Symlinking packages and binaries
 lerna info lifecycle postinstall
 lerna info lifecycle prepublish
+lerna info lifecycle prepare
 lerna success Bootstrapped 3 packages"
 `;
 
@@ -68,6 +70,7 @@ lerna info Installing external dependencies
 lerna info Symlinking packages and binaries
 lerna info lifecycle postinstall
 lerna info lifecycle prepublish
+lerna info lifecycle prepare
 lerna success Bootstrapped 4 packages"
 `;
 
@@ -87,5 +90,6 @@ lerna info Installing external dependencies
 lerna info Symlinking packages and binaries
 lerna info lifecycle postinstall
 lerna info lifecycle prepublish
+lerna info lifecycle prepare
 lerna success Bootstrapped 4 packages"
 `;


### PR DESCRIPTION
Followup to #499

## Description
Handle more lifecycle events during bootstrap - pairing in the behaviour with latest npms

## Motivation and Context
Handle correctly specified lifecycle events for npm4+. At the moment behaviours for regular npm install and lerna bootstrap are out of sync, which cause problems with preparation scripts i.e. not being run at all.
Fixes #421

## How Has This Been Tested?
Ran lerna's test suite + used this on my own project to check if added scripts are getting executed during bootstrap.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

cc @wzrdzl and @evocateur 