### PR TITLE
Republish prereleased packages during subsequent non-prerelease publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,9 @@ $ lerna publish --cd-version (major | minor | patch | premajor | preminor | prep
 ```
 
 When run with this flag, `publish` will skip the version selection prompt (in independent mode) and use the next specified semantic version.
-You must still use the `--yes` flag to avoid all prompts. This is useful when build systems need
-to publish without command prompts. Works in both normal and independent modes.
+You must still use the `--yes` flag to avoid all prompts. This is useful when build systems need to publish without command prompts. Works in both normal and independent modes.
+
+If you have any packages with a prerelease version number (e.g. `2.0.0-beta.3`) and you run `lerna publish` with `--cd-version` and a non-prerelease version increment (major / minor / patch), it will publish those packages in addition to the packages that have changed since the last release.
 
 #### --preid
 

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -641,6 +641,48 @@ describe("PublishCommand", () => {
     });
   });
 
+    /** =========================================================================
+   * CD VERSION - REPUBLISH PRERELEASED
+   * ======================================================================= */
+
+  describe("CD VERSION - REPUBLISH PRERELEASED ", () => {
+    let testDir;
+
+    beforeEach(async () => {
+      testDir = await initFixture("PublishCommand/republish-prereleased");
+
+      GitUtilities.hasTags.mockReturnValue(true);
+      GitUtilities.getLastTag.mockReturnValue('v1.0.1-beta.3');
+      GitUtilities.diffSinceIn.mockImplementation((since, location) => {
+        if (location.endsWith('package-3')) {
+          return 'packages/package-3/newfile.json';
+        }
+        return '';
+      });
+    });
+
+    it('publishes changed & prereleased packages if --cd-version is non-prerelease', async () => {
+      // should republish 3, 4, and 5 because:
+      // package 3 changed
+      // package 5 has a prerelease version
+      // package 4 depends on package 5
+      await run(testDir)("--cd-version", "patch");
+      expect(gitCommitMessage()).toBe("v1.0.1");
+      expect(updatedPackageVersions(testDir)).toMatchSnapshot("[republish prereleased] patch");
+      expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
+        "package-5": "^1.0.1",
+      });
+    });
+
+    it('should not publish prereleased packages if --cd-version is a pre-* increment', async () => {
+      // should republish only package 3, because it changed
+      await run(testDir)("--cd-version", "prerelease", '---preid', 'beta');
+      expect(gitCommitMessage()).toBe("v1.0.1-beta.4");
+      expect(updatedPackageVersions(testDir)).toMatchSnapshot("[republish prereleased] prerelease");
+    });
+
+  });
+
   /** =========================================================================
    * INDEPENDENT - CD VERSION
    * ======================================================================= */

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -499,6 +499,20 @@ Array [
 ]
 `;
 
+exports[`[republish prereleased] patch 1`] = `
+Object {
+  "packages/package-3": "1.0.1",
+  "packages/package-4": "1.0.1",
+  "packages/package-5": "1.0.1",
+}
+`;
+
+exports[`[republish prereleased] prerelease 1`] = `
+Object {
+  "packages/package-3": "1.0.1-beta.4",
+}
+`;
+
 exports[`PublishCommand --allow-branch with --canary does not restrict publishing canary versions 1`] = `
 Object {
   "packages/package-1": "1.1.0-alpha.deadbeef",

--- a/test/fixtures/PublishCommand/republish-prereleased/lerna.json
+++ b/test/fixtures/PublishCommand/republish-prereleased/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.1-beta.3"
+}

--- a/test/fixtures/PublishCommand/republish-prereleased/package.json
+++ b/test/fixtures/PublishCommand/republish-prereleased/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "normal"
+}

--- a/test/fixtures/PublishCommand/republish-prereleased/packages/package-1/package.json
+++ b/test/fixtures/PublishCommand/republish-prereleased/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/republish-prereleased/packages/package-2/package.json
+++ b/test/fixtures/PublishCommand/republish-prereleased/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/republish-prereleased/packages/package-3/package.json
+++ b/test/fixtures/PublishCommand/republish-prereleased/packages/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "devDependencies": {
+    "package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/republish-prereleased/packages/package-4/package.json
+++ b/test/fixtures/PublishCommand/republish-prereleased/packages/package-4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-5": "^1.0.1-beta.3"
+  }
+}

--- a/test/fixtures/PublishCommand/republish-prereleased/packages/package-5/package.json
+++ b/test/fixtures/PublishCommand/republish-prereleased/packages/package-5/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-5",
+  "dependencies": {
+    "package-1": "1.0.0"
+  },
+  "private": true,
+  "version": "1.0.1-beta.3"
+}

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -212,6 +212,7 @@ lerna info canary enabled
 lerna info current version 1.0.0
 lerna info Checking for updated packages...
 lerna info Comparing with initial commit.
+lerna info Checking for prereleased packages...
 lerna info auto-confirmed "
 `;
 
@@ -221,6 +222,7 @@ lerna info canary enabled
 lerna info current version 1.0.0
 lerna info Checking for updated packages...
 lerna info Comparing with initial commit.
+lerna info Checking for prereleased packages...
 lerna info auto-confirmed "
 `;
 
@@ -229,6 +231,7 @@ exports[`stderr: exit 0 when no updates 1`] = `
 lerna info current version 1.0.0
 lerna info Checking for updated packages...
 lerna info Comparing with v1.0.0.
+lerna info Checking for prereleased packages...
 lerna info No updated packages to publish. "
 `;
 
@@ -237,6 +240,7 @@ exports[`stderr: updates fixed versions 1`] = `
 lerna info current version 1.0.0
 lerna info Checking for updated packages...
 lerna info Comparing with initial commit.
+lerna info Checking for prereleased packages...
 lerna info auto-confirmed "
 `;
 
@@ -245,6 +249,7 @@ exports[`stderr: updates independent versions 1`] = `
 lerna info versioning independent
 lerna info Checking for updated packages...
 lerna info Comparing with initial commit.
+lerna info Checking for prereleased packages...
 lerna info auto-confirmed "
 `;
 


### PR DESCRIPTION
## Description
When you publish with --cd-version pre-*, and then publish with --cd-version major/minor/patch, some of your packages will still have prerelease version numbers, which is not desirable.

When you're finished with all your changes, all your packages should have non-prerelease version numbers.

This change updates the code to make it release both changed and prereleased versions if the version increment is a non-prerelease increment.

## Motivation and Context
Fixes #567

I manage a lerna monorepo with ~150 packages. Our current strategy for getting rid of prerelease version numbers is to run `lerna publish --force-publish=*`. Because of this, we often get stuck in merge hell when merging feature branches, because that updates every package's package.json file. Making this change means having conflicts in only a few package.json files instead of hundreds.

## How Has This Been Tested?
Added a few unit tests and verified that they passed without breaking other unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
