### PR TITLE
Generate root changelog in fixed mode

### DIFF
--- a/src/ConventionalChangelogContext.js
+++ b/src/ConventionalChangelogContext.js
@@ -1,0 +1,7 @@
+import Repository from './Repository';
+
+const repository = new Repository(process.cwd());
+
+export default {
+  version: repository.version
+};

--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -69,6 +69,15 @@ export default class ConventionalCommitUtilities {
     ConventionalCommitUtilities.updateChangelog(pkg, opts, "updateFixedChangelog", args);
   }
 
+  static updateFixedRootChangelog(pkg, opts) {
+    const args = [
+      CHANGELOG_CLI,
+      "-p", "angular",
+      "--context", path.resolve(__dirname, "..", "lib", "ConventionalChangelogContext.js"),
+    ];
+    ConventionalCommitUtilities.updateChangelog(pkg, opts, "updateFixedRootChangelog", args);
+  }
+
   static updateChangelog(pkg, opts, type, args) {
     log.silly(type, "for %s at %s", pkg.name, pkg.location);
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -590,6 +590,21 @@ export default class PublishCommand extends Command {
       changedFiles.push(packageJsonLocation);
     });
 
+    if (this.options.conventionalCommits) {
+      if (!this.repository.isIndependent()) {
+        const packageJson = this.repository.packageJson;
+
+        ConventionalCommitUtilities.updateFixedRootChangelog({
+          name: packageJson && packageJson.name ? packageJson.name : 'root',
+          location: this.repository.rootPath
+        }, this.execOpts);
+
+        changedFiles.push(ConventionalCommitUtilities.changelogLocation({
+          location: this.repository.rootPath
+        }));
+      }
+    }
+
     if (this.gitEnabled) {
       changedFiles.forEach((file) => GitUtilities.addFile(file, this.execOpts));
     }

--- a/test/ConventionalCommitUtilities.js
+++ b/test/ConventionalCommitUtilities.js
@@ -178,5 +178,77 @@ describe("ConventionalCommitUtilities", () => {
         `
       );
     });
+
+    it("should pass package-specific arguments in independent mode", () => {
+      ConventionalCommitUtilities.updateChangelog = jest.fn();
+
+      ConventionalCommitUtilities.updateIndependentChangelog({
+        name: "bar",
+        location: "/foo/bar",
+      }, null);
+
+      expect(ConventionalCommitUtilities.updateChangelog).toBeCalledWith(
+        {
+          name: "bar",
+          location: "/foo/bar",
+        },
+        null,
+        "updateIndependentChangelog",
+        [
+          require.resolve("conventional-changelog-cli/cli"),
+          "-l", "bar",
+          "--commit-path", "/foo/bar",
+          "--pkg", path.normalize("/foo/bar/package.json"),
+          "-p", "angular",
+        ]
+      );
+    });
+
+    it("should pass package-specific arguments in fixed mode", () => {
+      ConventionalCommitUtilities.updateChangelog = jest.fn();
+
+      ConventionalCommitUtilities.updateFixedChangelog({
+        name: "bar",
+        location: "/foo/bar",
+      }, null);
+
+      expect(ConventionalCommitUtilities.updateChangelog).toBeCalledWith(
+        {
+          name: "bar",
+          location: "/foo/bar",
+        },
+        null,
+        "updateFixedChangelog",
+        [
+          require.resolve("conventional-changelog-cli/cli"),
+          "--commit-path", "/foo/bar",
+          "--pkg", path.normalize("/foo/bar/package.json"),
+          "-p", "angular",
+        ]
+      );
+    });
+
+    it("should pass custom context in fixed root mode", () => {
+      ConventionalCommitUtilities.updateChangelog = jest.fn();
+
+      ConventionalCommitUtilities.updateFixedRootChangelog({
+        name: "bar",
+        location: "/foo/bar",
+      }, null);
+
+      expect(ConventionalCommitUtilities.updateChangelog).toBeCalledWith(
+        {
+          name: "bar",
+          location: "/foo/bar",
+        },
+        null,
+        "updateFixedRootChangelog",
+        [
+          require.resolve("conventional-changelog-cli/cli"),
+          "-p", "angular",
+          "--context", path.resolve(__dirname, "..", "lib", "ConventionalChangelogContext.js")
+        ]
+      );
+    });
   });
 });

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -801,6 +801,7 @@ describe("PublishCommand", () => {
     const recommendFixedVersion = ConventionalCommitUtilities.recommendFixedVersion;
 
     const updateIndependentChangelog = ConventionalCommitUtilities.updateIndependentChangelog;
+    const updateFixedRootChangelog = ConventionalCommitUtilities.updateFixedRootChangelog;
     const updateFixedChangelog = ConventionalCommitUtilities.updateFixedChangelog;
 
     let testDir;
@@ -869,11 +870,13 @@ describe("PublishCommand", () => {
         testDir = dir;
 
         ConventionalCommitUtilities.recommendFixedVersion = jest.fn(() => reccomendReplies.shift());
+        ConventionalCommitUtilities.updateFixedRootChangelog = jest.fn();
         ConventionalCommitUtilities.updateFixedChangelog = jest.fn();
       }));
 
       afterEach(() => {
         ConventionalCommitUtilities.recommendFixedVersion = recommendFixedVersion;
+        ConventionalCommitUtilities.updateFixedRootChangelog = updateFixedRootChangelog;
         ConventionalCommitUtilities.updateFixedChangelog = updateFixedChangelog;
       });
 
@@ -905,6 +908,14 @@ describe("PublishCommand", () => {
               execOpts(testDir)
             );
           });
+
+          expect(ConventionalCommitUtilities.updateFixedRootChangelog).toBeCalledWith(
+            expect.objectContaining({
+              name: 'normal',
+              location: path.join(testDir)
+            }),
+            execOpts(testDir)
+          );
         });
       });
     });

--- a/test/__snapshots__/PublishCommand.js.snap
+++ b/test/__snapshots__/PublishCommand.js.snap
@@ -13,6 +13,7 @@ Array [
   "packages/package-4/package.json",
   "packages/package-5/CHANGELOG.md",
   "packages/package-5/package.json",
+  "CHANGELOG.md",
 ]
 `;
 

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -243,10 +243,9 @@ describe("lerna publish", () => {
 
   });
 
-  // TODO: stabilize timestamp of changelog output
-  // TODO: make interesting git history for meaningful snapshots
-  test.skip("--conventional-commits", async () => {
-    const cwd = await initFixture("PublishCommand/independent");
+  // TODO: stabilize timestamp and commit sha of changelog output
+  test.skip("fixed mode --conventional-commits changelog", async () => {
+    const cwd = await initFixture("PublishCommand/normal", "feat: init repo");
     const args = [
       "publish",
       "--conventional-commits",
@@ -255,19 +254,96 @@ describe("lerna publish", () => {
       "--yes",
     ];
 
+    await commitChangeToPackage(
+      cwd,
+      "package-1",
+      "feat(package-1): Add foo feature",
+      { foo: true }
+    );
+    await commitChangeToPackage(
+      cwd,
+      "package-1",
+      "fix(package-1): Fix foo feature",
+      { foo: false }
+    );
+    await commitChangeToPackage(
+      cwd,
+      "package-2",
+      "fix(package-2): Fix bar feature",
+      { bar: true }
+    );
+    await commitChangeToPackage(
+      cwd,
+      "package-3",
+      "feat(package-3): Add baz feature\n\nBREAKING CHANGE: ... more information...",
+      { baz: true }
+    );
+
     const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
-    expect(stdout).toMatchSnapshot("stdout: --conventional-commits");
-    expect(stderr).toMatchSnapshot("stderr: --conventional-commits");
+    expect(stdout).toMatchSnapshot("stdout: --conventional-commits fixed mode");
+    expect(stderr).toMatchSnapshot("stderr: --conventional-commits fixed mode");
 
     const [allPackageJsons, changelogFiles] = await Promise.all([
       loadPkgManifests(cwd),
       globby(["CHANGELOG.md"], { cwd, absolute: true, matchBase: true })
         .then((changelogs) => Promise.all(
-          changelogs.map((fp) => fs.readFile(fp, "utf8"))
+          changelogs.map(async (fp) => [fp, await fs.readFile(fp, "utf8")])
         )),
     ]);
 
-    expect(allPackageJsons).toMatchSnapshot("packages: --conventional-commits");
-    expect(changelogFiles).toMatchSnapshot("changelog: --conventional-commits");
+    expect(allPackageJsons).toMatchSnapshot("packages: --conventional-commits fixed mode");
+    expect(changelogFiles).toMatchSnapshot("changelog: --conventional-commits fixed mode");
+  });
+
+  // TODO: stabilize timestamp of and commit sha changelog output
+  test.skip("independent mode --conventional-commits changelog", async () => {
+    const cwd = await initFixture("PublishCommand/independent", "feat: init repo");
+    const args = [
+      "publish",
+      "--conventional-commits",
+      "--skip-git",
+      "--skip-npm",
+      "--yes",
+    ];
+
+    await commitChangeToPackage(
+      cwd,
+      "package-1",
+      "feat(package-1): Add foo feature",
+      { foo: true }
+    );
+    await commitChangeToPackage(
+      cwd,
+      "package-1",
+      "fix(package-1): Fix foo feature",
+      { foo: false }
+    );
+    await commitChangeToPackage(
+      cwd,
+      "package-2",
+      "fix(package-2): Fix bar feature",
+      { bar: true }
+    );
+    await commitChangeToPackage(
+      cwd,
+      "package-3",
+      "feat(package-3): Add baz feature\n\nBREAKING CHANGE: ... more information...",
+      { baz: true }
+    );
+
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stdout).toMatchSnapshot("stdout: --conventional-commits independent mode");
+    expect(stderr).toMatchSnapshot("stderr: --conventional-commits independent mode");
+
+    const [allPackageJsons, changelogFiles] = await Promise.all([
+      loadPkgManifests(cwd),
+      globby(["CHANGELOG.md"], { cwd, absolute: true, matchBase: true })
+        .then((changelogs) => Promise.all(
+          changelogs.map(async (fp) => [fp, await fs.readFile(fp, "utf8")])
+        )),
+    ]);
+
+    expect(allPackageJsons).toMatchSnapshot("packages: --conventional-commits independent mode");
+    expect(changelogFiles).toMatchSnapshot("changelog: --conventional-commits independent mode");
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The integration of [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) into lerna (via the `--conventional-commits` flag) currently generates one `CHANGELOG.md` file per package.

This is fine as long as lerna is configured in "independent mode", but when using lerna in "fixed mode" it might be desirable to additionally generate a consolidated `CHANGELOG.md` in the root directory of the repository.  
This "root changelog" contains changes for all packages, while the per package changelogs only list changes affecting their package.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Based on the discussion in #1015 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added unit tests for changelog generation
* Updated unit tests for publish command
* locally tested this in a repository
* updated integration tests, activated them, compared snapshots and deactivated them
  * they were deactivated before, because the changelog contains dates and commit sha ids that are not stable across multiple runs. I therefore deactivated these tests again until a viable solution can be found (maybe a custom snapshot serializer to modify the files beforehand and remove all unstable values from it).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
