### PR TITLE
Add troubleshooting info for GitHub lightweight tags

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -77,8 +77,15 @@ For new manual releases, use `git tag -a -m <version>` instead of using the Gith
 For existing lightweight tags, they can be converted to an annotated tag using something like this: 
 
 ```sh
-date="$(git show <version> --format=%cD --no-patch)"
-GIT_COMMITTER_DATE="$date" git tag -a -m <version> -f <version> <version>
+GIT_AUTHOR_NAME="$(git show $1 --format=%aN -s)"
+GIT_AUTHOR_EMAIL="$(git show $1 --format=%aE -s)"
+GIT_AUTHOR_DATE="$(git show $1 --format=%aD -s)"
+GIT_COMMITTER_NAME="$(git show $1 --format=%cN -s)"
+GIT_COMMITTER_EMAIL="$(git show $1 --format=%cE -s)"
+GIT_COMMITTER_DATE="$(git show $1 --format=%cD -s)"
+
+git tag -a -m $1 -f $1 $1
+
 git push --tags --force
 ```
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds troubleshooting info for the publish command when lightweight tags have been created manually, rather than annotated tags. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Github web ui creates lightweight tags instead of annotated tags, which can cause issues when `lerna publish` is run. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
