### PR TITLE
Improve logging of package lifecycle errors during bootstrap

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -339,14 +339,7 @@ export default class Command {
           // If we have package details we can direct the developers attention
           // to that specific package.
           if (err.pkg) {
-            log.error(method, `Error occured with '${err.pkg.name}' while ` +
-              `running '${err.cmd}'`);
-            log.error(method, `    See logs below for details:`);
-            log.pause();
-            console.error('\n');
-            console.error(err.stdout, err.stderr);
-            console.error('\n');
-            log.resume();
+            this._logPackageError(method, err);
             this._complete(err, 1, callback);
           } else {
             log.error(method, "callback with error\n", err);
@@ -421,6 +414,35 @@ export default class Command {
 
   execute() {
     throw new Error("command.execute() needs to be implemented.");
+  }
+
+  _logPackageError(method, err) {
+    log.error(method, dedent`
+      Error occured with '${err.pkg.name}' while running '${err.cmd}'
+    `);
+
+    const pkgPrefix = `${err.cmd} [${err.pkg.name}]`;
+    log.error(pkgPrefix, `Output from stdout:`);
+    log.pause();
+    console.error(err.stdout);
+
+    log.resume();
+    log.error(pkgPrefix, `Output from stderr:`);
+    log.pause();
+    console.error(err.stderr);
+
+    log.resume();
+    log.error(pkgPrefix, `Stacktrace:`);
+    log.pause();
+    console.error(err.stack);
+
+    // Below is just to ensure something sensible is printed after the long
+    // stream of logs
+    console.error();
+    log.resume();
+    log.error(method, dedent`
+      Error occured with '${err.pkg.name}' while running '${err.cmd}'
+    `);
   }
 }
 

--- a/src/Command.js
+++ b/src/Command.js
@@ -336,8 +336,22 @@ export default class Command {
 
       this[method]((err, completed, code = 0) => {
         if (err) {
-          log.error(method, "callback with error\n", err);
-          this._complete(err, 1, callback);
+          // If we have package details we can direct the developers attention
+          // to that specific package.
+          if (err.pkg) {
+            log.error(method, `Error occured with '${err.pkg.name}' while ` +
+              `running '${err.cmd}'`);
+            log.error(method, `    See logs below for details:`);
+            log.pause();
+            console.error('\n');
+            console.error(err.stdout, err.stderr);
+            console.error('\n');
+            log.resume();
+            this._complete(err, 1, callback);
+          } else {
+            log.error(method, "callback with error\n", err);
+            this._complete(err, 1, callback);
+          }
         } else if (!completed) {
           // an early exit is rarely an error
           log.verbose(method, "exited early");

--- a/src/Command.js
+++ b/src/Command.js
@@ -431,14 +431,8 @@ export default class Command {
     log.pause();
     console.error(err.stderr);
 
-    log.resume();
-    log.error(pkgPrefix, `Stacktrace:`);
-    log.pause();
-    console.error(err.stack);
-
     // Below is just to ensure something sensible is printed after the long
     // stream of logs
-    console.error();
     log.resume();
     log.error(method, dedent`
       Error occured with '${err.pkg.name}' while running '${err.cmd}'

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -143,6 +143,9 @@ export default class BootstrapCommand extends Command {
       pkg.runScript(scriptName, (err) => {
         tracker.silly(pkg.name);
         tracker.completeWork(1);
+        if (err) {
+          err.pkg = pkg;
+        }
         done(err);
       });
     }, this.concurrency, (err) => {


### PR DESCRIPTION
Changes the output for failing bootstrap commands

## Description
Instead of using npm log to continue logging with extra lerna prefixes and relying on the formatting of npmlog, just use the available logs from the failing command to convey meaningful information.

**Original Output**
```
lerna info version 2.0.0
lerna info Bootstrapping 2 packages
lerna info lifecycle preinstall
lerna info Symlinking packages and binaries
lerna info lifecycle postinstall
lerna info lifecycle prepublish
lerna ERR! execute Error: Command failed: npm run prepublish
lerna ERR! execute [18:21:31] 'build-package (workbox-core) ["dev"]' errored after 68 ms
lerna ERR! execute [18:21:31] Error: Unexpected token
lerna ERR! execute     at error (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:177:12)
lerna ERR! execute     at Module.error$1 [as error] (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8434:2)
lerna ERR! execute     at tryParse (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8133:10)
lerna ERR! execute     at new Module (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8169:14)
lerna ERR! execute     at /home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:10010:17
lerna ERR! execute     at <anonymous>
lerna ERR! execute     at process._tickDomainCallback (internal/process/next_tick.js:208:7)
lerna ERR! execute [18:21:31] 'build-packages:build' errored after 70 ms
lerna ERR! execute [18:21:31] 'build-packages' errored after 82 ms
lerna ERR! execute npm ERR! code ELIFECYCLE
lerna ERR! execute npm ERR! errno 1
lerna ERR! execute npm ERR! workbox-core@1.2.0 prepublish: `gulp build-packages --package workbox-core`
lerna ERR! execute npm ERR! Exit status 1
lerna ERR! execute npm ERR! 
lerna ERR! execute npm ERR! Failed at the workbox-core@1.2.0 prepublish script.
lerna ERR! execute npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
lerna ERR! execute npm WARN Local package.json exists, but node_modules missing, did you mean to install?
lerna ERR! execute 
lerna ERR! execute npm ERR! A complete log of this run can be found in:
lerna ERR! execute npm ERR!     /home/matt/.npm/_logs/2017-08-31T01_21_31_528Z-debug.log
lerna ERR! execute 
lerna ERR! execute > workbox-core@1.2.0 prepublish /home/matt/Projects/Code/workbox/packages/workbox-core
lerna ERR! execute > gulp build-packages --package workbox-core
lerna ERR! execute 
lerna ERR! execute [18:21:30] Working directory changed to ~/Projects/Code/workbox
lerna ERR! execute [18:21:31] Using gulpfile ~/Projects/Code/workbox/gulpfile.js
lerna ERR! execute [18:21:31] Starting 'build-packages'...
lerna ERR! execute [18:21:31] Starting 'build-packages:clean'...
lerna ERR! execute [18:21:31] Starting 'build-packages:clean (workbox-core)'...
lerna ERR! execute [18:21:31] Finished 'build-packages:clean (workbox-core)' after 1.77 ms
lerna ERR! execute [18:21:31] Finished 'build-packages:clean' after 2.91 ms
lerna ERR! execute [18:21:31] Starting 'build-packages:generate-browser-entry'...
lerna ERR! execute [18:21:31] Starting 'build-packages:generate-browser-entry (workbox-core)'...
lerna ERR! execute [18:21:31] Finished 'build-packages:generate-browser-entry (workbox-core)' after 6.85 ms
lerna ERR! execute [18:21:31] Finished 'build-packages:generate-browser-entry' after 7.42 ms
lerna ERR! execute [18:21:31] Starting 'build-packages:build'...
lerna ERR! execute [18:21:31] Starting 'build-package (workbox-core) ["dev"]'...
lerna ERR! execute [Workbox Gulp Log]: Building Browser Bundle for workbox-core.
lerna ERR! execute [Workbox Gulp Log]:     Namespace: google.workbox.core
lerna ERR! execute [Workbox Gulp Log]:     Filename: workbox-core.dev.js
lerna ERR! execute 
lerna ERR! execute     at Promise.all.then.arr (/home/matt/Projects/Code/workbox/node_modules/execa/index.js:210:11)
lerna ERR! execute     at <anonymous>
lerna ERR! execute     at process._tickCallback (internal/process/next_tick.js:169:7)
lerna ERR! execute  callback with error
lerna ERR! execute  { Error: Command failed: npm run prepublish
lerna ERR! execute [18:21:31] 'build-package (workbox-core) ["dev"]' errored after 68 ms
lerna ERR! execute [18:21:31] Error: Unexpected token
lerna ERR! execute     at error (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:177:12)
lerna ERR! execute     at Module.error$1 [as error] (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8434:2)
lerna ERR! execute     at tryParse (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8133:10)
lerna ERR! execute     at new Module (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8169:14)
lerna ERR! execute     at /home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:10010:17
lerna ERR! execute     at <anonymous>
lerna ERR! execute     at process._tickDomainCallback (internal/process/next_tick.js:208:7)
lerna ERR! execute [18:21:31] 'build-packages:build' errored after 70 ms
lerna ERR! execute [18:21:31] 'build-packages' errored after 82 ms
lerna ERR! execute npm ERR! code ELIFECYCLE
lerna ERR! execute npm ERR! errno 1
lerna ERR! execute npm ERR! workbox-core@1.2.0 prepublish: `gulp build-packages --package workbox-core`
lerna ERR! execute npm ERR! Exit status 1
lerna ERR! execute npm ERR! 
lerna ERR! execute npm ERR! Failed at the workbox-core@1.2.0 prepublish script.
lerna ERR! execute npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
lerna ERR! execute npm WARN Local package.json exists, but node_modules missing, did you mean to install?
lerna ERR! execute 
lerna ERR! execute npm ERR! A complete log of this run can be found in:
lerna ERR! execute npm ERR!     /home/matt/.npm/_logs/2017-08-31T01_21_31_528Z-debug.log
lerna ERR! execute 
lerna ERR! execute > workbox-core@1.2.0 prepublish /home/matt/Projects/Code/workbox/packages/workbox-core
lerna ERR! execute > gulp build-packages --package workbox-core
lerna ERR! execute 
lerna ERR! execute [18:21:30] Working directory changed to ~/Projects/Code/workbox
lerna ERR! execute [18:21:31] Using gulpfile ~/Projects/Code/workbox/gulpfile.js
lerna ERR! execute [18:21:31] Starting 'build-packages'...
lerna ERR! execute [18:21:31] Starting 'build-packages:clean'...
lerna ERR! execute [18:21:31] Starting 'build-packages:clean (workbox-core)'...
lerna ERR! execute [18:21:31] Finished 'build-packages:clean (workbox-core)' after 1.77 ms
lerna ERR! execute [18:21:31] Finished 'build-packages:clean' after 2.91 ms
lerna ERR! execute [18:21:31] Starting 'build-packages:generate-browser-entry'...
lerna ERR! execute [18:21:31] Starting 'build-packages:generate-browser-entry (workbox-core)'...
lerna ERR! execute [18:21:31] Finished 'build-packages:generate-browser-entry (workbox-core)' after 6.85 ms
lerna ERR! execute [18:21:31] Finished 'build-packages:generate-browser-entry' after 7.42 ms
lerna ERR! execute [18:21:31] Starting 'build-packages:build'...
lerna ERR! execute [18:21:31] Starting 'build-package (workbox-core) ["dev"]'...
lerna ERR! execute [Workbox Gulp Log]: Building Browser Bundle for workbox-core.
lerna ERR! execute [Workbox Gulp Log]:     Namespace: google.workbox.core
lerna ERR! execute [Workbox Gulp Log]:     Filename: workbox-core.dev.js
lerna ERR! execute 
lerna ERR! execute     at Promise.all.then.arr (/home/matt/Projects/Code/workbox/node_modules/execa/index.js:210:11)
lerna ERR! execute     at <anonymous>
lerna ERR! execute     at process._tickCallback (internal/process/next_tick.js:169:7)
lerna ERR! execute   stack: 'Error: Command failed: npm run prepublish\n[18:21:31] \'build-package (workbox-core) ["dev"]\' errored after 68 ms\n[18:21:31] Error: Unexpected token\n    at error (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:177:12)\n    at Module.error$1 [as error] (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8434:2)\n    at tryParse (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8133:10)\n    at new Module (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8169:14)\n    at /home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:10010:17\n    at <anonymous>\n    at process._tickDomainCallback (internal/process/next_tick.js:208:7)\n[18:21:31] \'build-packages:build\' errored after 70 ms\n[18:21:31] \'build-packages\' errored after 82 ms\nnpm ERR! code ELIFECYCLE\nnpm ERR! errno 1\nnpm ERR! workbox-core@1.2.0 prepublish: `gulp build-packages --package workbox-core`\nnpm ERR! Exit status 1\nnpm ERR! \nnpm ERR! Failed at the workbox-core@1.2.0 prepublish script.\nnpm ERR! This is probably not a problem with npm. There is likely additional logging output above.\nnpm WARN Local package.json exists, but node_modules missing, did you mean to install?\n\nnpm ERR! A complete log of this run can be found in:\nnpm ERR!     /home/matt/.npm/_logs/2017-08-31T01_21_31_528Z-debug.log\n\n> workbox-core@1.2.0 prepublish /home/matt/Projects/Code/workbox/packages/workbox-core\n> gulp build-packages --package workbox-core\n\n[18:21:30] Working directory changed to ~/Projects/Code/workbox\n[18:21:31] Using gulpfile ~/Projects/Code/workbox/gulpfile.js\n[18:21:31] Starting \'build-packages\'...\n[18:21:31] Starting \'build-packages:clean\'...\n[18:21:31] Starting \'build-packages:clean (workbox-core)\'...\n[18:21:31] Finished \'build-packages:clean (workbox-core)\' after 1.77 ms\n[18:21:31] Finished \'build-packages:clean\' after 2.91 ms\n[18:21:31] Starting \'build-packages:generate-browser-entry\'...\n[18:21:31] Starting \'build-packages:generate-browser-entry (workbox-core)\'...\n[18:21:31] Finished \'build-packages:generate-browser-entry (workbox-core)\' after 6.85 ms\n[18:21:31] Finished \'build-packages:generate-browser-entry\' after 7.42 ms\n[18:21:31] Starting \'build-packages:build\'...\n[18:21:31] Starting \'build-package (workbox-core) ["dev"]\'...\n[Workbox Gulp Log]: Building Browser Bundle for workbox-core.\n[Workbox Gulp Log]:     Namespace: google.workbox.core\n[Workbox Gulp Log]:     Filename: workbox-core.dev.js\n\n    at Promise.all.then.arr (/home/matt/Projects/Code/workbox/node_modules/execa/index.js:210:11)\n    at <anonymous>\n    at process._tickCallback (internal/process/next_tick.js:169:7)',
lerna ERR! execute   code: 1,
lerna ERR! execute   killed: false,
lerna ERR! execute   stdout: '\n> workbox-core@1.2.0 prepublish /home/matt/Projects/Code/workbox/packages/workbox-core\n> gulp build-packages --package workbox-core\n\n[18:21:30] Working directory changed to ~/Projects/Code/workbox\n[18:21:31] Using gulpfile ~/Projects/Code/workbox/gulpfile.js\n[18:21:31] Starting \'build-packages\'...\n[18:21:31] Starting \'build-packages:clean\'...\n[18:21:31] Starting \'build-packages:clean (workbox-core)\'...\n[18:21:31] Finished \'build-packages:clean (workbox-core)\' after 1.77 ms\n[18:21:31] Finished \'build-packages:clean\' after 2.91 ms\n[18:21:31] Starting \'build-packages:generate-browser-entry\'...\n[18:21:31] Starting \'build-packages:generate-browser-entry (workbox-core)\'...\n[18:21:31] Finished \'build-packages:generate-browser-entry (workbox-core)\' after 6.85 ms\n[18:21:31] Finished \'build-packages:generate-browser-entry\' after 7.42 ms\n[18:21:31] Starting \'build-packages:build\'...\n[18:21:31] Starting \'build-package (workbox-core) ["dev"]\'...\n[Workbox Gulp Log]: Building Browser Bundle for workbox-core.\n[Workbox Gulp Log]:     Namespace: google.workbox.core\n[Workbox Gulp Log]:     Filename: workbox-core.dev.js\n',
lerna ERR! execute   stderr: '[18:21:31] \'build-package (workbox-core) ["dev"]\' errored after 68 ms\n[18:21:31] Error: Unexpected token\n    at error (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:177:12)\n    at Module.error$1 [as error] (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8434:2)\n    at tryParse (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8133:10)\n    at new Module (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8169:14)\n    at /home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:10010:17\n    at <anonymous>\n    at process._tickDomainCallback (internal/process/next_tick.js:208:7)\n[18:21:31] \'build-packages:build\' errored after 70 ms\n[18:21:31] \'build-packages\' errored after 82 ms\nnpm ERR! code ELIFECYCLE\nnpm ERR! errno 1\nnpm ERR! workbox-core@1.2.0 prepublish: `gulp build-packages --package workbox-core`\nnpm ERR! Exit status 1\nnpm ERR! \nnpm ERR! Failed at the workbox-core@1.2.0 prepublish script.\nnpm ERR! This is probably not a problem with npm. There is likely additional logging output above.\nnpm WARN Local package.json exists, but node_modules missing, did you mean to install?\n\nnpm ERR! A complete log of this run can be found in:\nnpm ERR!     /home/matt/.npm/_logs/2017-08-31T01_21_31_528Z-debug.log\n',
lerna ERR! execute   failed: true,
lerna ERR! execute   signal: null,
lerna ERR! execute   cmd: 'npm run prepublish',
lerna ERR! execute   timedOut: false }
lerna WARN complete Waiting for 1 child process to exit. CTRL-C to exit immediately.
(node:10469) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): Error: Command failed: npm run prepublish
[18:21:31] 'build-package (workbox-core) ["dev"]' errored after 68 ms
[18:21:31] Error: Unexpected token
    at error (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:177:12)
    at Module.error$1 [as error] (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8434:2)
    at tryParse (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8133:10)
    at new Module (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8169:14)
    at /home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:10010:17
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:208:7)
[18:21:31] 'build-packages:build' errored after 70 ms
[18:21:31] 'build-packages' errored after 82 ms
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! workbox-core@1.2.0 prepublish: `gulp build-packages --package workbox-core`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the workbox-core@1.2.0 prepublish script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/matt/.npm/_logs/2017-08-31T01_21_31_528Z-debug.log

> workbox-core@1.2.0 prepublish /home/matt/Projects/Code/workbox/packages/workbox-core
> gulp build-packages --package workbox-core

[18:21:30] Working directory changed to ~/Projects/Code/workbox
[18:21:31] Using gulpfile ~/Projects/Code/workbox/gulpfile.js
[18:21:31] Starting 'build-packages'...
[18:21:31] Starting 'build-packages:clean'...
[18:21:31] Starting 'build-packages:clean (workbox-core)'...
[18:21:31] Finished 'build-packages:clean (workbox-core)' after 1.77 ms
[18:21:31] Finished 'build-packages:clean' after 2.91 ms
[18:21:31] Starting 'build-packages:generate-browser-entry'...
[18:21:31] Starting 'build-packages:generate-browser-entry (workbox-core)'...
[18:21:31] Finished 'build-packages:generate-browser-entry (workbox-core)' after 6.85 ms
[18:21:31] Finished 'build-packages:generate-browser-entry' after 7.42 ms
[18:21:31] Starting 'build-packages:build'...
[18:21:31] Starting 'build-package (workbox-core) ["dev"]'...
[Workbox Gulp Log]: Building Browser Bundle for workbox-core.
[Workbox Gulp Log]:     Namespace: google.workbox.core
[Workbox Gulp Log]:     Filename: workbox-core.dev.js

(node:10469) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**New Output**
```
$ lerna bootstrap
lerna info version 2.1.2
lerna info Bootstrapping 2 packages
lerna info lifecycle preinstall
lerna info Symlinking packages and binaries
lerna info lifecycle postinstall
lerna info lifecycle prepublish
lerna ERR! execute Error occured with 'workbox-core' while running 'npm run prepublish'
lerna ERR! execute     See logs below for details:



> workbox-core@1.2.0 prepublish /home/matt/Projects/Code/workbox/packages/workbox-core
> gulp build-packages --package workbox-core

[18:14:05] Working directory changed to ~/Projects/Code/workbox
[18:14:05] Using gulpfile ~/Projects/Code/workbox/gulpfile.js
[18:14:05] Starting 'build-packages'...
[18:14:05] Starting 'build-packages:clean'...
[18:14:05] Starting 'build-packages:clean (workbox-core)'...
[18:14:05] Finished 'build-packages:clean (workbox-core)' after 6.53 ms
[18:14:05] Finished 'build-packages:clean' after 7.77 ms
[18:14:05] Starting 'build-packages:generate-browser-entry'...
[18:14:05] Starting 'build-packages:generate-browser-entry (workbox-core)'...
[18:14:05] Finished 'build-packages:generate-browser-entry (workbox-core)' after 8.2 ms
[18:14:05] Finished 'build-packages:generate-browser-entry' after 8.7 ms
[18:14:05] Starting 'build-packages:build'...
[18:14:05] Starting 'build-package (workbox-core) ["dev"]'...
[Workbox Gulp Log]: Building Browser Bundle for workbox-core.
[Workbox Gulp Log]:     Namespace: google.workbox.core
[Workbox Gulp Log]:     Filename: workbox-core.dev.js
 [18:14:06] 'build-package (workbox-core) ["dev"]' errored after 48 ms
[18:14:06] Error: Unexpected token
    at error (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:177:12)
    at Module.error$1 [as error] (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8434:2)
    at tryParse (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8133:10)
    at new Module (/home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:8169:14)
    at /home/matt/Projects/Code/workbox/node_modules/rollup/dist/rollup.js:10010:17
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:208:7)
[18:14:06] 'build-packages:build' errored after 49 ms
[18:14:06] 'build-packages' errored after 68 ms
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! workbox-core@1.2.0 prepublish: `gulp build-packages --package workbox-core`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the workbox-core@1.2.0 prepublish script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/matt/.npm/_logs/2017-08-31T01_14_06_017Z-debug.log



lerna WARN complete Waiting for 1 child process to exit. CTRL-C to exit immediately.
```

## Motivation and Context
The current output makes is difficult to identify the failing package.

## How Has This Been Tested?
I simply made the changes on a fail repo and then ran:

```
$ npm link ../lerna && npm link lerna && lerna bootstrap
```

## Types of changes
I honestly don't know what you would class this as. It shouldn't be a breaking change but could run the risk of reducing the logged information.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Fixes #977