### PR TITLE
Throw publish validation errors before version selection

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -74,7 +74,7 @@ export const builder = {
   }
 };
 
-class ValidationError extends Error {
+export class ValidationError extends Error {
   constructor(prefix, message) {
     super(message);
     this.name = "ValidationError";
@@ -342,11 +342,10 @@ export default class Command {
           // to that specific package.
           if (err.pkg) {
             this._logPackageError(method, err);
-            this._complete(err, 1, callback);
           } else {
             log.error(method, "callback with error\n", err);
-            this._complete(err, 1, callback);
           }
+          this._complete(err, 1, callback);
         } else if (!completed) {
           // an early exit is rarely an error
           log.verbose(method, "exited early");

--- a/src/Command.js
+++ b/src/Command.js
@@ -356,7 +356,10 @@ export default class Command {
         }
       });
     } catch (err) {
-      log.error(method, "caught error\n", err);
+      // ValidationError already logged appropriately
+      if (err.name !== "ValidationError") {
+        log.error(method, "caught error\n", err);
+      }
       this._complete(err, 1, callback);
     }
   }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -179,8 +179,8 @@ export default class PublishCommand extends Command {
         throw new ValidationError(
           "ENOTALLOWED",
           dedent`
-            Branch ${currentBranch} is not allowed to be published.
-            Use --allow-branch ${currentBranch} to override.
+            Branch '${currentBranch}' is restricted from publishing due to allowBranch config.
+            Please consider the reasons for this restriction before overriding the option.
           `
         );
       }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -8,7 +8,7 @@ import semver from "semver";
 import writeJsonFile from "write-json-file";
 import writePkg from "write-pkg";
 
-import Command from "../Command";
+import Command, { ValidationError } from "../Command";
 import ConventionalCommitUtilities from "../ConventionalCommitUtilities";
 import FileSystemUtilities from "../FileSystemUtilities";
 import GitUtilities from "../GitUtilities";
@@ -165,6 +165,27 @@ export default class PublishCommand extends Command {
       this.logger.info("current version", this.globalVersion);
     }
 
+    // git validation, if enabled, should happen before updates are calculated and versions picked
+    if (this.gitEnabled) {
+      if (GitUtilities.isDetachedHead(this.execOpts)) {
+        throw new ValidationError(
+          "ENOGIT",
+          "Detached git HEAD, please checkout a branch to publish changes."
+        );
+      }
+
+      const currentBranch = GitUtilities.getCurrentBranch(this.execOpts);
+      if (this.options.allowBranch && !minimatch(currentBranch, this.options.allowBranch)) {
+        throw new ValidationError(
+          "ENOTALLOWED",
+          dedent`
+            Branch ${currentBranch} is not allowed to be published.
+            Use --allow-branch ${currentBranch} to override.
+          `
+        );
+      }
+    }
+
     this.updates = new UpdatedPackagesCollector(this).getUpdates();
 
     this.packagesToPublish = this.updates
@@ -210,31 +231,14 @@ export default class PublishCommand extends Command {
   }
 
   execute(callback) {
-    try {
-      if (this.gitEnabled && GitUtilities.isDetachedHead(this.execOpts)) {
-        throw new Error("Detached git HEAD, please checkout a branch to publish changes.");
-      }
+    if (!this.repository.isIndependent() && !this.options.canary) {
+      this.updateVersionInLernaJson();
+    }
 
-      const currentBranch = GitUtilities.getCurrentBranch(this.execOpts);
-      if (this.options.allowBranch && !minimatch(currentBranch, this.options.allowBranch)) {
-        throw new Error(dedent`
-          Branch ${currentBranch} is not allowed to be published.
-          Use --allow-branch ${currentBranch} to override.
-        `);
-      }
+    this.updateUpdatedPackages();
 
-      if (!this.repository.isIndependent() && !this.options.canary) {
-        this.updateVersionInLernaJson();
-      }
-
-      this.updateUpdatedPackages();
-
-      if (this.gitEnabled) {
-        this.commitAndTagUpdates();
-      }
-    } catch (err) {
-      callback(err);
-      return;
+    if (this.gitEnabled) {
+      this.commitAndTagUpdates();
     }
 
     if (this.options.skipNpm) {

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -936,7 +936,7 @@ describe("PublishCommand", () => {
   });
 
 
-  describe('allow branch', () => {
+  describe("--allow-branch", () => {
     describe("cli", () => {
       let testDir;
 
@@ -953,16 +953,14 @@ describe("PublishCommand", () => {
       });
 
       it("should accept an exactly matching branch", async () => {
-        expect(await run(testDir)("--allow-branch", "master")).toEqual(
-          expect.objectContaining({ exitCode: 0 })
-        );
+        const { exitCode } = await run(testDir)("--allow-branch", "master");
+        expect(exitCode).toBe(0);
       });
 
       it("should accept a branch that matches by wildcard", async () => {
         GitUtilities.getCurrentBranch.mockReturnValueOnce("feature/awesome");
-        expect(await run(testDir)("--allow-branch", "feature/*")).toEqual(
-          expect.objectContaining({ exitCode: 0 })
-        );
+        const { exitCode } = await run(testDir)("--allow-branch", "feature/*");
+        expect(exitCode).toBe(0);
       });
     });
 
@@ -983,15 +981,25 @@ describe("PublishCommand", () => {
 
       it("should accept a matching branch", async () => {
         GitUtilities.getCurrentBranch.mockReturnValueOnce("lerna");
-        expect(await run(testDir)()).toEqual(
-          expect.objectContaining({ exitCode: 0 })
-        );
+
+        const { exitCode } = await run(testDir)();
+        expect(exitCode).toBe(0);
       });
 
       it("should prioritize cli over defaults", async () => {
-        expect(await run(testDir)("--allow-branch", "master")).toEqual(
-          expect.objectContaining({ exitCode: 0 })
-        );
+        const { exitCode } = await run(testDir)("--allow-branch", "master");
+        expect(exitCode).toBe(0);
+      });
+    });
+
+    describe("with --canary", () => {
+      it("does not restrict publishing canary versions", async () => {
+        const testDir = await initFixture("PublishCommand/normal");
+        GitUtilities.getCurrentBranch.mockReturnValueOnce("other");
+
+        const { exitCode } = await run(testDir)("--allow-branch", "master", "--canary");
+        expect(exitCode).toBe(0);
+        expect(updatedPackageVersions(testDir)).toMatchSnapshot();
       });
     });
   });

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -945,20 +945,25 @@ describe("PublishCommand", () => {
       });
 
       it("should reject a non matching branch", async () => {
+        GitUtilities.getCurrentBranch.mockReturnValueOnce("unmatched");
+
         try {
-          await run(testDir)("--allow-branch", "develop");
+          await run(testDir)("--allow-branch", "master");
         } catch (err) {
-          expect(err).toEqual(expect.stringMatching(/not allowed to be published/));
+          expect(err.message).toMatch("Branch 'unmatched' is restricted from publishing");
         }
       });
 
       it("should accept an exactly matching branch", async () => {
-        const { exitCode } = await run(testDir)("--allow-branch", "master");
+        GitUtilities.getCurrentBranch.mockReturnValueOnce("exact-match");
+
+        const { exitCode } = await run(testDir)("--allow-branch", "exact-match");
         expect(exitCode).toBe(0);
       });
 
       it("should accept a branch that matches by wildcard", async () => {
         GitUtilities.getCurrentBranch.mockReturnValueOnce("feature/awesome");
+
         const { exitCode } = await run(testDir)("--allow-branch", "feature/*");
         expect(exitCode).toBe(0);
       });
@@ -972,10 +977,12 @@ describe("PublishCommand", () => {
       });
 
       it("should reject a non matching branch", async () => {
+        GitUtilities.getCurrentBranch.mockReturnValueOnce("unmatched");
+
         try {
           await run(testDir)();
         } catch (err) {
-          expect(err).toEqual(expect.stringMatching(/not allowed to be published/));
+          expect(err.message).toMatch("Branch 'unmatched' is restricted from publishing");
         }
       });
 
@@ -987,7 +994,9 @@ describe("PublishCommand", () => {
       });
 
       it("should prioritize cli over defaults", async () => {
-        const { exitCode } = await run(testDir)("--allow-branch", "master");
+        GitUtilities.getCurrentBranch.mockReturnValueOnce("cli-override");
+
+        const { exitCode } = await run(testDir)("--allow-branch", "cli-override");
         expect(exitCode).toBe(0);
       });
     });

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -498,3 +498,13 @@ Array [
   ],
 ]
 `;
+
+exports[`PublishCommand --allow-branch with --canary does not restrict publishing canary versions 1`] = `
+Object {
+  "packages/package-1": "1.1.0-alpha.deadbeef",
+  "packages/package-2": "1.1.0-alpha.deadbeef",
+  "packages/package-3": "1.1.0-alpha.deadbeef",
+  "packages/package-4": "1.1.0-alpha.deadbeef",
+  "packages/package-5": "1.1.0-alpha.deadbeef",
+}
+`;


### PR DESCRIPTION
## Description
When attempting to publish in a branch restricted by `--allow-branch`, the error should be thrown (and the publish process halted) _before_ the version selection prompt is rendered.

Also, `--canary` releases should _always_ be allowed, even if the branch isn't whitelisted by `--allow-branch`. Effectively, we should consider `--allow-branch` to describe "the branch (or branches) allowed to publish non-canary versions on".

## Motivation and Context
It makes the error cases much less confusing, since you don't spend a lot of effort choosing versions and whatnot before the validation error occurs.

## How Has This Been Tested?
added unit tests, local testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
