### PR TITLE
Add support for git-hosted urls as sibling package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,8 +663,6 @@ Running `lerna` without arguments will show all commands/options.
     }
   },
   "packages": ["packages/*"]
-  "useGitVersion": true,
-  "gitVersionPrefix": "v"
 }
 ```
 
@@ -674,24 +672,6 @@ Running `lerna` without arguments will show all commands/options.
 - `commands.bootstrap.ignore`: an array of globs that won't be bootstrapped when running the `lerna bootstrap` command.
 - `commands.bootstrap.scope`: an array of globs that restricts which packages will be bootstrapped when running the `lerna bootstrap` command.
 - `packages`: Array of globs to use as package locations.
-- `useGitVersion`: a boolean (defaults to `false`) indicating if [git hosted urls](https://github.com/npm/hosted-git-info) should be allowed instead of plain version number. If enabled, Lerna will attempt to extract and save the interpackage dependency versions using git url-aware parser.
-    This allows packages to be distributed via git repos if eg. packages are private and [private npm repo is not an option](https://www.dotconferences.com/2016/05/fabien-potencier-monolithic-repositories-vs-many-repositories).
-    Please note that using `gitVersion` requires `publish` command to be used with `--exact` and is limited to urls with [`committish`](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies) part present.
-
-    Example assuming 2 packages where `my-package-1` depends on `my-package-2`, for which `package.json` of `my-package-1` could be:
-  ```
-  {
-    name: "my-package-1",
-    version: "1.0.0",
-    bin: "bin.js",
-    dependencies: { "my-package-2": "github:example-user/my-package-2#1.0.0" },
-    devDependencies: { "my-dev-dependency": "^1.0.0" },
-    peerDependencies: { "my-peer-dependency": "^1.0.0" }
-  }
-  ```
-- `gitVersionPrefix`: version prefix string (defaults to 'v') ignored when extracting version number from commitish part of git url. eg. given `github:example-user/my-package-2#v1.0.0`
- and `gitVersionPrefix: 'v'` version will be read as `1.0.0`. Ignored if `useGitVersion` is set to `false`.
-
 
 ### Common `devDependencies`
 
@@ -942,6 +922,63 @@ The root-level package.json must also include a `workspaces` array:
 ```
 This list is broadly similar to lerna's `packages` config (a list of globs matching directories with a package.json),
 except it does not support recursive globs (`"**"`, a.k.a. "globstars").
+
+#### --use-git-version
+
+Allow target versions of dependent packages to be written as [git hosted urls](https://github.com/npm/hosted-git-info) instead of a plain version number.
+If enabled, Lerna will attempt to extract and save the interpackage dependency versions from `package.json` files using git url-aware parser.
+
+Eg. assuming monorepo with 2 packages where `my-package-1` depends on `my-package-2`, `package.json` of `my-package-1` could be:
+```
+// packages/my-package-1/package.json
+{
+  name: "my-package-1",
+  version: "1.0.0",
+  bin: "bin.js",
+  dependencies: {
+    "my-package-2": "github:example-user/my-package-2#v1.0.0"
+  },
+  devDependencies: {
+    "my-dev-dependency": "^1.0.0"
+  },
+  peerDependencies: {
+    "my-peer-dependency": "^1.0.0"
+  }
+}
+```
+For the case above Lerna will read the version of `my-package-2` dependency as `1.0.0`.
+
+This allows packages to be distributed via git repos if eg. packages are private and [private npm repo is not an option](https://www.dotconferences.com/2016/05/fabien-potencier-monolithic-repositories-vs-many-repositories).
+
+Please note that using `--use-git-version`
+- is limited to urls with [`committish`](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies) part present (ie. `github:example-user/my-package-2` is invalid)
+- requires `publish` command to be used with `--exact`
+
+May also be configured in `lerna.json`:
+```js
+{
+  ...
+  "useGitVersion": true
+}
+```
+
+#### --git-version-prefix
+
+Defines version prefix string (defaults to 'v') ignored when extracting version number from a commitish part of git url.
+Everything after the prefix will be considered a version.
+
+
+Eg. given `github:example-user/my-package-2#v1.0.0` and `gitVersionPrefix: 'v'` version will be read as `1.0.0`.
+
+Only used if `--use-git-version` is set to `true`.
+
+May also be configured in `lerna.json`:
+```js
+{
+  ...
+  "gitVersionPrefix": "v"
+}
+```
 
 #### --stream
 

--- a/README.md
+++ b/README.md
@@ -663,6 +663,8 @@ Running `lerna` without arguments will show all commands/options.
     }
   },
   "packages": ["packages/*"]
+  "useGitVersion": true,
+  "gitVersionPrefix": "v"
 }
 ```
 
@@ -672,6 +674,23 @@ Running `lerna` without arguments will show all commands/options.
 - `commands.bootstrap.ignore`: an array of globs that won't be bootstrapped when running the `lerna bootstrap` command.
 - `commands.bootstrap.scope`: an array of globs that restricts which packages will be bootstrapped when running the `lerna bootstrap` command.
 - `packages`: Array of globs to use as package locations.
+- `useGitVersion`: a boolean (defaults to `false`) indicating if [git hosted urls](https://github.com/npm/hosted-git-info) should be allowed instead of plain version number. If enabled, Lerna will attempt to extract and save the interpackage dependency versions using git url-aware parser.
+    This allows packages to be distributed via git repos if eg. packages are private and [private npm repo is not an option](https://www.dotconferences.com/2016/05/fabien-potencier-monolithic-repositories-vs-many-repositories).
+    Please note that using `gitVersion` requires `publish` command to be used with `--exact` and is limited to urls with [`committish`](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies) part present.
+
+    Example assuming 2 packages where `my-package-1` depends on `my-package-2`, for which `package.json` of `my-package-1` could be:
+  ```
+  {
+    name: "my-package-1",
+    version: "1.0.0",
+    bin: "bin.js",
+    dependencies: { "my-package-2": "github:example-user/my-package-2#1.0.0" },
+    devDependencies: { "my-dev-dependency": "^1.0.0" },
+    peerDependencies: { "my-peer-dependency": "^1.0.0" }
+  }
+  ```
+- `gitVersionPrefix`: version prefix string (defaults to 'v') ignored when extracting version number from commitish part of git url. eg. given `github:example-user/my-package-2#v1.0.0`
+ and `gitVersionPrefix: 'v'` version will be read as `1.0.0`. Ignored if `useGitVersion` is set to `false`.
 
 
 ### Common `devDependencies`
@@ -896,9 +915,9 @@ May also be configured in `lerna.json`:
 
 #### --use-workspaces
 
-Enables integration with [Yarn Workspaces](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-workspaces-install-phase-1.md) (available since yarn@0.27+).  
-The values in the array are the commands in which Lerna will delegate operation to Yarn (currently only bootstrapping).    
-If `--use-workspaces` is true then `packages` will be overridden by the value from `package.json/workspaces.`  
+Enables integration with [Yarn Workspaces](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-workspaces-install-phase-1.md) (available since yarn@0.27+).
+The values in the array are the commands in which Lerna will delegate operation to Yarn (currently only bootstrapping).
+If `--use-workspaces` is true then `packages` will be overridden by the value from `package.json/workspaces.`
 May also be configured in `lerna.json`:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "glob-parent": "^3.1.0",
     "globby": "^6.1.0",
     "graceful-fs": "^4.1.11",
+    "hosted-git-info": "^2.5.0",
     "inquirer": "^3.2.2",
     "is-ci": "^1.0.10",
     "load-json-file": "^3.0.0",

--- a/src/GitVersionParser.js
+++ b/src/GitVersionParser.js
@@ -1,0 +1,22 @@
+import { escapeRegExp } from "lodash";
+import hostedGitInfo from "hosted-git-info";
+
+export default class GitVersionParser {
+  constructor(versionPrefix = "v") {
+    this._gitUrlPattern = new RegExp(`(.+?#${escapeRegExp(versionPrefix)})(.+)$`);
+  }
+
+  parseVersion(version) {
+    const gitInfo = hostedGitInfo.fromUrl(version);
+    let targetMatches;
+
+    if (gitInfo && gitInfo.committish) {
+      targetMatches = this._gitUrlPattern.exec(version);
+    }
+
+    return {
+      prefix: targetMatches ? targetMatches[1] : null,
+      version: targetMatches ? targetMatches[2] : version
+    };
+  }
+}

--- a/src/Package.js
+++ b/src/Package.js
@@ -62,13 +62,7 @@ export default class Package {
   }
 
   set versionSerializer(versionSerializer) {
-    const previousSerializer = this._versionSerializer;
-
     this._versionSerializer = versionSerializer;
-
-    if (previousSerializer) {
-      this._package = previousSerializer.serialize(this._package);
-    }
 
     if (versionSerializer) {
       this._package = versionSerializer.deserialize(this._package);

--- a/src/Package.js
+++ b/src/Package.js
@@ -2,6 +2,7 @@ import dedent from "dedent";
 import log from "npmlog";
 import path from "path";
 import semver from "semver";
+import _ from "lodash";
 
 import dependencyIsSatisfied from "./utils/dependencyIsSatisfied";
 import NpmUtilities from "./NpmUtilities";
@@ -60,12 +61,27 @@ export default class Package {
     return this._package.scripts || {};
   }
 
+  set versionSerializer(versionSerializer) {
+    const previousSerializer = this._versionSerializer;
+
+    this._versionSerializer = versionSerializer;
+
+    if (previousSerializer) {
+      this._package = previousSerializer.serialize(this._package);
+    }
+
+    if (versionSerializer) {
+      this._package = versionSerializer.deserialize(this._package);
+    }
+  }
+
   isPrivate() {
     return !!this._package.private;
   }
 
   toJSON() {
-    return this._package;
+    const pkg = _.cloneDeep(this._package);
+    return this._versionSerializer ? this._versionSerializer.serialize(pkg) : pkg;
   }
 
   /**

--- a/src/PackageGraph.js
+++ b/src/PackageGraph.js
@@ -20,7 +20,7 @@ export class PackageGraphNode {
  *    devDependencies that would normally be included.
  */
 export default class PackageGraph {
-  constructor(packages, depsOnly = false) {
+  constructor(packages, depsOnly = false, versionParser) {
     this.nodes = [];
     this.nodesByName = {};
 
@@ -38,11 +38,17 @@ export default class PackageGraph {
 
       for (let d = 0; d < depNames.length; d++) {
         const depName = depNames[d];
-        const depVersion = dependencies[depName];
         const packageNode = this.nodesByName[depName];
 
-        if (packageNode && semver.satisfies(packageNode.package.version, depVersion)) {
-          node.dependencies.push(depName);
+        if (packageNode) {
+          const depVersion = (versionParser
+            ? versionParser.parseVersion(dependencies[depName]).version
+            : dependencies[depName]
+          );
+
+          if (semver.satisfies(packageNode.package.version, depVersion)) {
+            node.dependencies.push(depName);
+          }
         }
       }
     }

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -87,8 +87,8 @@ export default class PackageUtilities {
     return packages;
   }
 
-  static getPackageGraph(packages, depsOnly) {
-    return new PackageGraph(packages, depsOnly);
+  static getPackageGraph(packages, depsOnly, versionParser) {
+    return new PackageGraph(packages, depsOnly, versionParser);
   }
 
   /**

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -8,9 +8,6 @@ import semver from "semver";
 
 import dependencyIsSatisfied from "./utils/dependencyIsSatisfied";
 import Package from "./Package";
-import PackageUtilities from "./PackageUtilities";
-import GitVersionParser from "./GitVersionParser";
-import VersionSerializer from "./VersionSerializer";
 
 const DEFAULT_PACKAGE_GLOB = "packages/*";
 
@@ -69,22 +66,6 @@ export default class Repository {
       .map(parentDir => path.resolve(this.rootPath, parentDir));
   }
 
-  get packages() {
-    if (!this._packages) {
-      this.buildPackageGraph();
-    }
-
-    return this._packages;
-  }
-
-  get packageGraph() {
-    if (!this._packageGraph) {
-      this.buildPackageGraph();
-    }
-
-    return this._packageGraph;
-  }
-
   get packageJson() {
     if (!this._packageJson) {
       try {
@@ -117,27 +98,6 @@ export default class Repository {
 
   isIndependent() {
     return this.version === "independent";
-  }
-
-  buildPackageGraph() {
-    // FIXME: should be destructured from command.options to support CLI flag overrides
-    const { useGitVersion, gitVersionPrefix } = this.lernaJson;
-
-    const versionParser = useGitVersion && new GitVersionParser(gitVersionPrefix);
-    const packages = PackageUtilities.getPackages(this);
-    const packageGraph = PackageUtilities.getPackageGraph(packages, false, versionParser);
-
-    if (useGitVersion) {
-      packages.forEach((pkg) => {
-        pkg.versionSerializer = new VersionSerializer({
-          graphDependencies: packageGraph.get(pkg.name).dependencies,
-          versionParser
-        });
-      });
-    }
-
-    this._packages = packages;
-    this._packageGraph = packageGraph;
   }
 
   hasDependencyInstalled(depName, version) {

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -120,16 +120,18 @@ export default class Repository {
   }
 
   buildPackageGraph() {
-    const packages = PackageUtilities.getPackages(this);
-    const packageGraph = PackageUtilities.getPackageGraph(packages, false, this.lernaJson.useGitVersion
-      ? new GitVersionParser(this.lernaJson.gitVersionPrefix)
-      : null);
+    // FIXME: should be destructured from command.options to support CLI flag overrides
+    const { useGitVersion, gitVersionPrefix } = this.lernaJson;
 
-    if (this.lernaJson.useGitVersion) {
+    const versionParser = useGitVersion && new GitVersionParser(gitVersionPrefix);
+    const packages = PackageUtilities.getPackages(this);
+    const packageGraph = PackageUtilities.getPackageGraph(packages, false, versionParser);
+
+    if (useGitVersion) {
       packages.forEach((pkg) => {
         pkg.versionSerializer = new VersionSerializer({
-          monorepoDependencies: packageGraph.get(pkg.name).dependencies,
-          versionParser: new GitVersionParser(this.lernaJson.gitVersionPrefix)
+          graphDependencies: packageGraph.get(pkg.name).dependencies,
+          versionParser
         });
       });
     }

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -37,7 +37,7 @@ export default class UpdatedPackagesCollector {
     this.logger = command.logger;
     this.repository = command.repository;
     this.packages = command.filteredPackages;
-    this.packageGraph = command.repository.packageGraph;
+    this.packageGraph = command.packageGraph;
     this.options = command.options;
   }
 

--- a/src/VersionSerializer.js
+++ b/src/VersionSerializer.js
@@ -1,6 +1,6 @@
 export default class VersionSerializer {
-  constructor({ monorepoDependencies, versionParser }) {
-    this._monorepoDependencies = monorepoDependencies;
+  constructor({ graphDependencies, versionParser }) {
+    this._graphDependencies = graphDependencies;
     this._versionParser = versionParser;
     this._dependenciesKeys = ["dependencies", "devDependencies", "peerDependencies"];
     this._strippedPrefixes = new Map();
@@ -33,7 +33,7 @@ export default class VersionSerializer {
 
   _stripPrefix(dependencies) {
     Object.keys(dependencies).forEach((name) => {
-      if (this._monorepoDependencies.includes(name)) {
+      if (this._graphDependencies.includes(name)) {
         const result = this._versionParser.parseVersion(dependencies[name]);
 
         if (result.prefix) {

--- a/src/VersionSerializer.js
+++ b/src/VersionSerializer.js
@@ -1,0 +1,46 @@
+export default class VersionSerializer {
+  constructor({ monorepoDependencies, versionParser }) {
+    this._monorepoDependencies = monorepoDependencies;
+    this._versionParser = versionParser;
+    this._dependenciesKeys = ["dependencies", "devDependencies", "peerDependencies"];
+    this._strippedPrefixes = new Map();
+  }
+
+  serialize(pkg) {
+    this._dependenciesKeys.forEach((key) => {
+      this._prependPrefix(pkg[key] || {});
+    });
+
+    return pkg;
+  }
+
+  deserialize(pkg) {
+    this._dependenciesKeys.forEach((key) => {
+      this._stripPrefix(pkg[key] || {});
+    });
+
+    return pkg;
+  }
+
+  _prependPrefix(dependencies) {
+    this._strippedPrefixes.forEach((prefix, name) => {
+      const version = dependencies[name];
+      if (version) {
+        dependencies[name] = `${prefix}${version}`;
+      }
+    });
+  }
+
+  _stripPrefix(dependencies) {
+    Object.keys(dependencies).forEach((name) => {
+      if (this._monorepoDependencies.includes(name)) {
+        const result = this._versionParser.parseVersion(dependencies[name]);
+
+        if (result.prefix) {
+          dependencies[name] = result.version;
+          this._strippedPrefixes.set(name, result.prefix);
+        }
+      }
+    });
+  }
+}

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -156,9 +156,11 @@ export default class PublishCommand extends Command {
     this.gitRemote = this.options.gitRemote || "origin";
     this.gitEnabled = !(this.options.canary || this.options.skipGit);
 
-    if (this.repository.lernaJson.useGitVersion && !this.options.exact) {
-      this.logger.error("config", ```Using git version without 'exact' option is not recommended.
-        Please make sure you publish with --exact.```);
+    if (this.options.useGitVersion && !this.options.exact) {
+      throw new Error(dedent`
+        Using git version without 'exact' option is not recommended.
+        Please make sure you publish with --exact.
+      `);
     }
 
     if (this.options.canary) {
@@ -608,7 +610,6 @@ export default class PublishCommand extends Command {
       }
     });
   }
-
 
   commitAndTagUpdates() {
     if (this.repository.isIndependent()) {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -156,6 +156,11 @@ export default class PublishCommand extends Command {
     this.gitRemote = this.options.gitRemote || "origin";
     this.gitEnabled = !(this.options.canary || this.options.skipGit);
 
+    if (this.repository.lernaJson.useGitVersion && !this.options.exact) {
+      this.logger.error("config", ```Using git version without 'exact' option is not recommended.
+        Please make sure you publish with --exact.```);
+    }
+
     if (this.options.canary) {
       this.logger.info("canary", "enabled");
     }
@@ -603,6 +608,7 @@ export default class PublishCommand extends Command {
       }
     });
   }
+
 
   commitAndTagUpdates() {
     if (this.repository.isIndependent()) {

--- a/test/Command.js
+++ b/test/Command.js
@@ -236,21 +236,42 @@ describe("Command", () => {
   });
 
   describe(".runPreparations()", () => {
+    let testDir;
+
+    function cli(cmd, ...args) {
+      return execa(cmd, args, { cwd: testDir });
+    }
+
+    function run(opts) {
+      const cmd = new OkCommand([], opts, testDir);
+      return cmd.run().then(() => cmd);
+    }
+
+    describe("get .packages", () => {
+
+      it("returns the list of packages", async () => {
+        testDir = await initFixture("Command/basic")
+        const { packages } = await run();
+        expect(packages).toEqual([]);
+      });
+    });
+
+    describe("get .packageGraph", () => {
+
+      it("returns the graph of packages", async () => {
+        testDir = await initFixture("Command/basic")
+        const { packageGraph } = await run();
+        expect(packageGraph).toBeDefined();
+        expect(packageGraph).toHaveProperty("nodes", []);
+        expect(packageGraph).toHaveProperty("nodesByName", {});
+      });
+    });
+
     describe(".filteredPackages", () => {
-      let testDir;
 
       beforeEach(() => initFixture("UpdatedCommand/basic").then((dir) => {
         testDir = dir;
       }));
-
-      function cli(cmd, ...args) {
-        return execa(cmd, args, { cwd: testDir });
-      }
-
-      function run(opts) {
-        const cmd = new OkCommand([], opts, testDir);
-        return cmd.run().then(() => cmd);
-      }
 
       it("--scope should filter packages", async () => {
         const { filteredPackages } = await run({ scope: ["package-2", "package-4"] });

--- a/test/GitVersionParser.js
+++ b/test/GitVersionParser.js
@@ -1,0 +1,79 @@
+import log from "npmlog";
+
+// file under test
+import GitVersionParser from "../src/GitVersionParser";
+
+// silence logs
+log.level = "silent";
+
+describe("GitVersionParser", () => {
+
+  describe("parseVersion - without prefix", () => {
+    let parser;
+
+    beforeEach(() => {
+      parser = new GitVersionParser("");
+    });
+
+    it("should work for semver version", () => {
+      expect(parser.parseVersion("0.0.2")).toEqual({
+        prefix: null,
+        version: "0.0.2"
+      });
+
+      expect(parser.parseVersion("~0.0.2")).toEqual({
+        prefix: null,
+        version: "~0.0.2"
+      });
+    });
+
+    it("should work for git url", () => {
+      expect(parser.parseVersion("github:user-foo/project-foo#v0.0.1")).toEqual({
+        prefix: "github:user-foo/project-foo#",
+        version: "v0.0.1"
+      });
+
+      expect(parser.parseVersion("git@github.com:user-foo/project-foo#0.0.5")).toEqual({
+        prefix: "git@github.com:user-foo/project-foo#",
+        version: "0.0.5"
+      });
+    });
+  });
+
+  describe("parseVersion - with version prefix", () => {
+    let parser;
+
+    beforeEach(() => {
+      parser = new GitVersionParser("v");
+    });
+
+    it("should work for semver version", () => {
+      expect(parser.parseVersion("0.0.2")).toEqual({
+        prefix: null,
+        version: "0.0.2"
+      });
+
+      expect(parser.parseVersion("~0.0.2")).toEqual({
+        prefix: null,
+        version: "~0.0.2"
+      });
+    });
+
+    it("should work for git url", () => {
+      expect(parser.parseVersion("github:user-foo/project-foo#v0.0.1")).toEqual({
+        prefix: "github:user-foo/project-foo#v",
+        version: "0.0.1"
+      });
+
+      expect(parser.parseVersion("git@github.com:user-foo/project-foo#0.0.5")).toEqual({
+        prefix: null,
+        version: "git@github.com:user-foo/project-foo#0.0.5"
+      });
+
+      expect(parser.parseVersion("git@github.com:user-foo/project-foo#v0.0.5")).toEqual({
+        prefix: "git@github.com:user-foo/project-foo#v",
+        version: "0.0.5"
+      });
+    });
+  });
+});

--- a/test/GitVersionParser.js
+++ b/test/GitVersionParser.js
@@ -9,11 +9,7 @@ log.level = "silent";
 describe("GitVersionParser", () => {
 
   describe("parseVersion - without prefix", () => {
-    let parser;
-
-    beforeEach(() => {
-      parser = new GitVersionParser("");
-    });
+    const parser = new GitVersionParser("");
 
     it("should work for semver version", () => {
       expect(parser.parseVersion("0.0.2")).toEqual({
@@ -41,11 +37,7 @@ describe("GitVersionParser", () => {
   });
 
   describe("parseVersion - with version prefix", () => {
-    let parser;
-
-    beforeEach(() => {
-      parser = new GitVersionParser("v");
-    });
+    const parser = new GitVersionParser("v");
 
     it("should work for semver version", () => {
       expect(parser.parseVersion("0.0.2")).toEqual({

--- a/test/Package.js
+++ b/test/Package.js
@@ -102,66 +102,55 @@ describe("Package", () => {
     });
   });
 
-  describe(".set versionSerializer()", () => {
+  describe(".set versionSerializer", () => {
     it("should call 'deserialize' method of serializer'", () => {
 
       const mockSerializer = {
-        serialize: jest.fn((pkg) => {
-          return pkg;
-        }),
-        deserialize: jest.fn((pkg) => {
-          return pkg;
-        })
+        serialize: jest.fn((pkg) => pkg),
+        deserialize: jest.fn((pkg) => pkg)
       };
 
       pkg.versionSerializer = mockSerializer;
 
-      expect(mockSerializer.deserialize.mock.calls.length).toBe(1);
-      expect(mockSerializer.deserialize.mock.calls[0][0]).toBe(pkg._package);
-      expect(mockSerializer.serialize.mock.calls.length).toBe(0);
+      expect(mockSerializer.deserialize).toBeCalled();
+      expect(mockSerializer.deserialize).toBeCalledWith(pkg._package);
+      expect(mockSerializer.serialize).not.toBeCalled();
     });
 
     it("should call 'serialize' on old and 'deserialize' on new serializer'", () => {
 
       const firstMockSerializer = {
-        serialize: jest.fn((pkg) => {
-          return pkg;
-        }),
-        deserialize: jest.fn((pkg) => {
-          return pkg;
-        })
+        serialize: jest.fn((pkg) => pkg),
+        deserialize: jest.fn((pkg) => pkg)
       };
 
       const secondMockSerializer = {
-        serialize: jest.fn((pkg) => {
-          return pkg;
-        }),
-        deserialize: jest.fn((pkg) => {
-          return pkg;
-        })
+        serialize: jest.fn((pkg) => pkg),
+        deserialize: jest.fn((pkg) => pkg)
       };
 
       pkg.versionSerializer = firstMockSerializer;
 
-      expect(firstMockSerializer.deserialize.mock.calls.length).toBe(1);
-      expect(firstMockSerializer.deserialize.mock.calls[0][0]).toBe(pkg._package);
-      expect(firstMockSerializer.serialize.mock.calls.length).toBe(0);
+      expect(firstMockSerializer.deserialize).toBeCalled();
+      expect(firstMockSerializer.deserialize).toBeCalledWith(pkg._package);
+      expect(firstMockSerializer.serialize).not.toBeCalled();
 
       pkg.versionSerializer = secondMockSerializer;
 
-      expect(firstMockSerializer.deserialize.mock.calls.length).toBe(1);
-      expect(firstMockSerializer.serialize.mock.calls.length).toBe(1);
-      expect(firstMockSerializer.serialize.mock.calls[0][0]).toBe(pkg._package);
+      expect(firstMockSerializer.deserialize).toBeCalled();
+      expect(firstMockSerializer.serialize).toBeCalled();
+      expect(firstMockSerializer.serialize).toBeCalledWith(pkg._package);
 
-      expect(secondMockSerializer.deserialize.mock.calls.length).toBe(1);
-      expect(secondMockSerializer.deserialize.mock.calls[0][0]).toBe(pkg._package);
-      expect(secondMockSerializer.serialize.mock.calls.length).toBe(0);
+      expect(secondMockSerializer.deserialize).toBeCalled();
+      expect(secondMockSerializer.deserialize).toBeCalledWith(pkg._package);
+      expect(secondMockSerializer.serialize).not.toBeCalled();
     });
   });
 
 
   describe(".toJSON()", () => {
     it("should return internal package copy for serialization", () => {
+      expect(pkg.toJSON()).not.toBe(pkg._package);
       expect(pkg.toJSON()).toEqual(pkg._package);
 
       const implicit = JSON.stringify(pkg, null, 2);
@@ -190,38 +179,34 @@ describe("Package", () => {
       expect(serializedPackage).not.toEqual(pkg._package);
       expect(serializedPackage).toEqual(pkgPackageClone);
 
-      expect(mockSerializer.deserialize.mock.calls.length).toBe(1);
-      expect(mockSerializer.serialize.mock.calls.length).toBe(1);
-      expect(mockSerializer.serialize.mock.calls[0][0]).toEqual(pkg._package);
+      expect(mockSerializer.deserialize).toBeCalled();
+      expect(mockSerializer.serialize).toBeCalled();
+      expect(mockSerializer.serialize).toBeCalledWith(pkg._package);
 
       serializedPackage = pkg.toJSON();
 
       expect(serializedPackage).not.toEqual(pkg._package);
       expect(serializedPackage).toEqual(pkgPackageClone);
 
-      expect(mockSerializer.deserialize.mock.calls.length).toBe(1);
-      expect(mockSerializer.serialize.mock.calls.length).toBe(2);
-      expect(mockSerializer.serialize.mock.calls[0][0]).toEqual(pkg._package);
-      expect(mockSerializer.serialize.mock.calls[1][0]).toEqual(pkg._package);
+      expect(mockSerializer.deserialize).toBeCalled();
+      expect(mockSerializer.serialize).toHaveBeenCalledTimes(2);
+      expect(mockSerializer.serialize).toBeCalledWith(pkg._package);
+      expect(mockSerializer.serialize).lastCalledWith(pkg._package);
     });
 
     it("should use versionSerializer.serialize on internal package before return", () => {
       const mockSerializer = {
-        serialize: jest.fn((pkg) => {
-          return pkg;
-        }),
-        deserialize: jest.fn((pkg) => {
-          return pkg;
-        })
+        serialize: jest.fn((pkg) => pkg),
+        deserialize: jest.fn((pkg) => pkg)
       };
 
       pkg.versionSerializer = mockSerializer;
 
       expect(pkg.toJSON()).toEqual(pkg._package);
 
-      expect(mockSerializer.deserialize.mock.calls.length).toBe(1);
-      expect(mockSerializer.serialize.mock.calls.length).toBe(1);
-      expect(mockSerializer.serialize.mock.calls[0][0]).toEqual(pkg._package);
+      expect(mockSerializer.deserialize).toBeCalled();
+      expect(mockSerializer.serialize).toBeCalled();
+      expect(mockSerializer.serialize).toBeCalledWith(pkg._package);
     });
   });
 

--- a/test/PackageGraph.js
+++ b/test/PackageGraph.js
@@ -9,7 +9,7 @@ log.level = "silent";
 
 describe("PackageGraph", () => {
 
-  const createPackages = function(version, dependencyVersion) {
+  function createPackages(version, dependencyVersion = version) {
     dependencyVersion = dependencyVersion || version;
 
     return [
@@ -38,7 +38,7 @@ describe("PackageGraph", () => {
         "/path/to/package2"
       )
     ];
-  };
+  }
 
   describe("constructor", () => {
     it(".get should return dependencies", () => {

--- a/test/PackageGraph.js
+++ b/test/PackageGraph.js
@@ -1,0 +1,76 @@
+import log from "npmlog";
+
+// file under test
+import Package from "../src/Package";
+import PackageGraph from "../src/PackageGraph";
+
+// silence logs
+log.level = "silent";
+
+describe("PackageGraph", () => {
+
+  const createPackages = function(version, dependencyVersion) {
+    dependencyVersion = dependencyVersion || version;
+
+    return [
+      new Package(
+        {
+          name: "my-package-1",
+          version: version,
+          bin: "bin.js",
+          scripts: { "my-script": "echo 'hello world'" },
+          dependencies: { "my-dependency": "^1.0.0" },
+          devDependencies: { "my-dev-dependency": "^1.0.0" },
+          peerDependencies: { "my-peer-dependency": "^1.0.0" }
+        },
+        "/path/to/package1"
+      ),
+      new Package(
+        {
+          name: "my-package-2",
+          version: version,
+          bin: "bin.js",
+          scripts: { "my-script": "echo 'hello world'" },
+          dependencies: { "my-dependency": "^1.0.0" },
+          devDependencies: { "my-package-1": dependencyVersion },
+          peerDependencies: { "my-peer-dependency": "^1.0.0" }
+        },
+        "/path/to/package2"
+      )
+    ];
+  };
+
+  describe("constructor", () => {
+    it(".get should return dependencies", () => {
+      const [ pkg1, pkg2 ] = createPackages("0.0.1");
+      const graph = new PackageGraph([ pkg1, pkg2 ]);
+
+      expect(graph.get(pkg1.name).dependencies).toEqual([]);
+      expect(graph.get(pkg2.name).dependencies).toEqual([pkg1.name]);
+    });
+
+    it(".get should not return the dependencies for unrecognized versions", () => {
+      const [ pkg1, pkg2 ] = createPackages("0.0.1", "github:user-foo/project-foo#v0.0.1");
+      const graph = new PackageGraph([ pkg1, pkg2 ]);
+
+      expect(graph.get(pkg1.name).dependencies).toEqual([]);
+      expect(graph.get(pkg2.name).dependencies).toEqual([]);
+    });
+
+    it(".get should not return the dependencies for unrecognized versions", () => {
+      const [ pkg1, pkg2 ] = createPackages("0.0.1", "github:user-foo/project-foo#v0.0.1");
+
+      const mockParser = {
+        parseVersion: jest.fn().mockReturnValue({
+          prefix: "github:user-foo/project-foo#v",
+          version: "0.0.1"
+        })
+      };
+
+      const graph = new PackageGraph([pkg1, pkg2], false, mockParser);
+
+      expect(graph.get(pkg1.name).dependencies).toEqual([]);
+      expect(graph.get(pkg2.name).dependencies).toEqual([ pkg1.name ]);
+    });
+  });
+});

--- a/test/Repository.js
+++ b/test/Repository.js
@@ -142,32 +142,6 @@ describe("Repository", () => {
     });
   });
 
-  describe("get .packages", () => {
-    it("returns the list of packages", () => {
-      const repo = new Repository(testDir);
-      expect(repo.packages).toEqual([]);
-    });
-
-    it("caches the initial value", () => {
-      const repo = new Repository(testDir);
-      expect(repo.packages).toBe(repo.packages);
-    });
-  });
-
-  describe("get .packageGraph", () => {
-    it("returns the graph of packages", () => {
-      const repo = new Repository(testDir);
-      expect(repo.packageGraph).toBeDefined();
-      expect(repo.packageGraph).toHaveProperty("nodes", []);
-      expect(repo.packageGraph).toHaveProperty("nodesByName", {});
-    });
-
-    it("caches the initial value", () => {
-      const repo = new Repository(testDir);
-      expect(repo.packageGraph).toBe(repo.packageGraph);
-    });
-  });
-
   describe("get .packageJson", () => {
     afterEach(() => {
       readPkg.sync = readPkgSync;

--- a/test/Repository.js
+++ b/test/Repository.js
@@ -138,7 +138,7 @@ describe("Repository", () => {
         path.join(testDir, "packages"),
         path.join(testDir, "dir/nested"),
         path.join(testDir, "globstar"),
-      ])
+      ]);
     });
   });
 

--- a/test/VersionSerializer.js
+++ b/test/VersionSerializer.js
@@ -21,7 +21,7 @@ describe("VersionSerializer", () => {
       }
     };
     serializer = new VersionSerializer({
-      monorepoDependencies: [
+      graphDependencies: [
         "my-package-1", "my-package-2", "my-package-3"
       ],
       versionParser: parser
@@ -39,7 +39,7 @@ describe("VersionSerializer", () => {
       };
 
       serializer = new VersionSerializer({
-        monorepoDependencies: [
+        graphDependencies: [
           "my-package-1", "my-package-2", "my-package-3"
         ],
         versionParser: mockParser
@@ -56,7 +56,7 @@ describe("VersionSerializer", () => {
       };
 
       serializer.deserialize(pkg);
-      expect(mockParser.parseVersion.mock.calls.length).toBe(2);
+      expect(mockParser.parseVersion).toHaveBeenCalledTimes(2);
     });
 
     it("should not touch versions parser does not recognize", () => {
@@ -111,24 +111,19 @@ describe("VersionSerializer", () => {
     });
 
     it("should write back version strings transformed by deserialize", () => {
-        expect(serializer.deserialize({
-          name: "my-package-1",
-          version: "1.0.0",
-          bin: "bin.js",
-          scripts: { "my-script": "echo 'hello world'" },
-          dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
-          devDependencies: { "my-package-2": "bbb#1.0.0" },
-          peerDependencies: { "my-package-3": "ccc#1.0.0" }
-        })).toEqual({
+
+      // since serializer is stateful, version prefixes will be stored in its state
+      serializer.deserialize({
         name: "my-package-1",
         version: "1.0.0",
         bin: "bin.js",
         scripts: { "my-script": "echo 'hello world'" },
         dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
-        devDependencies: { "my-package-2": "1.0.0" },
-        peerDependencies: { "my-package-3": "1.0.0" }
-      });
+        devDependencies: { "my-package-2": "bbb#1.0.0" },
+        peerDependencies: { "my-package-3": "ccc#1.0.0" }
+      })
 
+      // the preserved prefixes should be written back
       expect(serializer.serialize({
         name: "my-package-1",
         version: "1.0.0",

--- a/test/VersionSerializer.js
+++ b/test/VersionSerializer.js
@@ -1,0 +1,151 @@
+import log from "npmlog";
+
+// file under test
+import VersionSerializer from "../src/VersionSerializer";
+
+// silence logs
+log.level = "silent";
+
+describe("VersionSerializer", () => {
+
+  let serializer;
+
+  beforeEach(() => {
+    const parser = {
+      parseVersion(version) {
+       const chunks = version.split("#");
+       return  {
+         prefix: chunks.length > 1 ? chunks[0] + "#" : null,
+         version: chunks.length > 1 ? chunks[1] : version,
+       };
+      }
+    };
+    serializer = new VersionSerializer({
+      monorepoDependencies: [
+        "my-package-1", "my-package-2", "my-package-3"
+      ],
+      versionParser: parser
+    });
+  });
+
+  describe("deserialize", () => {
+
+    it("should use version parser for inter-package dependencies only", () => {
+      const mockParser = {
+        parseVersion: jest.fn().mockReturnValue({
+          prefix: null,
+          version: "0.0.1"
+        })
+      };
+
+      serializer = new VersionSerializer({
+        monorepoDependencies: [
+          "my-package-1", "my-package-2", "my-package-3"
+        ],
+        versionParser: mockParser
+      });
+
+      const pkg = {
+        name: "my-package-1",
+        version: "1.0.0",
+        bin: "bin.js",
+        scripts: { "my-script": "echo 'hello world'" },
+        dependencies: { "my-dependency": "^1.0.0" },
+        devDependencies: { "my-package-2": "^1.0.0" },
+        peerDependencies: { "my-package-3": "^1.0.0" }
+      };
+
+      serializer.deserialize(pkg);
+      expect(mockParser.parseVersion.mock.calls.length).toBe(2);
+    });
+
+    it("should not touch versions parser does not recognize", () => {
+      const pkg = {
+        name: "my-package-1",
+        version: "1.0.0",
+        bin: "bin.js",
+        scripts: { "my-script": "echo 'hello world'" },
+        dependencies: { "my-dependency": "^1.0.0" },
+        devDependencies: { "my-package-2": "^1.0.0" },
+        peerDependencies: { "my-package-3": "^1.0.0" }
+      };
+
+      expect(serializer.deserialize(pkg)).toEqual(pkg);
+    });
+
+    it("should extract versions recognized by parser", () => {
+      expect(serializer.deserialize({
+        name: "my-package-1",
+        version: "1.0.0",
+        bin: "bin.js",
+        scripts: { "my-script": "echo 'hello world'" },
+        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
+        devDependencies: { "my-package-2": "bbb#1.0.0" },
+        peerDependencies: { "my-package-3": "ccc#1.0.0" }
+      })).toEqual({
+        name: "my-package-1",
+        version: "1.0.0",
+        bin: "bin.js",
+        scripts: { "my-script": "echo 'hello world'" },
+        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
+        devDependencies: { "my-package-2": "1.0.0" },
+        peerDependencies: { "my-package-3": "1.0.0" }
+      });
+    });
+  });
+
+  describe("serialize", () => {
+
+    it("should not touch versions parser does not recognize", () => {
+      const pkg = {
+        name: "my-package-1",
+        version: "1.0.0",
+        bin: "bin.js",
+        scripts: { "my-script": "echo 'hello world'" },
+        dependencies: { "my-dependency": "^1.0.0" },
+        devDependencies: { "my-package-2": "^1.0.0" },
+        peerDependencies: { "my-package-3": "^1.0.0" }
+      };
+
+      expect(serializer.serialize(pkg)).toEqual(pkg);
+    });
+
+    it("should write back version strings transformed by deserialize", () => {
+        expect(serializer.deserialize({
+          name: "my-package-1",
+          version: "1.0.0",
+          bin: "bin.js",
+          scripts: { "my-script": "echo 'hello world'" },
+          dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
+          devDependencies: { "my-package-2": "bbb#1.0.0" },
+          peerDependencies: { "my-package-3": "ccc#1.0.0" }
+        })).toEqual({
+        name: "my-package-1",
+        version: "1.0.0",
+        bin: "bin.js",
+        scripts: { "my-script": "echo 'hello world'" },
+        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
+        devDependencies: { "my-package-2": "1.0.0" },
+        peerDependencies: { "my-package-3": "1.0.0" }
+      });
+
+      expect(serializer.serialize({
+        name: "my-package-1",
+        version: "1.0.0",
+        bin: "bin.js",
+        scripts: { "my-script": "echo 'hello world'" },
+        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
+        devDependencies: { "my-package-2": "1.0.0" },
+        peerDependencies: { "my-package-3": "1.0.0" }
+      })).toEqual({
+        name: "my-package-1",
+        version: "1.0.0",
+        bin: "bin.js",
+        scripts: { "my-script": "echo 'hello world'" },
+        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
+        devDependencies: { "my-package-2": "bbb#1.0.0" },
+        peerDependencies: { "my-package-3": "ccc#1.0.0" }
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,6 +1926,10 @@ hosted-git-info@^2.1.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.2.0.tgz#7a0d097863d886c0fabbdcd37bf1758d8becf8a5"
 
+hosted-git-info@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+
 html-encoding-sniffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"


### PR DESCRIPTION
## Description

This PR introduces optional support for package dependency version to be stored as url to [git hosted](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies) repositories in `package.json` eg. given `package-1` that depends on `package-2`, a `package.json` of the former might look like:

```
// packages/package-1/package.json
{
  version: "0.0.1",
  ...
  dependencies: {
    "package-2": "git://github.com/user/package-2.git#v0.0.1"
  }
}
```

- implementation is based around the idea that `package.json` file contains a `serialized` version of package dependency versions, as full urls, that are read internally as semver ones ie. eg. `0.0.1`.
- uses `useGitVersion` and `gitVersionPrefix` options in `lerna.json` to enable the feature and optionally configure it
  ```
  {
    "lerna": "2.2.0",
    "packages": [
      "packages/*"
    ],
    "version": "0.0.1",
    "useGitVersion": true,
    "gitVersionPrefix": "v"
  } 
  ```
- introduces `VersionSerializer` that handles deserializing/serializing dependency version from/to `package.json` and `GitVersionParser` to handle git-specific urls.

## Motivation and Context
Lerna assumes packages to be distributed on npm upon publish. However, when private repo is not an option, packages can be distributed on private GH repositories.

We run a private Github Lerna monorepo with Ember addons and [we publish our packages to separate read-only repositories](https://www.dotconferences.com/2016/05/fabien-potencier-monolithic-repositories-vs-many-repositories), from which addons are installable separately (and can bring in other subpackages as dependencies).

With versions written down as `0.0.1` installation of git-hosted downstream repositories would fail when resolving other package dependencies. Storing urls in GH forms solves the issues, also keeps history and tags to point to an identical version of `package.json` files in monorepo and read-only repositories.

This PR shares the work we've done with @synaptiko to streamline this process. We've done our best to make it least invasive. We are open to improvement suggestions to make it even more suitable for inclusion in Lerna. 

## Known limitations:
- feature requires dependency url to contain [`committish`](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies) part 
- `publish` command should be used with `--exact` since using `^` or `~` in commitish part is not supported

## How Has This Been Tested?
We run code from this PR internally to bootstrap and publish our monorepo. We have also updated Lerna tests to cover added code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (we checked with `run ci`)
