### PR TITLE
Add runScriptSync for use in version lifecycle methods

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -156,6 +156,13 @@ export default class NpmUtilities {
     ChildProcessUtilities.exec("npm", ["run", script, ...args], opts, callback);
   }
 
+  static runScriptInDirSync(script, args, directory, callback) {
+    log.silly("runScriptInDirSync", script, args, path.basename(directory));
+
+    const opts = NpmUtilities.getExecOpts(directory);
+    ChildProcessUtilities.execSync("npm", ["run", script, ...args], opts, callback);
+  }
+
   static runScriptInPackageStreaming(script, args, pkg, callback) {
     log.silly("runScriptInPackageStreaming", [script, args, pkg.name]);
 

--- a/src/Package.js
+++ b/src/Package.js
@@ -84,6 +84,21 @@ export default class Package {
   }
 
   /**
+   * Run a NPM script synchronously in this package's directory
+   * @param {String} script NPM script to run
+   * @param {Function} callback
+   */
+  runScriptSync(script, callback) {
+    log.silly("runScriptSync", script, this.name);
+
+    if (this.scripts[script]) {
+      NpmUtilities.runScriptInDirSync(script, [], this.location, callback);
+    } else {
+      callback();
+    }
+  }
+
+  /**
    * Determine if a dependency version satisfies the requirements of this package
    * @param {Package} dependency
    * @param {Boolean} doWarn

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -537,7 +537,7 @@ export default class PublishCommand extends Command {
       this.updatePackageDepsObject(pkg, "peerDependencies", exact);
 
       // exec preversion script
-      pkg.runScript("preversion", (err) => {
+      pkg.runScriptSync("preversion", (err) => {
         if (err) {
           this.logger.error("publish", "error running preversion", pkg.name, err);
         }
@@ -550,7 +550,7 @@ export default class PublishCommand extends Command {
       // so it has to be explicit here (otherwise it mangles the instance properties)
 
       // exec version script
-      pkg.runScript("version", (err) => {
+      pkg.runScriptSync("version", (err) => {
         if (err) {
           this.logger.error("publish", "error running version", pkg.name, err);
         }
@@ -620,7 +620,7 @@ export default class PublishCommand extends Command {
 
     // run the postversion script for each update
     this.updates.forEach(({ "package": pkg }) => {
-      pkg.runScript("postversion", (err) => {
+      pkg.runScriptSync("postversion", (err) => {
         if (err) {
           this.logger.error("publish", "error running postversion", pkg.name, err);
         }
@@ -639,7 +639,7 @@ export default class PublishCommand extends Command {
 
     // run the postversion script for each update
     this.updates.forEach(({ "package": pkg }) => {
-      pkg.runScript("postversion", (err) => {
+      pkg.runScriptSync("postversion", (err) => {
         if (err) {
           this.logger.error("publish", "error running postversion", pkg.name, err);
         }

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -1,12 +1,10 @@
 import { EOL } from "os";
 import log from "npmlog";
 import path from "path";
-
 // mocked modules
 import writePkg from "write-pkg";
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import FileSystemUtilities from "../src/FileSystemUtilities";
-
 // file under test
 import NpmUtilities from "../src/NpmUtilities";
 
@@ -138,6 +136,25 @@ describe("NpmUtilities", () => {
         cwd: directory,
       };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
+    });
+  });
+
+  describe(".runScriptInDirSync()", () => {
+    it("runs an npm script syncrhonously in a directory", () => {
+      const script = "foo";
+      const args = ["--bar", "baz"];
+      const directory = "/test/runScriptInDirSync";
+      const callback = () => {
+      };
+
+      NpmUtilities.runScriptInDirSync(script, args, directory, callback);
+
+      const cmd = "npm";
+      const scriptArgs = ["run", "foo", "--bar", "baz"];
+      const opts = {
+        cwd: directory,
+      };
+      expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
   });
 

--- a/test/Package.js
+++ b/test/Package.js
@@ -1,12 +1,9 @@
 import log from "npmlog";
-
 // mocked modules
 import NpmUtilities from "../src/NpmUtilities";
-
 // helpers
 import callsBack from "./helpers/callsBack";
 import loggingOutput from "./helpers/loggingOutput";
-
 // file under test
 import Package from "../src/Package";
 
@@ -134,6 +131,21 @@ describe("Package", () => {
           done.fail(ex);
         }
       });
+    });
+  });
+
+  describe(".runScriptSync()", () => {
+    it("should run the script", () => {
+      NpmUtilities.runScriptInDirSync = jest.fn(callsBack());
+
+      pkg.runScriptSync("my-script", () => {});
+
+      expect(NpmUtilities.runScriptInDirSync).lastCalledWith(
+        "my-script",
+        [],
+        pkg.location,
+        expect.any(Function)
+      );
     });
   });
 

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -1012,7 +1012,7 @@ describe("PublishCommand", () => {
     it("should call version lifecycle scripts for a package", async () => {
       await run(testDir)();
       scripts.forEach(script => {
-        expect(NpmUtilities.runScriptInDir).toHaveBeenCalledWith(
+        expect(NpmUtilities.runScriptInDirSync).toHaveBeenCalledWith(
           script,
           [],
           path.resolve(testDir, "packages", "package-1"),
@@ -1024,7 +1024,7 @@ describe("PublishCommand", () => {
     it("should not call version lifecycle scripts for a package missing them", async () => {
       await run(testDir)();
       scripts.forEach(script => {
-        expect(NpmUtilities.runScriptInDir).not.toHaveBeenCalledWith(
+        expect(NpmUtilities.runScriptInDirSync).not.toHaveBeenCalledWith(
           script,
           [],
           path.resolve(testDir, "packages", "package-2"),
@@ -1035,7 +1035,7 @@ describe("PublishCommand", () => {
 
     it("should call version lifecycle scripts in the correct order", async () => {
       await run(testDir)();
-      expect(NpmUtilities.runScriptInDir.mock.calls.map(args => args[0])).toEqual(scripts);
+      expect(NpmUtilities.runScriptInDirSync.mock.calls.map(args => args[0])).toEqual(scripts);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
follow up for https://github.com/lerna/lerna/pull/1029 and https://github.com/lerna/lerna/issues/774

Makes npm preversion/version/postversion scripts synchronous

## Description
<!--- Describe your changes in detail -->
Add Package.runScriptSync, NpmUtilities.runScriptInDirSync
Converted Publish.js to use these to run lifecycle scripts at appropriate times

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The prior pr ran the scripts async, which is slightly confusing when a preversion/version script performs side effects like `git add abc`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for all three edited files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

It would be nice to run all the preversion/version/postversion scripts in parallel instead of sequentially, but still block on them. I thought about doing this but there were significant code changes needed that would add promises everywhere. If that's preferred I can do that too.
