### PR TITLE
When hoisting, only install with --global-style in leaf nodes, not root

### DIFF
--- a/test/__snapshots__/BootstrapCommand.js.snap
+++ b/test/__snapshots__/BootstrapCommand.js.snap
@@ -36,7 +36,8 @@ Object {
 
 exports[`BootstrapCommand with hoisting should hoist 1`] = `
 Object {
-  "": Array [
+  "ROOT": Array [
+    "bar@^2.0.0",
     "foo@^1.0.0",
     "@test/package-1@^0.0.0",
   ],
@@ -48,6 +49,7 @@ Object {
 
 exports[`BootstrapCommand with hoisting should hoist 2`] = `
 Array [
+  "packages/package-1/node_modules/bar",
   "packages/package-1/node_modules/foo",
   "packages/package-2/node_modules/foo",
   "packages/package-4/node_modules/@test/package-1",
@@ -56,7 +58,8 @@ Array [
 
 exports[`BootstrapCommand with hoisting should not hoist when disallowed 1`] = `
 Object {
-  "": Array [
+  "ROOT": Array [
+    "bar@^2.0.0",
     "foo@^1.0.0",
   ],
   "packages/package-3": Array [
@@ -70,34 +73,16 @@ Object {
 
 exports[`BootstrapCommand with hoisting should not hoist when disallowed 2`] = `
 Array [
+  "packages/package-1/node_modules/bar",
   "packages/package-1/node_modules/foo",
   "packages/package-2/node_modules/foo",
-]
-`;
-
-exports[`BootstrapCommand with hoisting should use global style to install disallowed external dependencies 1`] = `
-Object {
-  "": Array [
-    "foo@^1.0.0",
-    "@test/package-1@^0.0.0",
-  ],
-  "packages/package-3": Array [
-    "foo@0.1.12",
-  ],
-}
-`;
-
-exports[`BootstrapCommand with hoisting should use global style to install disallowed external dependencies 2`] = `
-Array [
-  "packages/package-1/node_modules/foo",
-  "packages/package-2/node_modules/foo",
-  "packages/package-4/node_modules/@test/package-1",
 ]
 `;
 
 exports[`BootstrapCommand with local package dependencies should bootstrap packages 1`] = `
 Object {
   "packages/package-1": Array [
+    "bar@^2.0.0",
     "foo@^1.0.0",
   ],
   "packages/package-2": Array [
@@ -155,6 +140,7 @@ Array [
 exports[`BootstrapCommand with local package dependencies should not bootstrap ignored packages 1`] = `
 Object {
   "packages/package-1": Array [
+    "bar@^2.0.0",
     "foo@^1.0.0",
   ],
   "packages/package-2": Array [

--- a/test/fixtures/BootstrapCommand/basic/package.json
+++ b/test/fixtures/BootstrapCommand/basic/package.json
@@ -1,3 +1,8 @@
 {
-  "name": "independent"
+  "name": "basic",
+  "version": "monorepo",
+  "private": true,
+  "dependencies": {
+    "bar": "^2.0.0"
+  }
 }

--- a/test/fixtures/BootstrapCommand/basic/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-1/package.json
@@ -2,6 +2,7 @@
   "name": "@test/package-1",
   "version": "1.0.0",
   "dependencies": {
+    "bar": "^2.0.0",
     "foo": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Description
I introduced a performance regression in v2.3.0 with incorrect application of the `--global-style` argument to `npm install`. This fixes that.

## Motivation and Context
Fixes #1050

## How Has This Been Tested?
improvements to existing unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
