### PR TITLE
Add `lerna link` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,14 @@ repo.  Each commit is modified to make changes relative to the package
 directory.  So, for example, the commit that added `package.json` will
 instead add `packages/<directory-name>/package.json`.
 
+### link
+
+```sh
+$ lerna link
+```
+
+Symlink together all Lerna `packages` that are dependencies of each other in the current Lerna repo.
+
 ## Misc
 
 Lerna will log to a `lerna-debug.log` file (same as `npm-debug.log`) when it encounters an error running a command.

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -224,6 +224,9 @@ export default class PackageUtilities {
   /**
    * Symlink all packages to the packages/node_modules directory
    * Symlink package binaries to dependent packages' node_modules/.bin directory
+   * @param {Array.<Package>} packages
+   * @param {Object} packageGraph
+   * @param {Object} logger
    * @param {Function} callback
    */
   static symlinkPackages(packages, packageGraph, logger, callback) {

--- a/src/commands/LinkCommand.js
+++ b/src/commands/LinkCommand.js
@@ -1,0 +1,30 @@
+import Command from "../Command";
+import PackageUtilities from "../PackageUtilities";
+
+export function handler(argv) {
+  return new LinkCommand(argv._, argv).run();
+}
+
+export const command = "link";
+
+export const describe = "Symlink together all packages which are dependencies of each other";
+
+export const builder = {};
+
+export default class LinkCommand extends Command {
+  get defaultOptions() {
+    return {};
+  }
+
+  initialize(callback) {
+    this.exact = this.options.exact;
+
+    callback(null, true);
+  }
+
+  execute(callback) {
+    const {packages, packageGraph, logger} = this;
+
+    PackageUtilities.symlinkPackages(packages, packageGraph, logger, callback);
+  }
+}

--- a/src/commands/LinkCommand.js
+++ b/src/commands/LinkCommand.js
@@ -2,7 +2,8 @@ import Command from "../Command";
 import PackageUtilities from "../PackageUtilities";
 
 export function handler(argv) {
-  return new LinkCommand(argv._, argv).run();
+  new LinkCommand([argv.pkg], argv, argv._cwd).run()
+    .then(argv._onFinish, argv._onFinish);
 }
 
 export const command = "link";
@@ -12,13 +13,7 @@ export const describe = "Symlink together all packages which are dependencies of
 export const builder = {};
 
 export default class LinkCommand extends Command {
-  get defaultOptions() {
-    return {};
-  }
-
   initialize(callback) {
-    this.exact = this.options.exact;
-
     callback(null, true);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
 import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
+import LinkCommand from "./commands/LinkCommand";
 
 export default {
   BootstrapCommand,
@@ -19,5 +20,6 @@ export default {
   InitCommand,
   RunCommand,
   ExecCommand,
-  LsCommand
+  LsCommand,
+  LinkCommand
 };

--- a/test/LinkCommand.js
+++ b/test/LinkCommand.js
@@ -5,12 +5,14 @@ import FileSystemUtilities from "../src/FileSystemUtilities";
 
 // helpers
 import callsBack from "./helpers/callsBack";
-import exitWithCode from "./helpers/exitWithCode";
 import initFixture from "./helpers/initFixture";
 import normalizeRelativeDir from "./helpers/normalizeRelativeDir";
+import yargsRunner from "./helpers/yargsRunner";
 
 // file under test
-import LinkCommand from "../src/commands/LinkCommand";
+import * as commandModule from "../src/commands/LinkCommand";
+
+const run = yargsRunner(commandModule);
 
 // silence logs
 log.level = "silent";
@@ -41,32 +43,15 @@ describe("LinkCommand", () => {
   afterEach(() => jest.resetAllMocks());
 
   describe("with local package dependencies", () => {
-    let testDir;
-
-    beforeEach(() => initFixture("LinkCommand/basic").then((dir) => {
-      testDir = dir;
-    }));
-
     beforeEach(stubSymlink);
     afterEach(resetSymlink);
 
-    it("should symlink all packages", (done) => {
-      const linkCommand = new LinkCommand([], {}, testDir);
+    it("should symlink all packages", async () => {
+      const testDir = await initFixture("LinkCommand/basic");
+      const lernaLink = run(testDir);
+      await lernaLink();
 
-      linkCommand.runValidations();
-      linkCommand.runPreparations();
-
-      linkCommand.runCommand(exitWithCode(0, (err) => {
-        if (err) return done.fail(err);
-
-        try {
-          expect(symlinkedDirectories(testDir)).toMatchSnapshot();
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      }));
+      expect(symlinkedDirectories(testDir)).toMatchSnapshot();
     });
   });
 });

--- a/test/LinkCommand.js
+++ b/test/LinkCommand.js
@@ -1,0 +1,72 @@
+import log from "npmlog";
+
+// mocked or stubbed modules
+import FileSystemUtilities from "../src/FileSystemUtilities";
+
+// helpers
+import callsBack from "./helpers/callsBack";
+import exitWithCode from "./helpers/exitWithCode";
+import initFixture from "./helpers/initFixture";
+import normalizeRelativeDir from "./helpers/normalizeRelativeDir";
+
+// file under test
+import LinkCommand from "../src/commands/LinkCommand";
+
+// silence logs
+log.level = "silent";
+
+// stub symlink in certain tests to reduce redundancy
+const fsSymlink = FileSystemUtilities.symlink;
+const resetSymlink = () => {
+  FileSystemUtilities.symlink = fsSymlink;
+};
+const stubSymlink = () => {
+  FileSystemUtilities.symlink = jest.fn(callsBack());
+};
+
+// object snapshots have sorted keys
+const symlinkedDirectories = (testDir) =>
+  FileSystemUtilities.symlink.mock.calls.map((args) => {
+    return {
+      _src: normalizeRelativeDir(testDir, args[0]),
+      dest: normalizeRelativeDir(testDir, args[1]),
+      type: args[2],
+    };
+  });
+
+describe("LinkCommand", () => {
+  beforeEach(() => {
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  describe("with local package dependencies", () => {
+    let testDir;
+
+    beforeEach(() => initFixture("LinkCommand/basic").then((dir) => {
+      testDir = dir;
+    }));
+
+    beforeEach(stubSymlink);
+    afterEach(resetSymlink);
+
+    it("should symlink all packages", (done) => {
+      const linkCommand = new LinkCommand([], {}, testDir);
+
+      linkCommand.runValidations();
+      linkCommand.runPreparations();
+
+      linkCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done.fail(err);
+
+        try {
+          expect(symlinkedDirectories(testDir)).toMatchSnapshot();
+
+          done();
+        } catch (ex) {
+          done.fail(ex);
+        }
+      }));
+    });
+  });
+});

--- a/test/__snapshots__/LinkCommand.js.snap
+++ b/test/__snapshots__/LinkCommand.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LinkCommand with local package dependencies should symlink all packages 1`] = `
+Array [
+  Object {
+    "_src": "packages/package-1",
+    "dest": "packages/package-2/node_modules/@test/package-1",
+    "type": "junction",
+  },
+  Object {
+    "_src": "packages/package-1",
+    "dest": "packages/package-3/node_modules/@test/package-1",
+    "type": "junction",
+  },
+  Object {
+    "_src": "packages/package-2",
+    "dest": "packages/package-3/node_modules/@test/package-2",
+    "type": "junction",
+  },
+  Object {
+    "_src": "packages/package-2/cli.js",
+    "dest": "packages/package-3/node_modules/.bin/package-2",
+    "type": "exec",
+  },
+  Object {
+    "_src": "packages/package-3",
+    "dest": "packages/package-4/node_modules/package-3",
+    "type": "junction",
+  },
+  Object {
+    "_src": "packages/package-3/cli1.js",
+    "dest": "packages/package-4/node_modules/.bin/package3cli1",
+    "type": "exec",
+  },
+  Object {
+    "_src": "packages/package-3/cli2.js",
+    "dest": "packages/package-4/node_modules/.bin/package3cli2",
+    "type": "exec",
+  },
+]
+`;

--- a/test/fixtures/LinkCommand/basic/lerna.json
+++ b/test/fixtures/LinkCommand/basic/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/LinkCommand/basic/package.json
+++ b/test/fixtures/LinkCommand/basic/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/LinkCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/LinkCommand/basic/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/LinkCommand/basic/packages/package-2/cli.js
+++ b/test/fixtures/LinkCommand/basic/packages/package-2/cli.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/LinkCommand/basic/packages/package-2/package.json
+++ b/test/fixtures/LinkCommand/basic/packages/package-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/package-2",
+  "version": "1.0.0",
+  "bin": "cli.js",
+  "dependencies": {
+    "@test/package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/LinkCommand/basic/packages/package-3/cli1.js
+++ b/test/fixtures/LinkCommand/basic/packages/package-3/cli1.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/LinkCommand/basic/packages/package-3/cli2.js
+++ b/test/fixtures/LinkCommand/basic/packages/package-3/cli2.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/LinkCommand/basic/packages/package-3/package.json
+++ b/test/fixtures/LinkCommand/basic/packages/package-3/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "bin": {
+    "package3cli1": "cli1.js",
+    "package3cli2": "cli2.js"
+  },
+  "devDependencies": {
+    "@test/package-1": "^1.0.0",
+    "@test/package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/LinkCommand/basic/packages/package-4/package.json
+++ b/test/fixtures/LinkCommand/basic/packages/package-4/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/package-1": "^0.0.0",
+    "package-3": "^1.0.0"
+  }
+}


### PR DESCRIPTION
[![Sponsored by Immowelt](https://img.shields.io/badge/sponsored%20by-immowelt-yellow.svg?colorB=ffb200)](https://stackshare.io/immowelt-group/)

@evocateur

## Description
This commit adds a new 'link' command to the CLI which will create symlinks across the lerna package dependencies. This command was requested in #341 and solves issues with using 'npm prune' with lerna based repositories, e.g. 'npm prune' removes extranous packages, which include the symlinks of lerna.

## Motivation and Context
Since the bootstrap command is a bit heavy, especially while hoisting, I opted for a seperate command since the bootsrap command is pretty complex as of now anyway and I don't think it will be particularly usefull to add option after option.

I also refactored most of the code, e.g. made it more purely functional, regarding the symlinkPackages method and extracted it into the PackageUtilities.

## How Has This Been Tested?
I've used the Bootstrap test as a base and included a test case with fixtures which checks if all of the symlinks are created accordingly with Jests snapshots feature.

All of the pre-existing tests including the code style checks are green. (Except for the Node 4 integration test, but this is also failing on master itself)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
