### PR TITLE
publish command now respects the .gitignore

### DIFF
--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -40,6 +40,17 @@ export default class GitUtilities {
     ChildProcessUtilities.execSync("git", ["add", file], opts);
   }
 
+  static checkIgnore(file, opts) {
+    log.silly("checkIgnore", file);
+    try {
+      // returns non-zero exit code if its NOT ignored
+      ChildProcessUtilities.execSync("git", ["check-ignore", file], opts);
+      return true
+    } catch (err) {
+      return false
+    }
+  }
+
   static commit(message, opts) {
     log.silly("commit", message);
     const args = ["commit"];

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -45,9 +45,9 @@ export default class GitUtilities {
     try {
       // returns non-zero exit code if its NOT ignored
       ChildProcessUtilities.execSync("git", ["check-ignore", file], opts);
-      return true
+      return true;
     } catch (err) {
-      return false
+      return false;
     }
   }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -591,7 +591,14 @@ export default class PublishCommand extends Command {
     });
 
     if (this.gitEnabled) {
-      changedFiles.forEach((file) => GitUtilities.addFile(file, this.execOpts));
+      changedFiles.forEach((file) => {
+        const ignored = GitUtilities.checkIgnore(file, this.execOpts)
+        if (ignored) {
+          this.logger.info('git', `skipping "${file}" because its git-ignored`)
+        } else {
+          return GitUtilities.addFile(file, this.execOpts)
+        }
+      });
     }
   }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -592,11 +592,11 @@ export default class PublishCommand extends Command {
 
     if (this.gitEnabled) {
       changedFiles.forEach((file) => {
-        const ignored = GitUtilities.checkIgnore(file, this.execOpts)
+        const ignored = GitUtilities.checkIgnore(file, this.execOpts);
         if (ignored) {
-          this.logger.info('git', `skipping "${file}" because its git-ignored`)
+          this.logger.info('git', `skipping "${file}" because its git-ignored`);
         } else {
-          return GitUtilities.addFile(file, this.execOpts)
+          return GitUtilities.addFile(file, this.execOpts);
         }
       });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This change makes `lerna publish` skip files in the `.gitignore`.

## Description
Before attempting to `git add` files, `git check-ignore` is run first. This allows `lerna publish` to proceed if a file is ignored, rather than exiting.

## Motivation and Context
 Presently, Lerna assumes that all the sub-packages are part of the mono-repo. This change allows more flexible workflows, like if a package inside the monorepo still wants to benefit from the cross-linking and version-updating features of Lerna but isn't actually checked into the monorepo.

More details in this issue: #1075

## How Has This Been Tested?
We use our fork for our internal workflow and it works. Test suite is still passing, although no new unit tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
