### PR TITLE
Improve "import" edgecases + (i18n fixes + git tweaks)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preintegration": "npm pack",
     "integration": "jest --config test/config/integration.json",
     "pretest": "npm run lint -- --cache",
-    "test": "jest",
+    "test": "cross-env LC_ALL=en-US jest",
     "ci": "npm test -- --coverage --verbose && npm run integration",
     "prepublish": "npm run build"
   },
@@ -76,6 +76,7 @@
     "babel-eslint": "^7.2.3",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-env": "^1.6.0",
+    "cross-env": "^5.0.5",
     "eslint": "^4.5.0",
     "eslint-config-babel": "^7.0.2",
     "eslint-plugin-babel": "^4.1.2",

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -42,7 +42,7 @@ export default class GitUtilities {
 
   static commit(message, opts) {
     log.silly("commit", message);
-    const args = ["commit"];
+    const args = ["commit", "--no-gpg-sign"];
 
     if (message.indexOf(EOL) > -1) {
       // Use tempfile to allow multi\nline strings.

--- a/test/Command.js
+++ b/test/Command.js
@@ -289,7 +289,7 @@ describe("Command", () => {
         await cli("git", "tag", "1.0.0");
         await touch(path.join(testDir, "packages/package-2/random-file"));
         await cli("git", "add", ".");
-        await cli("git", "commit", "-m", "test");
+        await cli("git", "commit", "--no-gpg-sign", "-m", "test");
 
         const { filteredPackages } = await run({ since: "" });
         expect(filteredPackages.length).toEqual(2);
@@ -303,13 +303,13 @@ describe("Command", () => {
         await cli("git", "tag", "1.0.0");
         await touch(path.join(testDir, "packages/package-1/random-file"));
         await cli("git", "add", ".");
-        await cli("git", "commit", "-m", "test");
+        await cli("git", "commit", "--no-gpg-sign", "-m", "test");
 
         // Then we can checkout a new branch, update and commit.
         await cli("git", "checkout", "-b", "test");
         await touch(path.join(testDir, "packages/package-2/random-file"));
         await cli("git", "add", ".");
-        await cli("git", "commit", "-m", "test");
+        await cli("git", "commit", "--no-gpg-sign", "-m", "test");
 
         const { filteredPackages } = await run({ since: "master" });
         expect(filteredPackages.length).toEqual(2);
@@ -321,7 +321,7 @@ describe("Command", () => {
         await cli("git", "checkout", "-b", "test");
         await touch(path.join(testDir, "packages/package-4/random-file"));
         await cli("git", "add", ".");
-        await cli("git", "commit", "-m", "test");
+        await cli("git", "commit", "--no-gpg-sign", "-m", "test");
 
         const { filteredPackages } = await run({
           scope: ["package-2", "package-3", "package-4"],

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -73,7 +73,7 @@ describe("GitUtilities", () => {
 
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git",
-        ["commit", "-m", "foo"],
+        ["commit", "--no-gpg-sign", "-m", "foo"],
         opts
       );
       expect(tempWrite.sync).not.toBeCalled();
@@ -87,7 +87,7 @@ describe("GitUtilities", () => {
 
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git",
-        ["commit", "-F", "TEMPFILE"],
+        ["commit", "--no-gpg-sign", "-F", "TEMPFILE"],
         opts
       );
       expect(tempWrite.sync).lastCalledWith(`foo${EOL}bar`, "lerna-commit.txt");

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -65,22 +65,22 @@ describe("ImportCommand", () => {
 
       await fs.writeFile(conflictedFile, "initial content");
       await execa("git", ["add", conflictedFileName], cwdExternalDir);
-      await execa("git", ["commit", "-m", "Initial content written"], cwdExternalDir);
+      await execa("git", ["commit", "--no-gpg-sign", "-m", "Initial content written"], cwdExternalDir);
       await execa("git", ["checkout", "-b", branchName], cwdExternalDir);
 
       await fs.writeFile(conflictedFile, "branch content");
-      await execa("git", ["commit", "-am", "branch content written"], cwdExternalDir);
+      await execa("git", ["commit", "--no-gpg-sign", "-am", "branch content written"], cwdExternalDir);
       await execa("git", ["checkout", "master"], cwdExternalDir);
 
       await fs.writeFile(conflictedFile, "master content");
-      await execa("git", ["commit", "-am", "master content written"], cwdExternalDir);
+      await execa("git", ["commit", "--no-gpg-sign", "-am", "master content written"], cwdExternalDir);
       try {
         await execa("git", ["merge", branchName], cwdExternalDir);
       } catch (e) {}
 
       await fs.writeFile(conflictedFile, "merged content");
       await execa("git", ["add", conflictedFileName], cwdExternalDir);
-      await execa("git", ["commit", "-m", "Branch merged"], cwdExternalDir);
+      await execa("git", ["commit", "--no-gpg-sign", "-m", "Branch merged"], cwdExternalDir);
       expect(await lastCommitInDir(externalDir)).toBe("Branch merged");
 
       await lernaImport(externalDir, "--flatten");
@@ -101,7 +101,8 @@ describe("ImportCommand", () => {
       const newFilePath = path.join(testDir, "packages", path.basename(externalDir), "new-file");
 
       await execa("git", ["mv", "old-file", "new-file"], { cwd: externalDir });
-      await execa("git", ["commit", "-m", "Moved old-file to new-file"], { cwd: externalDir });
+      await execa("git", ["commit", "--no-gpg-sign", "-m", "Moved old-file to new-file"],
+        { cwd: externalDir });
 
       await lernaImport(externalDir);
 

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -31,7 +31,7 @@ const consoleOutput = () =>
 
 const gitTag = (cwd) => execa("git", ["tag", "v1.0.0"], { cwd });
 const gitAdd = (cwd) => execa("git", ["add", "-A"], { cwd });
-const gitCommit = (cwd) => execa("git", ["commit", "-m", "Commit"], { cwd });
+const gitCommit = (cwd) => execa("git", ["commit", "--no-gpg-sign", "-m", "Commit"], { cwd });
 const touchFile = (cwd) => (filePath) => touch(path.join(cwd, filePath));
 
 const setupGitChanges = async (cwd, filePaths) => {

--- a/test/helpers/gitInit.js
+++ b/test/helpers/gitInit.js
@@ -7,5 +7,5 @@ async function gitInit(cwd, message) {
 
   await execa("git", ["init", "."], opts);
   await execa("git", ["add", "-A"], opts);
-  await execa("git", ["commit", "-m", message], opts);
+  await execa("git", ["commit", "--no-gpg-sign", "-m", message], opts);
 }

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -28,7 +28,7 @@ async function commitChangeToPackage(cwd, packageName, commitMsg, data) {
   const pkg = await loadJsonFile(packageJSONPath);
   await writeJsonFile(packageJSONPath, Object.assign(pkg, data));
   await execa("git", ["add", "."], {cwd});
-  return await execa("git", ["commit", "-m", commitMsg], {cwd});
+  return await execa("git", ["commit", "--no-gpg-sign", "-m", commitMsg], {cwd});
 }
 
 describe("lerna publish", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,6 +1186,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cross-env@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.5.tgz#4383d364d9660873dd185b398af3bfef5efffef3"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -2165,6 +2172,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Originally this just contains the fixes for handling issues detecting in https://github.com/lerna/lerna/issues/1058

- Outputting added for errors when something unintended happens during importing of projects.
- Added new handling to automatically skip empty commits. These are an anti-pattern I figure, but I saw them accidentally in some of my own repositories. As `git` does not seem to have a useful parameter for its `am` command we have to `skip` the command when detecting the empty commits error (my approach analyzes the error message from `git`).
- Disabling GPG signing of all "git commit" runs as this seems to break the system. Lerna should not rely on the user to disabling this behavior manually.
- We have some tests which compare the exact output of some commands. As these commands might be executed under the local env variables of the user they might differ from our tested ones. I added `cross-env` and added a `LC_ALL` setting in front of the `npm` script to run `jest` to overcome this.

## Motivation and Context

This fixes to import my projects from Edge Platform into a single repository. 

Without the change on skipping empty commits it just failed. Without the logging change, it failed without any useful user-facing error.


## How Has This Been Tested?

The test suite and linting pass without any errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.