### PR TITLE
Support durable --loglevel config from lerna.json

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -95,10 +95,6 @@ export default class Command {
     log.pause();
     log.heading = "lerna";
 
-    if (flags.loglevel) {
-      log.level = flags.loglevel;
-    }
-
     this.input = input;
     this._flags = flags;
 
@@ -108,8 +104,6 @@ export default class Command {
     this.lernaVersion = require("../package.json").version;
     this.repository = new Repository(cwd);
     this.logger = log.newGroup(this.name);
-
-    log.resume();
   }
 
   get concurrency() {
@@ -201,6 +195,14 @@ export default class Command {
   }
 
   run() {
+    const { loglevel } = this.options;
+
+    if (loglevel) {
+      log.level = loglevel;
+    }
+
+    // no logging is emitted until run() is called
+    log.resume();
     log.info("version", this.lernaVersion);
 
     if (this.repository.isIndependent()) {

--- a/test/Command.js
+++ b/test/Command.js
@@ -1,6 +1,8 @@
+import loadJsonFile from "load-json-file";
 import log from "npmlog";
-import touch from "touch";
 import path from "path";
+import touch from "touch";
+import writeJsonFile from "write-json-file";
 
 import ChildProcessUtilities from "../src/ChildProcessUtilities";
 import FileSystemUtilities from "../src/FileSystemUtilities";
@@ -207,6 +209,24 @@ describe("Command", () => {
             name: "pkg-err-name"
           });
         }
+      });
+    });
+
+    describe("loglevel", () => {
+      afterEach(() => {
+        log.level = "silent";
+      });
+
+      it("is set from lerna.json config", async () => {
+        const lernaJsonLocation = path.join(testDir, "lerna.json");
+        const lernaConfig = await loadJsonFile(lernaJsonLocation);
+        lernaConfig.loglevel = "warn";
+        await writeJsonFile(lernaJsonLocation, lernaConfig, { indent: 2 });
+
+        const ok = new OkCommand([], {}, testDir);
+        await ok.run();
+
+        expect(log.level).toBe("warn");
       });
     });
   });


### PR DESCRIPTION
## Description
Almost unique among our CLI flags, `--loglevel` is not currently supported as a "durable" config via lerna.json. This PR fixes that.

Additionally, only emit logging once `run()` has been called on a command.

## Motivation and Context
Fixes #1035

## How Has This Been Tested?
added a unit test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
