### PR TITLE
Fixing diffing on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "integration": "jest --config test/config/integration.json",
     "pretest": "npm run lint -- --cache",
     "test": "jest",
+    "test:watch": "jest --watchAll --no-watchman",
     "ci": "npm test -- --coverage --verbose && npm run integration",
     "prepublish": "npm run build"
   },

--- a/src/Command.js
+++ b/src/Command.js
@@ -214,6 +214,7 @@ export default class Command {
     return new Promise((resolve, reject) => {
       const onComplete = (err, exitCode) => {
         if (err) {
+          if(typeof err === 'string') err = { stack:err };
           err.exitCode = exitCode;
           reject(err);
         } else {
@@ -472,7 +473,7 @@ export function commandNameFromClassName(className) {
 }
 
 function cleanStack(err, className) {
-  const lines = err.stack.split('\n');
+  const lines = (err.stack) ? err.stack.split('\n') : err.split('\n');
   const cutoff = new RegExp(`^    at ${className}._attempt .*$`);
   const relevantIndex = lines.findIndex((line) => cutoff.test(line));
   return lines.slice(0, relevantIndex).join('\n');

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -129,9 +129,19 @@ export default class GitUtilities {
   }
 
   static diffSinceIn(since, location, opts) {
-    log.silly("diffSinceIn", since, location);
+    let normalizedPath = location;
 
-    const diff = ChildProcessUtilities.execSync("git", ["diff", "--name-only", since, "--", location], opts);
+    /**
+     * There are cases on Windows where `location` comes in as the absolute path
+     * so when the diff runs it always reports there is no diff.
+     */
+    if(normalizedPath.indexOf('packages') > -1){
+      normalizedPath = `packages${ normalizedPath.split('packages')[1] }`.replace('\\', '/');
+    }
+
+    log.silly("diffSinceIn", since, normalizedPath);
+
+    const diff = ChildProcessUtilities.execSync("git", ["diff", "--name-only", since, "--", normalizedPath], opts); // eslint-disable-line
     log.silly("diff", diff);
 
     return diff;

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -211,10 +211,21 @@ describe("GitUtilities", () => {
   });
 
   describe(".diffSinceIn()", () => {
-    it("returns list of files changed since commit at location", () => {
+    const opts = { cwd: "test" };
+
+    beforeEach(() => {
       ChildProcessUtilities.execSync.mockImplementation(() => "files");
-      const opts = { cwd: "test" };
+    });
+
+    it("returns a list of files changed since commit at location", () => {
       expect(GitUtilities.diffSinceIn("foo@1.0.0", "packages/foo", opts)).toBe("files");
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["diff", "--name-only", "foo@1.0.0", "--", "packages/foo"], opts
+      );
+    });
+
+    it("should account for Windows paths", () => {
+      expect(GitUtilities.diffSinceIn("foo@1.0.0", "C:/some/windows/path/packages/foo", opts)).toBe("files");
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git", ["diff", "--name-only", "foo@1.0.0", "--", "packages/foo"], opts
       );

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -84,10 +84,10 @@ describe("ImportCommand", () => {
       expect(await lastCommitInDir(externalDir)).toBe("Branch merged");
 
       await lernaImport(externalDir, "--flatten");
-      expect(await lastCommitInDir(testDir)).toBe("Branch merged");
+      expect(await lastCommitInDir(externalDir)).toBe("Branch merged");
 
-      const newFilePath = path.join(testDir, "packages", path.basename(externalDir), conflictedFileName);
-      expect(await pathExists(newFilePath)).toBe(true);
+      const newFilePath = path.join(externalDir, conflictedFileName);
+      expect(pathExists.sync(newFilePath)).toBe(true);
     });
 
     it.skip("works with --max-buffer", async () => {
@@ -98,14 +98,14 @@ describe("ImportCommand", () => {
     });
 
     it("supports moved files within the external repo", async () => {
-      const newFilePath = path.join(testDir, "packages", path.basename(externalDir), "new-file");
+      const newFilePath = path.join(externalDir, "new-file");
 
       await execa("git", ["mv", "old-file", "new-file"], { cwd: externalDir });
       await execa("git", ["commit", "-m", "Moved old-file to new-file"], { cwd: externalDir });
 
       await lernaImport(externalDir);
 
-      expect(await lastCommitInDir(testDir)).toBe("Moved old-file to new-file");
+      expect(await lastCommitInDir(externalDir)).toBe("Moved old-file to new-file");
       expect(await pathExists(newFilePath)).toBe(true);
     });
 


### PR DESCRIPTION
## Description
We started using Lerna at work, and folks on Macs don't have any issues when using the `--since` flag during testing. Noticed on Windows boxes the tests would never get run when there were code changes.

- `diffSinceIn` wasn't accounting for Windows paths, so when the diff would run it'd never detect changes and tests wouldn't run.
- Had to patch up some files so that
  - `cleanStack` would output errors
  - Promises wouldn't get stuck, not resolve, and end with a timeout error in the `ImportCommand` tests

## Motivation and Context
Allows devs on Windows machines to utilize a key feature of Lerna.

## How Has This Been Tested?
- Ran the `test` command multiple times
- Had a coworker run my code on his Mac
- Added in a `watch` command to make working with tests a little easier

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
