### PR TITLE
Fix --conventional-commits recommending already released version

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -330,18 +330,18 @@ export default class PublishCommand extends Command {
         return callback(null, { versions });
       } else {
         // Non-Independent Conventional-Commits Mode
-        // const currentFixedVersion = this.repository.lernaJson.version || "0.0.0";
-        //
-        // this.updates.forEach((update) => {
-        //   const pkg = update.package;
-        //   if (semver.lt(pkg.version, currentFixedVersion)) {
-        //     this.logger.verbose("publish",
-        //       `Overriding version of ${pkg.name} from  ${pkg.version} to ${currentFixedVersion}`);
-        //     pkg.version = currentFixedVersion;
-        //     return update;
-        //   }
-        //   return update;
-        // });
+        const currentFixedVersion = this.repository.lernaJson.version || "0.0.0";
+
+        this.updates.forEach((update) => {
+          const pkg = update.package;
+          if (semver.lt(pkg.version, currentFixedVersion)) {
+            this.logger.verbose("publish",
+              `Overriding version of ${pkg.name} from  ${pkg.version} to ${currentFixedVersion}`);
+            pkg.version = currentFixedVersion;
+            return update;
+          }
+          return update;
+        });
 
         let version = "0.0.0";
         this.recommendVersions(this.updates, ConventionalCommitUtilities.recommendFixedVersion,

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -330,18 +330,18 @@ export default class PublishCommand extends Command {
         return callback(null, { versions });
       } else {
         // Non-Independent Conventional-Commits Mode
-        const currentFixedVersion = this.repository.lernaJson.version || "0.0.0";
-
-        this.updates.forEach((update) => {
-          const pkg = update.package;
-          if (semver.lt(pkg.version, currentFixedVersion)) {
-            this.logger.verbose("publish",
-              `Overriding version of ${pkg.name} from  ${pkg.version} to ${currentFixedVersion}`);
-            pkg.version = currentFixedVersion;
-            return update;
-          }
-          return update;
-        });
+        // const currentFixedVersion = this.repository.lernaJson.version || "0.0.0";
+        //
+        // this.updates.forEach((update) => {
+        //   const pkg = update.package;
+        //   if (semver.lt(pkg.version, currentFixedVersion)) {
+        //     this.logger.verbose("publish",
+        //       `Overriding version of ${pkg.name} from  ${pkg.version} to ${currentFixedVersion}`);
+        //     pkg.version = currentFixedVersion;
+        //     return update;
+        //   }
+        //   return update;
+        // });
 
         let version = "0.0.0";
         this.recommendVersions(this.updates, ConventionalCommitUtilities.recommendFixedVersion,

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -330,6 +330,19 @@ export default class PublishCommand extends Command {
         return callback(null, { versions });
       } else {
         // Non-Independent Conventional-Commits Mode
+        const currentFixedVersion = this.repository.lernaJson.version || "0.0.0";
+
+        this.updates.forEach((update) => {
+          const pkg = update.package;
+          if (semver.lt(pkg.version, currentFixedVersion)) {
+            this.logger.verbose("publish",
+              `Overriding version of ${pkg.name} from  ${pkg.version} to ${currentFixedVersion}`);
+            pkg.version = currentFixedVersion;
+            return update;
+          }
+          return update;
+        });
+
         let version = "0.0.0";
         this.recommendVersions(this.updates, ConventionalCommitUtilities.recommendFixedVersion,
           (versionBump) => {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -330,7 +330,7 @@ export default class PublishCommand extends Command {
         return callback(null, { versions });
       } else {
         // Non-Independent Conventional-Commits Mode
-        const currentFixedVersion = this.repository.lernaJson.version || "0.0.0";
+        const currentFixedVersion = this.repository.lernaJson.version;
 
         this.updates.forEach((update) => {
           const pkg = update.package;
@@ -338,9 +338,7 @@ export default class PublishCommand extends Command {
             this.logger.verbose("publish",
               `Overriding version of ${pkg.name} from  ${pkg.version} to ${currentFixedVersion}`);
             pkg.version = currentFixedVersion;
-            return update;
           }
-          return update;
         });
 
         let version = "0.0.0";

--- a/test/fixtures/PublishCommand/normal-no-inter-dependencies/lerna.json
+++ b/test/fixtures/PublishCommand/normal-no-inter-dependencies/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/normal-no-inter-dependencies/package.json
+++ b/test/fixtures/PublishCommand/normal-no-inter-dependencies/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "normal-no-inter-dependencies"
+}

--- a/test/fixtures/PublishCommand/normal-no-inter-dependencies/packages/package-1/package.json
+++ b/test/fixtures/PublishCommand/normal-no-inter-dependencies/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/normal-no-inter-dependencies/packages/package-2/package.json
+++ b/test/fixtures/PublishCommand/normal-no-inter-dependencies/packages/package-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-2",
+  "version": "1.0.0"
+}

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -63,7 +63,7 @@ Array [
 exports[`packages: first feature added in fixed mode --conventional-commits 1`] = `
 Array [
   Object {
-    "foo": true,
+    "foobar": true,
     "name": "package-1",
     "version": "1.1.0",
   },
@@ -118,12 +118,12 @@ Array [
 exports[`packages: second feature added in fixed mode --conventional-commits 1`] = `
 Array [
   Object {
-    "foo": true,
+    "foobar": true,
     "name": "package-1",
     "version": "1.1.0",
   },
   Object {
-    "bar": true,
+    "baz": true,
     "name": "package-2",
     "version": "1.2.0",
   },
@@ -212,54 +212,6 @@ lerna info current version 1.0.0
 lerna info Checking for updated packages...
 lerna info Comparing with v1.0.0.
 lerna info No updated packages to publish. "
-`;
-
-exports[`stderr: first feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
-"lerna info version __TEST_VERSION__
-lerna info current version 1.0.1
-lerna info Checking for updated packages...
-lerna info Comparing with v1.0.1.
-lerna info auto-confirmed "
-`;
-
-exports[`stderr: first feature added in fixed mode --conventional-commits 1`] = `
-"lerna info version __TEST_VERSION__
-lerna info current version 1.0.1
-lerna info Checking for updated packages...
-lerna info Comparing with v1.0.1.
-lerna info auto-confirmed "
-`;
-
-exports[`stderr: initial commit in fixed mode --conventional-commits --force-publish=* 1`] = `
-"lerna info version __TEST_VERSION__
-lerna info current version 1.0.0
-lerna info Checking for updated packages...
-lerna info Comparing with initial commit.
-lerna info auto-confirmed "
-`;
-
-exports[`stderr: initial commit in fixed mode --conventional-commits 1`] = `
-"lerna info version __TEST_VERSION__
-lerna info current version 1.0.0
-lerna info Checking for updated packages...
-lerna info Comparing with initial commit.
-lerna info auto-confirmed "
-`;
-
-exports[`stderr: second feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
-"lerna info version __TEST_VERSION__
-lerna info current version 1.1.0
-lerna info Checking for updated packages...
-lerna info Comparing with v1.1.0.
-lerna info auto-confirmed "
-`;
-
-exports[`stderr: second feature added in fixed mode --conventional-commits 1`] = `
-"lerna info version __TEST_VERSION__
-lerna info current version 1.1.0
-lerna info Checking for updated packages...
-lerna info Comparing with v1.1.0.
-lerna info auto-confirmed "
 `;
 
 exports[`stderr: updates fixed versions 1`] = `

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`commit: first feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
+"v1.1.0
+"
+`;
+
+exports[`commit: first feature added in fixed mode --conventional-commits 1`] = `
+"v1.1.0
+"
+`;
+
+exports[`commit: initial commit in fixed mode --conventional-commits --force-publish=* 1`] = `
+"v1.0.1
+"
+`;
+
+exports[`commit: initial commit in fixed mode --conventional-commits 1`] = `
+"v1.0.1
+"
+`;
+
+exports[`commit: second feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
+"v1.2.0
+"
+`;
+
+exports[`commit: second feature added in fixed mode --conventional-commits 1`] = `
+"v1.2.0
+"
+`;
+
 exports[`commit: updates fixed versions 1`] = `
 "v1.0.1
 "
@@ -14,6 +44,90 @@ exports[`commit: updates independent versions 1`] = `
  - package-4@5.0.0
  - package-5@6.0.0
 "
+`;
+
+exports[`packages: first feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
+Array [
+  Object {
+    "foo": true,
+    "name": "package-1",
+    "version": "1.1.0",
+  },
+  Object {
+    "name": "package-2",
+    "version": "1.1.0",
+  },
+]
+`;
+
+exports[`packages: first feature added in fixed mode --conventional-commits 1`] = `
+Array [
+  Object {
+    "foo": true,
+    "name": "package-1",
+    "version": "1.1.0",
+  },
+  Object {
+    "name": "package-2",
+    "version": "1.0.1",
+  },
+]
+`;
+
+exports[`packages: initial commit in fixed mode --conventional-commits --force-publish=* 1`] = `
+Array [
+  Object {
+    "name": "package-1",
+    "version": "1.0.1",
+  },
+  Object {
+    "name": "package-2",
+    "version": "1.0.1",
+  },
+]
+`;
+
+exports[`packages: initial commit in fixed mode --conventional-commits 1`] = `
+Array [
+  Object {
+    "name": "package-1",
+    "version": "1.0.1",
+  },
+  Object {
+    "name": "package-2",
+    "version": "1.0.1",
+  },
+]
+`;
+
+exports[`packages: second feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
+Array [
+  Object {
+    "foo": true,
+    "name": "package-1",
+    "version": "1.2.0",
+  },
+  Object {
+    "bar": true,
+    "name": "package-2",
+    "version": "1.2.0",
+  },
+]
+`;
+
+exports[`packages: second feature added in fixed mode --conventional-commits 1`] = `
+Array [
+  Object {
+    "foo": true,
+    "name": "package-1",
+    "version": "1.1.0",
+  },
+  Object {
+    "bar": true,
+    "name": "package-2",
+    "version": "1.2.0",
+  },
+]
 `;
 
 exports[`packages: updates fixed versions 1`] = `
@@ -100,6 +214,54 @@ lerna info Comparing with v1.0.0.
 lerna info No updated packages to publish. "
 `;
 
+exports[`stderr: first feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info current version 1.0.1
+lerna info Checking for updated packages...
+lerna info Comparing with v1.0.1.
+lerna info auto-confirmed "
+`;
+
+exports[`stderr: first feature added in fixed mode --conventional-commits 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info current version 1.0.1
+lerna info Checking for updated packages...
+lerna info Comparing with v1.0.1.
+lerna info auto-confirmed "
+`;
+
+exports[`stderr: initial commit in fixed mode --conventional-commits --force-publish=* 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info current version 1.0.0
+lerna info Checking for updated packages...
+lerna info Comparing with initial commit.
+lerna info auto-confirmed "
+`;
+
+exports[`stderr: initial commit in fixed mode --conventional-commits 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info current version 1.0.0
+lerna info Checking for updated packages...
+lerna info Comparing with initial commit.
+lerna info auto-confirmed "
+`;
+
+exports[`stderr: second feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info current version 1.1.0
+lerna info Checking for updated packages...
+lerna info Comparing with v1.1.0.
+lerna info auto-confirmed "
+`;
+
+exports[`stderr: second feature added in fixed mode --conventional-commits 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info current version 1.1.0
+lerna info Checking for updated packages...
+lerna info Comparing with v1.1.0.
+lerna info auto-confirmed "
+`;
+
 exports[`stderr: updates fixed versions 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info current version 1.0.0
@@ -117,6 +279,52 @@ lerna info auto-confirmed "
 `;
 
 exports[`stdout: exit 0 when no updates 1`] = `""`;
+
+exports[`stdout: first feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
+"
+Changes:
+ - package-1: 1.0.1 => 1.1.0
+ - package-2: 1.0.1 => 1.1.0
+"
+`;
+
+exports[`stdout: first feature added in fixed mode --conventional-commits 1`] = `
+"
+Changes:
+ - package-1: 1.0.1 => 1.1.0
+"
+`;
+
+exports[`stdout: initial commit in fixed mode --conventional-commits --force-publish=* 1`] = `
+"
+Changes:
+ - package-1: 1.0.0 => 1.0.1
+ - package-2: 1.0.0 => 1.0.1
+"
+`;
+
+exports[`stdout: initial commit in fixed mode --conventional-commits 1`] = `
+"
+Changes:
+ - package-1: 1.0.0 => 1.0.1
+ - package-2: 1.0.0 => 1.0.1
+"
+`;
+
+exports[`stdout: second feature added in fixed mode --conventional-commits --force-publish=* 1`] = `
+"
+Changes:
+ - package-1: 1.1.0 => 1.2.0
+ - package-2: 1.1.0 => 1.2.0
+"
+`;
+
+exports[`stdout: second feature added in fixed mode --conventional-commits 1`] = `
+"
+Changes:
+ - package-2: 1.1.0 => 1.2.0
+"
+`;
 
 exports[`stdout: updates fixed versions 1`] = `
 "

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -2,6 +2,9 @@ import execa from "execa";
 import fs from "fs-extra";
 import globby from "globby";
 import normalizeNewline from "normalize-newline";
+import writeJsonFile from "write-json-file";
+import loadJsonFile from "load-json-file";
+import path from "path";
 
 import { LERNA_BIN } from "../helpers/constants";
 import initFixture from "../helpers/initFixture";
@@ -9,6 +12,30 @@ import loadPkgManifests from "../helpers/loadPkgManifests";
 
 const lastCommitMessage = (cwd) =>
   execa.stdout("git", ["log", "-1", "--format=%B"], { cwd }).then(normalizeNewline);
+
+async function performAndVerifyLernaPublish(cwd, args, stdoutSnapshot, stderrSnapshot) {
+  const {stdout, stderr} = await execa(LERNA_BIN, args, {cwd});
+  expect(stdout).toMatchSnapshot(stdoutSnapshot);
+  expect(stderr).toMatchSnapshot(stderrSnapshot);
+}
+
+async function verifyPkgsAndCommitMsg(cwd, pkgSnapshot, commitMsgSnapshot) {
+  const [allPackageJsons, commitMessage] = await Promise.all([
+    loadPkgManifests(cwd),
+    lastCommitMessage(cwd),
+  ]);
+
+  expect(allPackageJsons).toMatchSnapshot(pkgSnapshot);
+  expect(commitMessage).toMatchSnapshot(commitMsgSnapshot);
+}
+
+async function commitChangeToPackage(cwd, packageName, commitMsg, data) {
+  const packageJSONPath = path.join(cwd, 'packages', packageName, 'package.json');
+  const pkg = await loadJsonFile(packageJSONPath);
+  await writeJsonFile(packageJSONPath, Object.assign(pkg, data));
+  await execa("git", ["add", "."], {cwd});
+  return await execa("git", ["commit", "-m", commitMsg], {cwd});
+}
 
 describe("lerna publish", () => {
   test.concurrent("exit 0 when no updates", async () => {
@@ -68,6 +95,99 @@ describe("lerna publish", () => {
 
     expect(allPackageJsons).toMatchSnapshot("packages: updates independent versions");
     expect(commitMessage).toMatchSnapshot("commit: updates independent versions");
+  });
+
+  test.concurrent("fixed mode --conventional-commits recommends versions for each publish", async () => {
+    const cwd = await initFixture("PublishCommand/normal-no-inter-dependencies", "chore: Init repo");
+    const args = [
+      "publish",
+      "--conventional-commits",
+      // "--skip-git", Note: git is not skipped to ensure creating tags for each publish execution works
+      "--skip-npm",
+      "--yes",
+    ];
+
+    await performAndVerifyLernaPublish(
+      cwd, args,
+      "stdout: initial commit in fixed mode --conventional-commits",
+      "stderr: initial commit in fixed mode --conventional-commits");
+
+    await verifyPkgsAndCommitMsg(cwd,
+      "packages: initial commit in fixed mode --conventional-commits",
+      "commit: initial commit in fixed mode --conventional-commits"
+    );
+
+    await commitChangeToPackage(cwd, 'package-1', "feat: Add foo feature", {foo: true});
+
+    await performAndVerifyLernaPublish(
+      cwd, args,
+      "stdout: first feature added in fixed mode --conventional-commits",
+      "stderr: first feature added in fixed mode --conventional-commits");
+
+    await verifyPkgsAndCommitMsg(cwd,
+      "packages: first feature added in fixed mode --conventional-commits",
+      "commit: first feature added in fixed mode --conventional-commits"
+    );
+
+    await commitChangeToPackage(cwd, 'package-2', "feat: Add bar feature", {bar: true});
+
+    await performAndVerifyLernaPublish(
+      cwd, args,
+      "stdout: second feature added in fixed mode --conventional-commits",
+      "stderr: second feature added in fixed mode --conventional-commits");
+
+    await verifyPkgsAndCommitMsg(cwd,
+      "packages: second feature added in fixed mode --conventional-commits",
+      "commit: second feature added in fixed mode --conventional-commits"
+    );
+
+  });
+
+  test.concurrent("fixed mode --conventional-commits --force-publish=*", async () => {
+    const cwd = await initFixture("PublishCommand/normal-no-inter-dependencies", "chore: Init repo");
+    const args = [
+      "publish",
+      "--force-publish=*",
+      "--conventional-commits",
+      // "--skip-git", Note: git is not skipped to ensure creating tags for each publish execution works
+      "--skip-npm",
+      "--yes",
+    ];
+
+    await performAndVerifyLernaPublish(
+      cwd, args,
+      "stdout: initial commit in fixed mode --conventional-commits --force-publish=*",
+      "stderr: initial commit in fixed mode --conventional-commits --force-publish=*");
+
+    await verifyPkgsAndCommitMsg(cwd,
+      "packages: initial commit in fixed mode --conventional-commits --force-publish=*",
+      "commit: initial commit in fixed mode --conventional-commits --force-publish=*"
+    );
+
+    await commitChangeToPackage(cwd, 'package-1', "feat: Add foo feature", {foo: true});
+
+    await performAndVerifyLernaPublish(
+      cwd, args,
+      "stdout: first feature added in fixed mode --conventional-commits --force-publish=*",
+      "stderr: first feature added in fixed mode --conventional-commits --force-publish=*");
+
+    await verifyPkgsAndCommitMsg(cwd,
+      "packages: first feature added in fixed mode --conventional-commits --force-publish=*",
+      "commit: first feature added in fixed mode --conventional-commits --force-publish=*"
+    );
+
+    await commitChangeToPackage(cwd, 'package-2', "feat: Add bar feature", {bar: true});
+
+    await performAndVerifyLernaPublish(
+      cwd, args,
+      "stdout: second feature added in fixed mode --conventional-commits --force-publish=*",
+      "stderr: second feature added in fixed mode --conventional-commits --force-publish=*");
+
+    await verifyPkgsAndCommitMsg(cwd,
+      "packages: second feature added in fixed mode --conventional-commits --force-publish=*",
+      "commit: second feature added in fixed mode --conventional-commits --force-publish=*"
+    );
+
   });
 
   // TODO: stabilize timestamp of changelog output


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix --conventional-commits in fixed mode recommending versions that have already been released. 

Overrides the version of a package when asking for a version bump if it is < the current fixed version, ie the version field in lerna.json 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/lerna/lerna/issues/988

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually, following the repro steps in https://github.com/lerna/lerna/issues/988

Added new Integration tests for `--conventional-commits`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
