### PR TITLE
Fixed diffing on Windows

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -6,6 +6,8 @@
   plugins:
     - node
   rules:
+    space-before-blocks:
+      - error
     node/no-unsupported-features:
       - error
       - version: 4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,12 +22,40 @@ In order to run the tests:
 
 ```sh
 $ npm test
+# If you want to watch for changes
+$ npm run test:watch
+# If you want to watch individual files
+$ npm run test:watch -- test.command # watches for changes to test/Command.js
+
+# with yarn
+$ yarn test
+$ yarn test:watch
+$ yarn test:watch test.command
+```
+
+As a note, you may want to run `npm run dev` or `yarn dev` in a separate
+terminal while running tests with the watcher to ensure any changes you need to
+make, get built.
+
+To run the integration tests:
+
+```sh
+$ npm run test:watch-integration
+# For a specific file
+$ npm run test:watch-integration -- lerna-publish
+
+# with yarn
+$ yarn test:watch-integration
+$ yarn test:watch-integration lerna-publish
 ```
 
 Or the linter:
 
 ```sh
 $ npm run lint
+
+# with yarn
+$ yarn lint
 ```
 
 If you want to test out Lerna on local repos:
@@ -35,6 +63,10 @@ If you want to test out Lerna on local repos:
 ```sh
 $ npm run build
 $ npm link
+
+# with yarn
+$ yarn build
+$ yarn link
 ```
 
 This will set your global `lerna` command to the local version.
@@ -44,6 +76,9 @@ Note that Lerna needs to be built after changes are made. So you can either run
 
 ```sh
 $ npm run dev
+
+# with yarn
+$ yarn dev
 ```
 
 Which will start a watch task that will continuously re-build Lerna while you

--- a/package.json
+++ b/package.json
@@ -9,15 +9,17 @@
   ],
   "scripts": {
     "build": "babel src -d lib",
+    "ci": "npm test -- --coverage --verbose && npm run integration",
     "dev": "babel -w src -d lib",
-    "lint": "eslint . --ignore-path .gitignore",
     "fix": "npm run lint -- --fix",
     "preintegration": "npm pack",
-    "integration": "jest --config test/config/integration.json",
+    "integration": "cross-env LC_ALL=en-US jest --config test/config/integration.json",
+    "lint": "eslint . --ignore-path .gitignore",
+    "prepublish": "npm run build",
     "pretest": "npm run lint -- --cache",
     "test": "cross-env LC_ALL=en-US jest",
-    "ci": "npm test -- --coverage --verbose && npm run integration",
-    "prepublish": "npm run build"
+    "test:watch": "cross-env LC_ALL=en-US jest --watchAll --no-watchman",
+    "test:watch-integration": "npm run integration -- --watchAll --no-watchman"
   },
   "repository": {
     "type": "git",

--- a/src/Command.js
+++ b/src/Command.js
@@ -219,6 +219,7 @@ export default class Command {
     return new Promise((resolve, reject) => {
       const onComplete = (err, exitCode) => {
         if (err) {
+          if(typeof err === 'string') err = { stack:err };
           err.exitCode = exitCode;
           reject(err);
         } else {
@@ -477,7 +478,7 @@ export function commandNameFromClassName(className) {
 }
 
 function cleanStack(err, className) {
-  const lines = err.stack.split('\n');
+  const lines = (err.stack) ? err.stack.split('\n') : err.split('\n');
   const cutoff = new RegExp(`^    at ${className}._attempt .*$`);
   const relevantIndex = lines.findIndex((line) => cutoff.test(line));
   return lines.slice(0, relevantIndex).join('\n');

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -1,5 +1,6 @@
 import { EOL } from "os";
 import log from "npmlog";
+import path from "path";
 import tempWrite from "temp-write";
 
 import ChildProcessUtilities from "./ChildProcessUtilities";
@@ -129,9 +130,12 @@ export default class GitUtilities {
   }
 
   static diffSinceIn(since, location, opts) {
-    log.silly("diffSinceIn", since, location);
+    const formattedLocation = path.relative(opts.cwd, location).replace(/\\/g, '/');
+    log.silly("diffSinceIn", since, formattedLocation);
 
-    const diff = ChildProcessUtilities.execSync("git", ["diff", "--name-only", since, "--", location], opts);
+    const diff = ChildProcessUtilities.execSync("git", [
+      "diff", "--name-only", since, "--", formattedLocation
+    ], opts);
     log.silly("diff", diff);
 
     return diff;

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -143,7 +143,8 @@ export default class ImportCommand extends Command {
       ]);
     }
 
-    const replacement = "$1/" + this.targetDir;
+    const formattedTarget = this.targetDir.replace(/\\/g, '/');
+    const replacement = `$1/${ formattedTarget }`;
     // Create a patch file for this commit and prepend the target directory
     // to all affected files.  This moves the git history for the entire
     // external repository into the package subdirectory, commit by commit.
@@ -152,7 +153,7 @@ export default class ImportCommand extends Command {
         .replace(/^([-+]{3} [ab])/mg,     replacement)
         .replace(/^(diff --git a)/mg,     replacement)
         .replace(/^(diff --git \S+ b)/mg, replacement)
-        .replace(/^(rename (from|to)) /mg, `$1 ${this.targetDir}/`)
+        .replace(/^(rename (from|to)) /mg, `$1 ${formattedTarget}/`)
     );
   }
 

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -1,4 +1,5 @@
 import { EOL } from "os";
+import path from "path";
 
 // mocked modules
 import tempWrite from "temp-write";
@@ -213,7 +214,7 @@ describe("GitUtilities", () => {
   describe(".diffSinceIn()", () => {
     it("returns list of files changed since commit at location", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "files");
-      const opts = { cwd: "test" };
+      const opts = { cwd: path.resolve(__dirname, "./..") };
       expect(GitUtilities.diffSinceIn("foo@1.0.0", "packages/foo", opts)).toBe("files");
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git", ["diff", "--name-only", "foo@1.0.0", "--", "packages/foo"], opts


### PR DESCRIPTION
## Description
- Added eslint rule to enforce block spacing
- Alphabetized package.json scripts and added a `watch` command for testing
- Ensured that paths are normalized so that when diffing occurs, changes show up on Windows systems

## Motivation and Context
Allows devs on Windows machines to utilize features such as `lerna updated`.

## How Has This Been Tested?
- Ran the test command multiple times
- Had a coworker run my code on his Mac
- Used my changes in a repo that was not showing diffs, and after adding my changes I'm now seeing a list of updated modules after running `lerna updated`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
