### PR TITLE
Warn about two or more packages having the same npm package.json name

### DIFF
--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -167,6 +167,27 @@ export default class PackageUtilities {
     ;
   }
 
+  static validatePackageNames(packages) {
+    const existingPackageNames = {};
+
+    packages.forEach((pkg) => {
+      if (!existingPackageNames[pkg.name]) {
+        existingPackageNames[pkg.name] = [];
+      }
+  
+      existingPackageNames[pkg.name].push(pkg._location);
+    });
+  
+    for (const pkgName in existingPackageNames) {
+      if (existingPackageNames[pkgName].length > 1) {
+        log.warn(
+          `Package name "${pkgName}" used in multiple packages:
+          \t${existingPackageNames[pkgName].join('\n\t')}`
+        );
+      }
+    }
+  }
+
   static topologicallyBatchPackages(packagesToBatch, { depsOnly } = {}) {
     // We're going to be chopping stuff out of this array, so copy it.
     const packages = packagesToBatch.slice();

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -73,6 +73,8 @@ export default class BootstrapCommand extends Command {
       }).catch(callback);
     }
 
+    PackageUtilities.validatePackageNames(this.filteredPackages);
+
     this.logger.silly("npmConfig", this.npmConfig);
     callback(null, true);
   }

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -231,6 +231,49 @@ describe("PackageUtilities", () => {
     });
   });
 
+  describe(".validatePackageNames()", () => {
+    it("should log a warning if multiple packages have the same name", () => {
+      const logMessages = [];
+      const packagesToValidate = [
+        { name: "name1", _location: "packages/package1" },
+        { name: "name2", _location: "packages/package2" },
+        { name: "name3", _location: "packages/package3" },
+        { name: "name1", _location: "packages/package4" },
+        { name: "name1", _location: "packages/package5" },
+        { name: "name2", _location: "packages/package6" },
+      ];
+      log.on("log.warn", (message) => {
+        logMessages.push(message.prefix);
+      });
+
+      PackageUtilities.validatePackageNames(packagesToValidate);
+      
+      expect(logMessages[0]).toContain('Package name "name1" used in multiple packages:');
+      expect(logMessages[0]).toContain('packages/package1');
+      expect(logMessages[0]).toContain('packages/package4');
+      expect(logMessages[0]).toContain('packages/package5');
+      expect(logMessages[1]).toContain('Package name "name2" used in multiple packages:');
+      expect(logMessages[1]).toContain('packages/package2');
+      expect(logMessages[1]).toContain('packages/package6');
+    });
+
+    it("should not log any warning if packages all have the unique name", () => {
+      let didLogOccur = false;
+      const packagesToValidate = [
+        { name: "name1", _location: "packages/package1" },
+        { name: "name2", _location: "packages/package2" },
+        { name: "name3", _location: "packages/package3" }
+      ];
+      log.once("log.warn", () => {
+        didLogOccur = true;
+      });
+
+      PackageUtilities.validatePackageNames(packagesToValidate);
+      
+      expect(didLogOccur).toBeFalsy();
+    });
+  });
+
   describe(".topologicallyBatchPackages()", () => {
     let packages;
 


### PR DESCRIPTION
## Description
Adds a warning when you bootstrap a project where 2 or more packages share the same name.

Example:
<img width="417" alt="screen shot 2017-10-18 at 18 40 04" src="https://user-images.githubusercontent.com/8076682/31733543-e1d7c424-b433-11e7-98b5-56a271e520a9.png">


## Motivation and Context
Closes #1046
"Lerna does some weird things if there are multiple packages with the same name, like leaving one directory empty and the other one full of things, while creating symlinks correctly."

## How Has This Been Tested?
Has unit tests.

Tested with 2 existing projects that utilise Lerna to ensure it doesn't warn when packages are name uniquely. Tested it with a dummy project that had packages that shared the same name and it did show the correct warning.

Tested on Mac OSX 10.12.4, node 5.8.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
