### PR TITLE
Use yargs parser in unit tests for greater fidelity

### DIFF
--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -5,7 +5,8 @@ import Command from "../Command";
 import GitUtilities from "../GitUtilities";
 
 export function handler(argv) {
-  return new DiffCommand([argv.pkg], argv).run();
+  new DiffCommand([argv.pkg], argv, argv._cwd).run()
+    .then(argv._onFinish, argv._onFinish);
 }
 
 export const command = "diff [pkg]";

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -44,7 +44,8 @@ export const builder = {
     defaultDescription: "alpha",
     describe: "Publish packages after every successful merge using the sha as part of the tag.",
     alias: "c",
-    type: "string",
+    // NOTE: this type must remain undefined, as it is too overloaded to make sense
+    // type: "string",
   },
   "cd-version": {
     group: "Command Options:",

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -17,7 +17,8 @@ import PromptUtilities from "../PromptUtilities";
 import UpdatedPackagesCollector from "../UpdatedPackagesCollector";
 
 export function handler(argv) {
-  return new PublishCommand(argv._, argv).run();
+  new PublishCommand(argv._, argv, argv._cwd).run()
+    .then(argv._onFinish, argv._onFinish);
 }
 
 export const command = "publish";

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -7,11 +7,13 @@ import GitUtilities from "../src/GitUtilities";
 
 // helpers
 import callsBack from "./helpers/callsBack";
-import exitWithCode from "./helpers/exitWithCode";
 import initFixture from "./helpers/initFixture";
+import yargsRunner from "./helpers/yargsRunner";
 
 // file under test
-import DiffCommand from "../src/commands/DiffCommand";
+import * as commandModule from "../src/commands/DiffCommand";
+
+const run = yargsRunner(commandModule);
 
 jest.mock("../src/ChildProcessUtilities");
 jest.mock("../src/GitUtilities");
@@ -26,158 +28,107 @@ describe("DiffCommand", () => {
 
   beforeEach(() => initFixture("DiffCommand/basic").then((dir) => {
     testDir = dir;
+    GitUtilities.isInitialized.mockImplementation(() => true);
     GitUtilities.hasCommit.mockImplementation(() => true);
   }));
   afterEach(() => jest.resetAllMocks());
 
-  it("should diff everything from the first commit", (done) => {
+  it("should diff everything from the first commit", () => {
     GitUtilities.getFirstCommit.mockImplementation(() => "beefcafe");
     ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
 
-    const diffCommand = new DiffCommand([], {}, testDir);
-
-    diffCommand.runValidations();
-    diffCommand.runPreparations();
-
-    diffCommand.runCommand(exitWithCode(0, (err) => {
-      if (err) return done.fail(err);
-      try {
-        expect(ChildProcessUtilities.spawn).lastCalledWith(
-          "git",
-          [
-            "diff",
-            "beefcafe",
-            "--color=auto",
-          ],
-          expect.objectContaining({
-            cwd: testDir,
-          }),
-          expect.any(Function)
-        );
-        done();
-      } catch (ex) {
-        done.fail(ex);
-      }
-    }));
+    return run(testDir)().then(() => {
+      expect(ChildProcessUtilities.spawn).lastCalledWith(
+        "git",
+        [
+          "diff",
+          "beefcafe",
+          "--color=auto",
+        ],
+        expect.objectContaining({
+          cwd: testDir,
+        }),
+        expect.any(Function)
+      );
+    });
   });
 
-  it("should diff everything from the most recent tag", (done) => {
+  it("should diff everything from the most recent tag", () => {
     GitUtilities.hasTags.mockImplementation(() => true);
     GitUtilities.getLastTaggedCommit.mockImplementation(() => "cafedead");
     ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
 
-    const diffCommand = new DiffCommand([], {}, testDir);
-
-    diffCommand.runValidations();
-    diffCommand.runPreparations();
-
-    diffCommand.runCommand(exitWithCode(0, (err) => {
-      if (err) return done.fail(err);
-      try {
-        expect(ChildProcessUtilities.spawn).lastCalledWith(
-          "git",
-          [
-            "diff",
-            "cafedead",
-            "--color=auto",
-          ],
-          expect.objectContaining({
-            cwd: testDir,
-          }),
-          expect.any(Function)
-        );
-        done();
-      } catch (ex) {
-        done.fail(ex);
-      }
-    }));
+    return run(testDir)().then(() => {
+      expect(ChildProcessUtilities.spawn).lastCalledWith(
+        "git",
+        [
+          "diff",
+          "cafedead",
+          "--color=auto",
+        ],
+        expect.objectContaining({
+          cwd: testDir,
+        }),
+        expect.any(Function)
+      );
+    });
   });
 
-  it("should diff a specific package", (done) => {
+  it("should diff a specific package", () => {
     GitUtilities.getFirstCommit.mockImplementation(() => "deadbeef");
     ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
 
-    const diffCommand = new DiffCommand(["package-1"], {}, testDir);
-
-    diffCommand.runValidations();
-    diffCommand.runPreparations();
-
-    diffCommand.runCommand(exitWithCode(0, (err) => {
-      if (err) return done.fail(err);
-      try {
-        expect(ChildProcessUtilities.spawn).lastCalledWith(
-          "git",
-          [
-            "diff",
-            "deadbeef",
-            "--color=auto",
-            "--",
-            path.join(testDir, "packages/package-1"),
-          ],
-          expect.objectContaining({
-            cwd: testDir,
-          }),
-          expect.any(Function)
-        );
-        done();
-      } catch (ex) {
-        done.fail(ex);
-      }
-    }));
+    return run(testDir)(
+      "package-1"
+    ).then(() => {
+      expect(ChildProcessUtilities.spawn).lastCalledWith(
+        "git",
+        [
+          "diff",
+          "deadbeef",
+          "--color=auto",
+          "--",
+          path.join(testDir, "packages/package-1"),
+        ],
+        expect.objectContaining({
+          cwd: testDir,
+        }),
+        expect.any(Function)
+      );
+    });
   });
 
-  it("should error when attempting to diff a package that doesn't exist", (done) => {
-    const diffCommand = new DiffCommand(["missing"], {}, testDir);
-
-    diffCommand.runValidations();
-    diffCommand.runPreparations();
-
-    diffCommand.runCommand(exitWithCode(1, (err) => {
-      try {
-        expect(err.message).toBe("Package 'missing' does not exist.");
-        done();
-      } catch (ex) {
-        done.fail(ex);
-      }
-    }));
+  it("should error when attempting to diff a package that doesn't exist", () => {
+    return run(testDir)(
+      "missing"
+    ).catch((err) => {
+      expect(err.exitCode).toBe(1);
+      expect(err.message).toBe("Package 'missing' does not exist.");
+    });
   });
 
-  it("should error when running in a repository without commits", (done) => {
+  it("should error when running in a repository without commits", () => {
     // override beforeEach mock
     GitUtilities.hasCommit.mockImplementation(() => false);
 
-    const diffCommand = new DiffCommand(["package-1"], {}, testDir);
-
-    diffCommand.runValidations();
-    diffCommand.runPreparations();
-
-    diffCommand.runCommand(exitWithCode(1, (err) => {
-      try {
-        expect(err.message).toBe("Can't diff. There are no commits in this repository, yet.");
-        done();
-      } catch (ex) {
-        done.fail(ex);
-      }
-    }));
+    return run(testDir)(
+      "package-1"
+    ).catch((err) => {
+      expect(err.exitCode).toBe(1);
+      expect(err.message).toBe("Can't diff. There are no commits in this repository, yet.");
+    });
   });
 
-  it("should error when git diff exits non-zero", (done) => {
+  it("should error when git diff exits non-zero", () => {
     const err = new Error("An actual non-zero, not git diff pager SIGPIPE");
     err.code = 1;
     ChildProcessUtilities.spawn.mockImplementation(callsBack(err));
 
-    const diffCommand = new DiffCommand(["package-1"], {}, testDir);
-
-    diffCommand.runValidations();
-    diffCommand.runPreparations();
-
-    diffCommand.runCommand(exitWithCode(1, (err) => {
-      try {
-        expect(err.message).toBe("An actual non-zero, not git diff pager SIGPIPE");
-        done();
-      } catch (ex) {
-        done.fail(ex);
-      }
-    }));
+    return run(testDir)(
+      "package-1"
+    ).catch((err) => {
+      expect(err.exitCode).toBe(1);
+      expect(err.message).toBe("An actual non-zero, not git diff pager SIGPIPE");
+    });
   });
 });

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -627,6 +627,18 @@ describe("PublishCommand", () => {
         expect(gitCommitMessage()).toBe("v1.1.0");
       });
     });
+
+    it("throws an error when an invalid semver keyword is used", async () => {
+      expect.assertions(1);
+      try {
+        await run(testDir)("--cd-version", "poopypants");
+      } catch (err) {
+        expect(err.message).toBe(
+          "--cd-version must be one of: " +
+          "'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', or 'prerelease'."
+        );
+      }
+    });
   });
 
   /** =========================================================================

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -330,7 +330,8 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          expect(updatedPackageVersions(testDir)).toMatchSnapshot("[normal --canary] bumps package versions");
+          expect(updatedPackageVersions(testDir))
+            .toMatchSnapshot("[normal --canary=beta] bumps package versions");
 
           expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
             "package-1": "^1.1.0-beta.deadbeef",
@@ -351,7 +352,7 @@ describe("PublishCommand", () => {
 
     it("should work with --canary and --cd-version=patch", (done) => {
       const publishCommand = new PublishCommand([], {
-        canary: "beta",
+        canary: true,
         cdVersion: "patch",
       }, testDir);
 
@@ -367,13 +368,14 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          expect(updatedPackageVersions(testDir)).toMatchSnapshot("[normal --canary] bumps package versions");
+          expect(updatedPackageVersions(testDir))
+            .toMatchSnapshot("[normal --canary --cd-version=patch] bumps package versions");
 
           expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
-            "package-1": "^1.0.1-beta.deadbeef",
+            "package-1": "^1.0.1-alpha.deadbeef",
           });
           expect(updatedPackageJSON("package-3").devDependencies).toMatchObject({
-            "package-2": "^1.0.1-beta.deadbeef",
+            "package-2": "^1.0.1-alpha.deadbeef",
           });
           expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
             "package-1": "^0.0.0",
@@ -967,7 +969,8 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          expect(updatedPackageVersions(testDir)).toMatchSnapshot("[normal --canary] bumps package versions");
+          expect(updatedPackageVersions(testDir))
+            .toMatchSnapshot("[independent --cd-version=prerelease --preid=foo] bumps package versions");
 
           expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
             "package-1": "^1.0.1-foo.0",
@@ -986,7 +989,7 @@ describe("PublishCommand", () => {
       }));
     });
 
-    it("should bump to prerelease versions with --cd-version prerelease (no --prerelease)", (done) => {
+    it("should bump to prerelease versions with --cd-version prerelease (no --preid)", (done) => {
       const publishCommand = new PublishCommand([], {
         cdVersion: "prerelease",
       }, testDir);
@@ -1003,7 +1006,8 @@ describe("PublishCommand", () => {
             throw new Error(fs.readFileSync(path.join(testDir, "lerna-debug.log"), "utf8"));
           }
 
-          expect(updatedPackageVersions(testDir)).toMatchSnapshot("[normal --canary] bumps package versions");
+          expect(updatedPackageVersions(testDir))
+            .toMatchSnapshot("[independent --cd-version=prerelease] bumps package versions");
 
           expect(updatedPackageJSON("package-2").dependencies).toMatchObject({
             "package-1": "^1.0.1-0",

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -70,6 +70,26 @@ Array [
 ]
 `;
 
+exports[`[independent --cd-version=prerelease --preid=foo] bumps package versions 1`] = `
+Object {
+  "packages/package-1": "1.0.1-foo.0",
+  "packages/package-2": "2.0.1-foo.0",
+  "packages/package-3": "3.0.1-foo.0",
+  "packages/package-4": "4.0.1-foo.0",
+  "packages/package-5": "5.0.1-foo.0",
+}
+`;
+
+exports[`[independent --cd-version=prerelease] bumps package versions 1`] = `
+Object {
+  "packages/package-1": "1.0.1-0",
+  "packages/package-2": "2.0.1-0",
+  "packages/package-3": "3.0.1-0",
+  "packages/package-4": "4.0.1-0",
+  "packages/package-5": "5.0.1-0",
+}
+`;
+
 exports[`[independent --cd-version] git commit message 1`] = `
 "Publish
 
@@ -194,17 +214,17 @@ Array [
 ]
 `;
 
-exports[`[normal --canary] bumps package versions 1`] = `
+exports[`[normal --canary --cd-version=patch] bumps package versions 1`] = `
 Object {
-  "packages/package-1": "1.1.0-alpha.deadbeef",
-  "packages/package-2": "1.1.0-alpha.deadbeef",
-  "packages/package-3": "1.1.0-alpha.deadbeef",
-  "packages/package-4": "1.1.0-alpha.deadbeef",
-  "packages/package-5": "1.1.0-alpha.deadbeef",
+  "packages/package-1": "1.0.1-alpha.deadbeef",
+  "packages/package-2": "1.0.1-alpha.deadbeef",
+  "packages/package-3": "1.0.1-alpha.deadbeef",
+  "packages/package-4": "1.0.1-alpha.deadbeef",
+  "packages/package-5": "1.0.1-alpha.deadbeef",
 }
 `;
 
-exports[`[normal --canary] bumps package versions 2`] = `
+exports[`[normal --canary=beta] bumps package versions 1`] = `
 Object {
   "packages/package-1": "1.1.0-beta.deadbeef",
   "packages/package-2": "1.1.0-beta.deadbeef",
@@ -214,33 +234,13 @@ Object {
 }
 `;
 
-exports[`[normal --canary] bumps package versions 3`] = `
+exports[`[normal --canary] bumps package versions 1`] = `
 Object {
-  "packages/package-1": "1.0.1-beta.deadbeef",
-  "packages/package-2": "1.0.1-beta.deadbeef",
-  "packages/package-3": "1.0.1-beta.deadbeef",
-  "packages/package-4": "1.0.1-beta.deadbeef",
-  "packages/package-5": "1.0.1-beta.deadbeef",
-}
-`;
-
-exports[`[normal --canary] bumps package versions 4`] = `
-Object {
-  "packages/package-1": "1.0.1-foo.0",
-  "packages/package-2": "2.0.1-foo.0",
-  "packages/package-3": "3.0.1-foo.0",
-  "packages/package-4": "4.0.1-foo.0",
-  "packages/package-5": "5.0.1-foo.0",
-}
-`;
-
-exports[`[normal --canary] bumps package versions 5`] = `
-Object {
-  "packages/package-1": "1.0.1-0",
-  "packages/package-2": "2.0.1-0",
-  "packages/package-3": "3.0.1-0",
-  "packages/package-4": "4.0.1-0",
-  "packages/package-5": "5.0.1-0",
+  "packages/package-1": "1.1.0-alpha.deadbeef",
+  "packages/package-2": "1.1.0-alpha.deadbeef",
+  "packages/package-3": "1.1.0-alpha.deadbeef",
+  "packages/package-4": "1.1.0-alpha.deadbeef",
+  "packages/package-5": "1.1.0-alpha.deadbeef",
 }
 `;
 

--- a/test/helpers/yargsRunner.js
+++ b/test/helpers/yargsRunner.js
@@ -9,31 +9,31 @@ import { builder as globalOptions } from '../../src/Command';
  * @return {Function} with partially-applied yargs config
  */
 export default function yargsRunner(commandModule) {
-    const cmd = commandModule.command.split(' ')[0];
+  const cmd = commandModule.command.split(' ')[0];
 
-    return cwd => {
-        // create a _new_ yargs instance every time cwd changes to avoid singleton pollution
-        const cli = yargs([], cwd).options(globalOptions).command(commandModule);
+  return cwd => {
+    // create a _new_ yargs instance every time cwd changes to avoid singleton pollution
+    const cli = yargs([], cwd).options(globalOptions).command(commandModule);
 
-        return (...args) =>
-            new Promise((resolve, reject) => {
-                const yargsMeta = {};
-                const _onFinish = result => {
-                    Object.assign(result, yargsMeta);
-                    // tests expect errors thrown to indicate failure,
-                    // _not_ just non-zero exitCode
-                    if (result instanceof Error) {
-                        reject(result);
-                    } else {
-                        resolve(result);
-                    }
-                };
-                const context = { _cwd: cwd, _onFinish };
-                const parseFn = (exitError, parsedArgv, yargsOutput) => {
-                    Object.assign(yargsMeta, { exitError, parsedArgv, yargsOutput });
-                };
+    return (...args) =>
+      new Promise((resolve, reject) => {
+        const yargsMeta = {};
+        const _onFinish = result => {
+          Object.assign(result, yargsMeta);
+          // tests expect errors thrown to indicate failure,
+          // _not_ just non-zero exitCode
+          if (result instanceof Error) {
+            reject(result);
+          } else {
+            resolve(result);
+          }
+        };
+        const context = { _cwd: cwd, _onFinish };
+        const parseFn = (yargsError, parsedArgv, yargsOutput) => {
+          Object.assign(yargsMeta, { parsedArgv, yargsOutput });
+        };
 
-                cli.parse([cmd, ...args], context, parseFn);
-            });
-    };
+        cli.parse([cmd, ...args], context, parseFn);
+      });
+  };
 }

--- a/test/helpers/yargsRunner.js
+++ b/test/helpers/yargsRunner.js
@@ -1,0 +1,39 @@
+import yargs from 'yargs/yargs';
+import { builder as globalOptions } from '../../src/Command';
+
+/**
+ * A higher-order function to help with passing _actual_ yargs-parsed argv
+ * into command constructors (instead of artificial direct parameters).
+ *
+ * @param {Object} commandModule The yargs command exports
+ * @return {Function} with partially-applied yargs config
+ */
+export default function yargsRunner(commandModule) {
+    const cmd = commandModule.command.split(' ')[0];
+
+    return cwd => {
+        // create a _new_ yargs instance every time cwd changes to avoid singleton pollution
+        const cli = yargs([], cwd).options(globalOptions).command(commandModule);
+
+        return (...args) =>
+            new Promise((resolve, reject) => {
+                const yargsMeta = {};
+                const _onFinish = result => {
+                    Object.assign(result, yargsMeta);
+                    // tests expect errors thrown to indicate failure,
+                    // _not_ just non-zero exitCode
+                    if (result instanceof Error) {
+                        reject(result);
+                    } else {
+                        resolve(result);
+                    }
+                };
+                const context = { _cwd: cwd, _onFinish };
+                const parseFn = (exitError, parsedArgv, yargsOutput) => {
+                    Object.assign(yargsMeta, { exitError, parsedArgv, yargsOutput });
+                };
+
+                cli.parse([cmd, ...args], context, parseFn);
+            });
+    };
+}

--- a/test/helpers/yargsRunner.js
+++ b/test/helpers/yargsRunner.js
@@ -31,6 +31,10 @@ export default function yargsRunner(commandModule) {
         const context = { _cwd: cwd, _onFinish };
         const parseFn = (yargsError, parsedArgv, yargsOutput) => {
           Object.assign(yargsMeta, { parsedArgv, yargsOutput });
+          // immediate rejection to avoid dangling promise timeout
+          if (yargsError) {
+            _onFinish(yargsError);
+          }
         };
 
         cli.parse([cmd, ...args], context, parseFn);


### PR DESCRIPTION
## Description
Use the _actual_ arg parser that creates _actual_ command instances when run via the CLI during unit tests, an amazing concept.

## Motivation and Context
Our artificial constructor arguments have led to several bugs, most recently (and egregiously) #989 (from #960).

This also _drastically_ simplifies the tests and makes them much more readable.

## How Has This Been Tested?
a whole bunch (the first push will intentionally fail with a #989 repro)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.