### PR TITLE
Use --canary=<value> as prerelease tag, not commit-ish

### DIFF
--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -58,13 +58,7 @@ export default class UpdatedPackagesCollector {
 
     if (GitUtilities.hasTags(execOpts)) {
       if (canary) {
-        let currentSHA;
-
-        if (canary !== true) {
-          currentSHA = canary;
-        } else {
-          currentSHA = GitUtilities.getCurrentSHA(execOpts);
-        }
+        const currentSHA = GitUtilities.getCurrentSHA(execOpts);
 
         since = this.getAssociatedCommits(currentSHA);
       } else if (!since) {

--- a/test/UpdatedPackagesCollector.js
+++ b/test/UpdatedPackagesCollector.js
@@ -1,5 +1,28 @@
+// mocked modules
+import GitUtilities from "../src/GitUtilities";
+
 // file under test
 import UpdatedPackagesCollector from "../src/UpdatedPackagesCollector";
+
+jest.mock("../src/GitUtilities");
+
+const filteredPackages = [{
+  name: 'package-1',
+  location: 'location-1'
+}, {
+  name: 'package-2',
+  location: 'location-2'
+}];
+
+const logger = {
+  silly: () => {},
+  info: () => {},
+  verbose: () => {}
+};
+
+const repository = {
+  rootPath: 'root-path'
+};
 
 describe("UpdatedPackagesCollector", () => {
   it("should exist", () => {
@@ -7,4 +30,55 @@ describe("UpdatedPackagesCollector", () => {
   });
 
   it("needs better tests");
+
+  describe(".collectUpdatedPackages()", () => {
+    beforeEach(() => {
+      GitUtilities.getCurrentSHA = jest.fn(() => "deadbeefcafe");
+      GitUtilities.hasTags = jest.fn(() => true);
+      GitUtilities.diffSinceIn = jest.fn(() => "");
+      GitUtilities.getLastTag = jest.fn(() => "lastTag");
+    });
+
+    afterEach(() => jest.resetAllMocks());
+
+    it("should use the current SHA for commit ranges when the canary flag has been passed", () => {
+      new UpdatedPackagesCollector({
+        options: {
+          canary: true
+        },
+        repository: repository,
+        logger: logger,
+        filteredPackages: filteredPackages
+      }).getUpdates();
+
+      expect(GitUtilities.diffSinceIn).toBeCalledWith('deadbeef^..deadbeef', 'location-1', undefined);
+      expect(GitUtilities.diffSinceIn).toBeCalledWith('deadbeef^..deadbeef', 'location-2', undefined);
+    });
+
+    it("should use the current SHA for commit ranges when the canary flag is a string", () => {
+      new UpdatedPackagesCollector({
+        options: {
+          canary: 'my-tag'
+        },
+        repository: repository,
+        logger: logger,
+        filteredPackages: filteredPackages
+      }).getUpdates();
+
+      expect(GitUtilities.diffSinceIn).toBeCalledWith('deadbeef^..deadbeef', 'location-1', undefined);
+      expect(GitUtilities.diffSinceIn).toBeCalledWith('deadbeef^..deadbeef', 'location-2', undefined);
+    });
+
+    it("should use the last tag in non-canary mode for commit ranges when a repo has tags", () => {
+      new UpdatedPackagesCollector({
+        options: {},
+        repository: repository,
+        logger: logger,
+        filteredPackages: filteredPackages
+      }).getUpdates();
+
+      expect(GitUtilities.diffSinceIn).toBeCalledWith('lastTag', 'location-1', undefined);
+      expect(GitUtilities.diffSinceIn).toBeCalledWith('lastTag', 'location-2', undefined);
+    });
+  });
 });

--- a/test/UpdatedPackagesCollector.js
+++ b/test/UpdatedPackagesCollector.js
@@ -29,8 +29,6 @@ describe("UpdatedPackagesCollector", () => {
     expect(UpdatedPackagesCollector).toBeDefined();
   });
 
-  it("needs better tests");
-
   describe(".collectUpdatedPackages()", () => {
     beforeEach(() => {
       GitUtilities.getCurrentSHA = jest.fn(() => "deadbeefcafe");

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -215,7 +215,7 @@ lerna info Comparing with initial commit.
 lerna info auto-confirmed "
 `;
 
-exports[`stderr: canary beta version 2`] = `
+exports[`stderr: canary default version 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info canary enabled
 lerna info current version 1.0.0

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -206,6 +206,24 @@ Array [
 ]
 `;
 
+exports[`stderr: canary beta version 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info canary enabled
+lerna info current version 1.0.0
+lerna info Checking for updated packages...
+lerna info Comparing with initial commit.
+lerna info auto-confirmed "
+`;
+
+exports[`stderr: canary beta version 2`] = `
+"lerna info version __TEST_VERSION__
+lerna info canary enabled
+lerna info current version 1.0.0
+lerna info Checking for updated packages...
+lerna info Comparing with initial commit.
+lerna info auto-confirmed "
+`;
+
 exports[`stderr: exit 0 when no updates 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info current version 1.0.0
@@ -228,6 +246,28 @@ lerna info versioning independent
 lerna info Checking for updated packages...
 lerna info Comparing with initial commit.
 lerna info auto-confirmed "
+`;
+
+exports[`stdout: canary beta version 1`] = `
+"
+Changes:
+ - package-1: 1.0.0 => 1.1.0-beta.hash
+ - package-2: 1.0.0 => 1.1.0-beta.hash
+ - package-3: 1.0.0 => 1.1.0-beta.hash
+ - package-4: 1.0.0 => 1.1.0-beta.hash
+ - package-5: 1.0.0 => 1.1.0-beta.hash (private)
+"
+`;
+
+exports[`stdout: canary default version 1`] = `
+"
+Changes:
+ - package-1: 1.0.0 => 1.1.0-alpha.hash
+ - package-2: 1.0.0 => 1.1.0-alpha.hash
+ - package-3: 1.0.0 => 1.1.0-alpha.hash
+ - package-4: 1.0.0 => 1.1.0-alpha.hash
+ - package-5: 1.0.0 => 1.1.0-alpha.hash (private)
+"
 `;
 
 exports[`stdout: exit 0 when no updates 1`] = `""`;

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -13,6 +13,9 @@ import loadPkgManifests from "../helpers/loadPkgManifests";
 const lastCommitMessage = (cwd) =>
   execa.stdout("git", ["log", "-1", "--format=%B"], { cwd }).then(normalizeNewline);
 
+const lastCommitId = (cwd) =>
+  execa.stdout("git", ["rev-parse", "HEAD"], { cwd }).then((line) => line.trim().substring(0, 8));
+
 async function pkgManifestsAndCommitMsg(cwd) {
   return Promise.all([
     loadPkgManifests(cwd),
@@ -64,6 +67,36 @@ describe("lerna publish", () => {
 
     expect(allPackageJsons).toMatchSnapshot("packages: updates fixed versions");
     expect(commitMessage).toMatchSnapshot("commit: updates fixed versions");
+  });
+
+  test.concurrent("uses detault suffix with canary flag", async () => {
+    const cwd = await initFixture("PublishCommand/normal");
+    const args = [
+      "publish",
+      "--canary",
+      "--skip-npm",
+      "--yes",
+    ];
+
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    const hash = await lastCommitId(cwd);
+    expect(stdout.replace(new RegExp(hash, 'g'), 'hash')).toMatchSnapshot("stdout: canary default version");
+    expect(stderr).toMatchSnapshot("stderr: canary beta version");
+  });
+
+  test.concurrent("uses meta suffix from canary flag", async () => {
+    const cwd = await initFixture("PublishCommand/normal");
+    const args = [
+      "publish",
+      "--canary=beta",
+      "--skip-npm",
+      "--yes",
+    ];
+
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    const hash = await lastCommitId(cwd);
+    expect(stdout.replace(new RegExp(hash, 'g'), 'hash')).toMatchSnapshot("stdout: canary beta version");
+    expect(stderr).toMatchSnapshot("stderr: canary beta version");
   });
 
   test.concurrent("updates independent versions", async () => {

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -14,7 +14,7 @@ const lastCommitMessage = (cwd) =>
   execa.stdout("git", ["log", "-1", "--format=%B"], { cwd }).then(normalizeNewline);
 
 const lastCommitId = (cwd) =>
-  execa.stdout("git", ["rev-parse", "HEAD"], { cwd }).then((line) => line.trim().substring(0, 8));
+  execa.stdout("git", ["rev-parse", "HEAD"], { cwd }).then((line) => line.substring(0, 8));
 
 async function pkgManifestsAndCommitMsg(cwd) {
   return Promise.all([
@@ -81,7 +81,7 @@ describe("lerna publish", () => {
     const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
     const hash = await lastCommitId(cwd);
     expect(stdout.replace(new RegExp(hash, 'g'), 'hash')).toMatchSnapshot("stdout: canary default version");
-    expect(stderr).toMatchSnapshot("stderr: canary beta version");
+    expect(stderr).toMatchSnapshot("stderr: canary default version");
   });
 
   test.concurrent("uses meta suffix from canary flag", async () => {


### PR DESCRIPTION
## Description

The docs say [we should be able to override the meta suffix by passing the canary flag as a string value](https://github.com/lerna/lerna#--canary--c).  lerna takes this value and tries to use it to work out what range of commits it should consider when publishing a package so you can't actually override the meta suffix unless you use a commit id to do this.  Considering the commit id is added to the version number for canary releases anyway this seems redundant.

eg:

This works:
```
lerna publish --canary
...
Changes:
 - package-1: 1.0.0 => 1.1.0-alpha.0a2f1a97
 - package-1: 1.0.0 => 1.1.0-alpha.0a2f1a97
```

According to the docs this should work but doesn't:
```
lerna publish --canary=beta
...
lerna ERR! initialize Error: fatal: bad revision 'beta^..beta'
*kaboom!*
```

## Motivation and Context

It would be useful to be able to override the meta suffix as described in the docs.

Fixes #1008.

## How Has This Been Tested?

Added some unit tests for the `UpdatedPackagesCollector` module and integration tests for the canary flag.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
