### PR TITLE
Add test for skipping empty patches during import --flatten

### DIFF
--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -110,6 +110,22 @@ describe("ImportCommand", () => {
       expect(await pathExists(newFilePath)).toBe(true);
     });
 
+    it("skips empty patches with --flatten", async () => {
+      const cwdExternalDir = { cwd: externalDir };
+      const filePath = path.join(externalDir, "file.txt");
+
+      await fs.writeFile(filePath, "non-empty content");
+      await execa("git", ["add", filePath], cwdExternalDir);
+      await execa("git", ["commit", "-m", "Non-empty commit"], cwdExternalDir);
+
+      await execa("git", ["commit", "--allow-empty", "-m", "Empty commit"], cwdExternalDir);
+
+      const { exitCode } = await lernaImport(externalDir, "--flatten");
+
+      expect(await lastCommitInDir(testDir)).toBe("Non-empty commit");
+      expect(exitCode).toBe(0);
+    });
+
     it("exits early when confirmation is rejected", async () => {
       PromptUtilities.confirm = jest.fn(callsBack(false));
 


### PR DESCRIPTION
Currently, `lerna import --flatten` fails to import repositories with empty commits. This PR fixes this by detecting the case and skipping any empty commits.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch skips empty commits when `lerna import --flatten` is used. This is done by detecting empty patches and using `git am --skip`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using `lerna import --flatten` on repos with empty commits yields a cryptic error, because `git am` does not support importing of empty commits:

```
lerna ERR! execute callback with error
(node:24090) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): TypeError: Cannot read property 'split' of undefined 
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a unit test, and used the new import on a repository that previously failed with the above error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
