### PR TITLE
Fix silly level log output for --conventional-commits

### DIFF
--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -94,7 +94,7 @@ export default class ConventionalCommitUtilities {
         `);
     }
 
-    log.silly("updateIndependentChangelog", "writing new entry: %j", newEntry);
+    log.silly(type, "writing new entry: %j", newEntry);
 
     // CHANGELOG entries start with <a name=, we remove
     // the header if it exists by starting at the first entry.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix silly level log output for --conventional-commits changelog generation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Silly level logging was outputting `updateIndependentChangelog` even when running in fixed mode. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
