### PR TITLE
Call version lifecycle scripts during publish

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -2,4 +2,3 @@
   extends: ../.eslintrc.yaml
   env:
     jest: true
-    jasmine: true

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -2,3 +2,4 @@
   extends: ../.eslintrc.yaml
   env:
     jest: true
+    jasmine: true

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import log from "npmlog";
 import normalizeNewline from "normalize-newline";
 import path from "path";
+
 // mocked or stubbed modules
 import writeJsonFile from "write-json-file";
 import writePkg from "write-pkg";
@@ -10,11 +11,13 @@ import GitUtilities from "../src/GitUtilities";
 import NpmUtilities from "../src/NpmUtilities";
 import PromptUtilities from "../src/PromptUtilities";
 import output from "../src/utils/output";
+
 // helpers
 import callsBack from "./helpers/callsBack";
 import initFixture from "./helpers/initFixture";
 import normalizeRelativeDir from "./helpers/normalizeRelativeDir";
 import yargsRunner from "./helpers/yargsRunner";
+
 // file under test
 import * as commandModule from "../src/commands/PublishCommand";
 
@@ -1013,7 +1016,7 @@ describe("PublishCommand", () => {
           script,
           [],
           path.resolve(testDir, "packages", "package-1"),
-          jasmine.any(Function)
+          expect.any(Function)
         );
       });
     });
@@ -1025,7 +1028,7 @@ describe("PublishCommand", () => {
           script,
           [],
           path.resolve(testDir, "packages", "package-2"),
-          jasmine.any(Function)
+          expect.any(Function)
         );
       });
     });

--- a/test/fixtures/PublishCommand/lifecycle/lerna.json
+++ b/test/fixtures/PublishCommand/lifecycle/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/lifecycle/package.json
+++ b/test/fixtures/PublishCommand/lifecycle/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "lifecycle"
+}

--- a/test/fixtures/PublishCommand/lifecycle/packages/package-1/package.json
+++ b/test/fixtures/PublishCommand/lifecycle/packages/package-1/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "scripts": {
+    "preversion": "exit 0",
+    "version": "exit 0",
+    "postversion": "exit 0",
+    "prepublishOnly": "exit 0",
+    "prepublish": "exit 0",
+    "publish": "exit 0",
+    "postpublish": "exit 0"
+  }
+}

--- a/test/fixtures/PublishCommand/lifecycle/packages/package-2/package.json
+++ b/test/fixtures/PublishCommand/lifecycle/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Following the guidelines here: https://docs.npmjs.com/cli/version

Lerna will now call preversion, version, and postversion scripts at the appropriate times in each package when running `lerna publish`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows more hooks into the lerna publish command. For example, I want to run a custom changelog generation script after package.json version is updated, but before the git commit.

Closes: https://github.com/lerna/lerna/issues/774

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added some tests to verify that the three lifecycle scripts are called. 

I wanted to mock Package.js but found no easy way to do that - the changes I was working on ended up affecting many of the tests in Publish.js, since it doesn't import or have access to the Package class directly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This may be a breaking change because it now calls version scripts on publish, whereas before they were ignored.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] ?? My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
