### PR TITLE
Exit properly when there is nothing to publish

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -318,13 +318,14 @@ export default class Command {
     try {
       log.silly(method, "attempt");
 
-      this[method]((err, completed) => {
+      this[method]((err, completed, code = 0) => {
         if (err) {
           log.error(method, "callback with error\n", err);
           this._complete(err, 1, callback);
         } else if (!completed) {
+          // an early exit is rarely an error
           log.verbose(method, "exited early");
-          this._complete(null, 1, callback);
+          this._complete(null, code, callback);
         } else {
           log.silly(method, "success");
           next();
@@ -337,7 +338,7 @@ export default class Command {
   }
 
   _complete(err, code, callback) {
-    if (code !== 0) {
+    if (err) {
       writeLogFile(this.repository.rootPath);
     }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -171,7 +171,7 @@ export default class PublishCommand extends Command {
 
     if (!this.updates.length) {
       this.logger.info("No updated packages to publish.");
-      callback(null, true);
+      callback(null, false);
       return;
     }
 

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -39,7 +39,7 @@ export default class UpdatedCommand extends Command {
       this.logger.info("No packages need updating");
     }
 
-    callback(null, proceedWithUpdates);
+    callback(null, proceedWithUpdates, 1);
   }
 
   get otherCommandConfigs() {

--- a/test/CleanCommand.js
+++ b/test/CleanCommand.js
@@ -75,6 +75,27 @@ describe("CleanCommand", () => {
       }));
     });
 
+    it("exits early when confirmation is rejected", (done) => {
+      PromptUtilities.confirm = jest.fn(callsBack(false));
+
+      const cleanCommand = new CleanCommand([], {}, testDir);
+
+      cleanCommand.runValidations();
+      cleanCommand.runPreparations();
+
+      cleanCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(removedDirectories(testDir)).toEqual([]);
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+
     it("should be possible to skip asking for confirmation", (done) => {
       const cleanCommand = new CleanCommand([], {
         yes: true

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -117,6 +117,26 @@ describe("ImportCommand", () => {
       }));
     });
 
+    it("exits early when confirmation is rejected", (done) => {
+      PromptUtilities.confirm = jest.fn(callsBack(false));
+
+      const importCommand = new ImportCommand([externalDir], {}, testDir);
+
+      importCommand.runValidations();
+      importCommand.runPreparations();
+
+      importCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(lastCommitInDir(testDir)).toBe("Init commit");
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+
     it("allows skipping confirmation prompt", (done) => {
       const importCommand = new ImportCommand([externalDir], {
         yes: true

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -92,7 +92,7 @@ Array [
 ]
 `;
 
-exports[`stderr: exists with a exit code 0 when there are no updates 1`] = `
+exports[`stderr: exit 0 when no updates 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info current version 1.0.0
 lerna info Checking for updated packages...
@@ -116,7 +116,7 @@ lerna info Comparing with initial commit.
 lerna info auto-confirmed "
 `;
 
-exports[`stdout: exists with a exit code 0 when there are no updates 1`] = `""`;
+exports[`stdout: exit 0 when no updates 1`] = `""`;
 
 exports[`stdout: updates fixed versions 1`] = `
 "

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -11,21 +11,19 @@ const lastCommitMessage = (cwd) =>
   execa.stdout("git", ["log", "-1", "--format=%B"], { cwd }).then(normalizeNewline);
 
 describe("lerna publish", () => {
-  test.concurrent("exists with a exit code 0 when there are no updates", async () => {
+  test.concurrent("exit 0 when no updates", async () => {
     const cwd = await initFixture("PublishCommand/normal");
     await execa("git", ["tag", "-a", "v1.0.0", "-m", "v1.0.0"], { cwd });
 
     const args = [
       "publish",
-      "--skip-npm",
-      "--cd-version=patch",
-      "--yes",
     ];
 
-    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    const { stdout, stderr, code } = await execa(LERNA_BIN, args, { cwd });
 
-    expect(stdout).toMatchSnapshot("stdout: exists with a exit code 0 when there are no updates");
-    expect(stderr).toMatchSnapshot("stderr: exists with a exit code 0 when there are no updates");
+    expect(code).toBe(0);
+    expect(stdout).toMatchSnapshot("stdout: exit 0 when no updates");
+    expect(stderr).toMatchSnapshot("stderr: exit 0 when no updates");
   });
 
   test.concurrent("updates fixed versions", async () => {


### PR DESCRIPTION
## Description
In most contexts, exiting early is not an error, so exit 0 and don't write a lerna-debug.log file.

## Motivation and Context
Fixes #853

## How Has This Been Tested?
Removing bad flags from the integration test revealed the issue, and thus the fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
