### PR TITLE
Only diff package locations, not the entire repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "fs-extra": "^4.0.1",
     "get-port": "^3.2.0",
     "glob": "^7.1.2",
+    "glob-parent": "^3.1.0",
     "globby": "^6.1.0",
     "graceful-fs": "^4.1.11",
     "inquirer": "^3.2.2",

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -1,4 +1,5 @@
 import findUp from "find-up";
+import globParent from "glob-parent";
 import loadJsonFile from "load-json-file";
 import log from "npmlog";
 import path from "path";
@@ -59,6 +60,11 @@ export default class Repository {
       return this.packageJson.workspaces;
     }
     return this.lernaJson.packages || [DEFAULT_PACKAGE_GLOB];
+  }
+
+  get packageParentDirs() {
+    return this.packageConfigs.map(globParent)
+      .map(parentDir => path.resolve(this.rootPath, parentDir));
   }
 
   get packages() {

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -52,6 +52,8 @@ export default class DiffCommand extends Command {
 
     if (targetPackage) {
       this.args.push("--", targetPackage.location);
+    } else {
+      this.args.push("--", ...this.repository.packageParentDirs);
     }
 
     callback(null, true);

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -33,7 +33,7 @@ describe("DiffCommand", () => {
   }));
   afterEach(() => jest.resetAllMocks());
 
-  it("should diff everything from the first commit", () => {
+  it("should diff packages from the first commit", () => {
     GitUtilities.getFirstCommit.mockImplementation(() => "beefcafe");
     ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
 
@@ -44,6 +44,8 @@ describe("DiffCommand", () => {
           "diff",
           "beefcafe",
           "--color=auto",
+          "--",
+          path.join(testDir, "packages"),
         ],
         expect.objectContaining({
           cwd: testDir,
@@ -53,7 +55,7 @@ describe("DiffCommand", () => {
     });
   });
 
-  it("should diff everything from the most recent tag", () => {
+  it("should diff packages from the most recent tag", () => {
     GitUtilities.hasTags.mockImplementation(() => true);
     GitUtilities.getLastTaggedCommit.mockImplementation(() => "cafedead");
     ChildProcessUtilities.spawn.mockImplementation(callbackSuccess);
@@ -65,6 +67,8 @@ describe("DiffCommand", () => {
           "diff",
           "cafedead",
           "--color=auto",
+          "--",
+          path.join(testDir, "packages"),
         ],
         expect.objectContaining({
           cwd: testDir,

--- a/test/Repository.js
+++ b/test/Repository.js
@@ -124,6 +124,24 @@ describe("Repository", () => {
     });
   });
 
+  describe("get .packageParentDirs", () => {
+    it("returns a list of package parent directories", () => {
+      const repo = new Repository(testDir);
+      repo.lernaJson.packages = [
+        ".",
+        "packages/*",
+        "dir/nested/*",
+        "globstar/**",
+      ];
+      expect(repo.packageParentDirs).toEqual([
+        testDir,
+        path.join(testDir, "packages"),
+        path.join(testDir, "dir/nested"),
+        path.join(testDir, "globstar"),
+      ])
+    });
+  });
+
   describe("get .packages", () => {
     it("returns the list of packages", () => {
       const repo = new Repository(testDir);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1802,6 +1802,13 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -2047,6 +2054,10 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
+is-extglob@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -2068,6 +2079,12 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  dependencies:
+    is-extglob "^2.1.0"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -2968,6 +2985,10 @@ parse-json@^3.0.0:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
 
 path-exists@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Contrary to the description of `lerna diff`, we weren't properly filtering the general case.

## Description
We pass the root directory paths of all configured `packages` locations to `git diff -- [dirs..]`, which acts as a filter for the diff output.

## Motivation and Context
It wasn't doing anything useful, moreso than anyone could do with `git diff v1.0.0..HEAD`.
Also, lockfiles are extreeeemely noisy nowadays, and it was bugging me.

## How Has This Been Tested?
updated tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
