### PR TITLE
ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ coverage/
 .nyc_output/
 .eslintcache
 *.tgz
+
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
When installing the dev install as documented in `CONTRIBUTING.md`, a `package-lock.json` is created with `npm`. This sets the `.npmrc` to not create `package-lock`s as well as gitignore them in the repository.

The motivation for this is to ensure that following the dev install keeps a clean git tree.