### PR TITLE
fix: fail when --hoist and --yarn are used together

### DIFF
--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -150,6 +150,15 @@ describe("BootstrapCommand", () => {
     });
   });
 
+  describe("with --npm-client and --hoist", async () => {
+    const testDir = await initFixture("BootstrapCommand/yarn-hoist");
+    const lernaBootstrap = run(testDir);
+
+    it("should throw", () => {
+      expect(() => lernaBootstrap()).toThrow();
+    });
+  });
+
   describe("with local package dependencies", () => {
     let testDir;
     let lernaBootstrap;

--- a/test/fixtures/BootstrapCommand/yarn-hoist/lerna.json
+++ b/test/fixtures/BootstrapCommand/yarn-hoist/lerna.json
@@ -1,0 +1,6 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "npmClient": "yarn",
+  "hoist": "**"
+}

--- a/test/fixtures/BootstrapCommand/yarn-hoist/package.json
+++ b/test/fixtures/BootstrapCommand/yarn-hoist/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "root",
+  "private": true
+}


### PR DESCRIPTION
## Description
* add a plausibility check for cases where `typeof options.hoist === 'string'` and `options.npmClient === 'yarn'`
* Fail for this case printing a detailed error message pointing to the `yarn + lerna` guide

## Motivation and Context
* `yarn` and hoisting produces unexpected results by using `npm` for nested installs #852
* The solution implemented was proposed via #1053

## How Has This Been Tested?
* Added a test case for this in `test/BootstrapCommand.js`
* Test case performs operation on prepared fixture `test/fixtures/BootstrapCommand/yarn-hoist`
* No additional effects on rest of code base expected

## Types of changes
Debateable, my guess:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
