### PR TITLE
Add --flatten option to use when merge conflicts cannot be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,14 @@ $ lerna ls --since some-branch
 
 *This can be particularly useful when used in CI, if you can obtain the target branch a PR will be going into, because you can use that as the `ref` to the `--since` option. This works well for PRs going into master as well as feature branches.*
 
+#### --flatten
+
+When importing repositories with merge commits with conflicts, the import command will fail trying to apply all commits. The user can use this flag to ask for import of "flat" history, i.e. with each merge commit as a single change the merge introduced.
+
+```
+$ lerna import ~/Product --flatten
+```
+
 #### --ignore [glob]
 
 Excludes a subset of packages when running a command.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -42,6 +42,22 @@ Run `lerna import` with the `--max-buffer` flag and provide a large enough
 number (in bytes). At the writing of this entry the underlying default is 
 10MB, so you should keep this in mind. 
 
+### Merge conflict commits cannot be imported
+
+When you try to import a repository that contains merge commits that needed
+conflict resolutions, the import command fails with an error:
+
+```
+lerna ERR! execute Error: Command failed: git am -3
+lerna ERR! execute error: Failed to merge in the changes.
+lerna ERR! execute CONFLICT (content): Merge conflict in [file]
+```
+
+#### Solution
+
+Run `lerna import` with the `--flatten` flag to import the history in "flat"
+mode, i.e. with each merge commit as a single change the merge introduced.
+
 ## Publish Command
 
 ### Publish does not detect manually created tags in fixed mode with Github/Github Enterprise

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -120,12 +120,27 @@ export default class ImportCommand extends Command {
   createPatchForCommit(sha) {
     let patch = null;
     if (this.options.flatten) {
-      const diff = this.externalExecSync("git", ["log", "--reverse", "--first-parent", "-p",
-        "-m", "--pretty=email", "--stat", "--binary", "-1", sha]);
+      const diff = this.externalExecSync("git", [
+        "log",
+        "--reverse",
+        "--first-parent",
+        "-p",
+        "-m",
+        "--pretty=email",
+        "--stat",
+        "--binary",
+        "-1",
+        sha
+      ]);
       const version = this.externalExecSync("git", ["--version"]).replace(/git version /g, '');
       patch = `${diff}\n--\n${version}`;
     } else {
-      patch = this.externalExecSync("git", ["format-patch", "-1", sha, "--stdout"]);
+      patch = this.externalExecSync("git", [
+        "format-patch",
+        "-1",
+        sha,
+        "--stdout"
+      ]);
     }
 
     const replacement = "$1/" + this.targetDir;

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -62,18 +62,22 @@ describe("ImportCommand", () => {
       const branchName = "conflict_branch";
       const conflictedFileName = "conflicted-file.txt";
       const conflictedFile = path.join(externalDir, conflictedFileName);
+
       await fs.writeFile(conflictedFile, "initial content");
       await execa("git", ["add", conflictedFileName], cwdExternalDir);
       await execa("git", ["commit", "-m", "Initial content written"], cwdExternalDir);
       await execa("git", ["checkout", "-b", branchName], cwdExternalDir);
+
       await fs.writeFile(conflictedFile, "branch content");
       await execa("git", ["commit", "-am", "branch content written"], cwdExternalDir);
       await execa("git", ["checkout", "master"], cwdExternalDir);
+
       await fs.writeFile(conflictedFile, "master content");
       await execa("git", ["commit", "-am", "master content written"], cwdExternalDir);
       try {
         await execa("git", ["merge", branchName], cwdExternalDir);
       } catch (e) {}
+
       await fs.writeFile(conflictedFile, "merged content");
       await execa("git", ["add", conflictedFileName], cwdExternalDir);
       await execa("git", ["commit", "-m", "Branch merged"], cwdExternalDir);


### PR DESCRIPTION
Add option "--flatten" to import each merge as a single change the merge introduced

## Description
Instead of doing "git format-patch", patches can be created by "git log" with a certain set of options that mimic format-patch, but with git log some additional options are available, like "--first-parent", which only follows main branch, so that side branch commits are not taken in separately, but instead only the merge commit is imported containing all changes from all branches commits that were merged there.

## Motivation and Context
This is required for situations when there were merge commits containing merge conflict resolutions in imported project. In the current implementation, "lerna import" fails because "git format-patch" does not include merge commits and its resolution, so such projects can't be imported. If "--flatten" is provided with the proposed solution, these problematic projects are successfully imported.

The issue was first reported in #730, and I personally had this issue so I had to fix it in order to use Lerna. Now I'm sharing the solution.

## How Has This Been Tested?
Tested with all sorts of importable repos, with several branches merged, with binary content, with conflicts and without conflicts, with my option and with the original option. Also all auto tests pass and one automatic test added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
