### PR TITLE
Add --reject-cycles parameter, logging packages when found

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,10 +895,10 @@ May also be configured in `lerna.json`:
 
 #### --reject-cycles
 
-Fail immediately if a cycle is found (in `oobstrap`, `exec`, `publish` or `run`).
+Fail immediately if a cycle is found (in `bootstrap`, `exec`, `publish` or `run`).
 
 ```sh
-$ lerna boostrap --reject-cycles
+$ lerna bootstrap --reject-cycles
 ```
 
 #### --use-workspaces

--- a/README.md
+++ b/README.md
@@ -893,6 +893,14 @@ May also be configured in `lerna.json`:
 }
 ```
 
+#### --reject-cycles
+
+Fail immediately if a cycle is found (in `oobstrap`, `exec`, `publish` or `run`).
+
+```sh
+$ lerna boostrap --reject-cycles
+```
+
 #### --use-workspaces
 
 Enables integration with [Yarn Workspaces](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-workspaces-install-phase-1.md) (available since yarn@0.27+).

--- a/src/Command.js
+++ b/src/Command.js
@@ -64,6 +64,11 @@ export const builder = {
     type: "string",
     requiresArg: true,
   },
+  "reject-cycles": {
+    describe: "Fail if a cycle is detected among dependencies",
+    type: "boolean",
+    default: false
+  },
   "sort": {
     describe: "Sort packages topologically (all dependencies before dependents)",
     type: "boolean",

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -49,9 +49,15 @@ export default class ExecCommand extends Command {
 
     const { filteredPackages } = this;
 
+    try {
     this.batchedPackages = this.toposort
-      ? PackageUtilities.topologicallyBatchPackages(filteredPackages)
+      ? PackageUtilities.topologicallyBatchPackages(filteredPackages, {
+        rejectCycles: this.options.rejectCycles
+      })
       : [filteredPackages];
+    } catch (e) {
+      return callback(e);
+    }
 
     callback(null, true);
   }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -200,13 +200,18 @@ export default class PublishCommand extends Command {
       .filter((pkg) => !pkg.isPrivate());
 
     this.packagesToPublishCount = this.packagesToPublish.length;
+    try {
     this.batchedPackagesToPublish = this.toposort
       ? PackageUtilities.topologicallyBatchPackages(this.packagesToPublish, {
         // Don't sort based on devDependencies because that would increase the chance of dependency cycles
         // causing less-than-ideal a publishing order.
         depsOnly: true,
+        rejectCycles: this.options.rejectCycles
       })
       : [this.packagesToPublish];
+    } catch (e) {
+      return callback(e);
+    }
 
     if (!this.updates.length) {
       this.logger.info("No updated packages to publish.");

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -68,9 +68,15 @@ export default class RunCommand extends Command {
       this.logger.disableProgress();
     }
 
+    try {
     this.batchedPackages = this.toposort
-      ? PackageUtilities.topologicallyBatchPackages(this.packagesWithScript)
+      ? PackageUtilities.topologicallyBatchPackages(this.packagesWithScript, {
+        rejectCycles: this.options.rejectCycles
+      })
       : [this.packagesWithScript];
+    } catch (e) {
+      return callback(e);
+    }
 
     callback(null, true);
   }


### PR DESCRIPTION
* When `--reject-cycles` is provided, `lerna` will stop with a non-zero exit code if a cycle is detected
* When a cycle is detected, the error message lists the package names in the cycle

## Motivation and Context
See #1085

## How Has This Been Tested?
1. Created a local `lerna` project with a cycle
2. Reproduced the "error in cycle" warning without `--reject-cycles`
3. Ensured that `lerna` stops immediately if `--reject-cycles` and a cycle is found

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
