### PR TITLE
Symlink peerDependencies that are in the same monorepo.

### DIFF
--- a/src/Package.js
+++ b/src/Package.js
@@ -57,6 +57,15 @@ export default class Package {
     );
   }
 
+  get fullDependencies() {
+    return Object.assign(
+      {},
+      this.peerDependencies,
+      this.devDependencies,
+      this.dependencies
+    );
+  }
+
   get scripts() {
     return this._package.scripts || {};
   }
@@ -117,7 +126,7 @@ export default class Package {
   hasMatchingDependency(dependency, doWarn) {
     log.silly("hasMatchingDependency", this.name, dependency.name);
 
-    const expectedVersion = this.allDependencies[dependency.name];
+    const expectedVersion = this.fullDependencies[dependency.name];
     const actualVersion = dependency.version;
 
     if (!expectedVersion) {
@@ -148,7 +157,7 @@ export default class Package {
     log.silly("hasDependencyInstalled", this.name, depName);
 
     return dependencyIsSatisfied(
-      this.nodeModulesLocation, depName, this.allDependencies[depName]
+      this.nodeModulesLocation, depName, this.fullDependencies[depName]
     );
   }
 }

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -267,7 +267,7 @@ export default class PackageUtilities {
 
     const actions = packages.map((iteratedPackage) => {
       const filteredDependencyNames = Object
-        .keys(iteratedPackage.allDependencies)
+        .keys(iteratedPackage.fullDependencies)
         .filter((dependency) => {
           // Filter out external dependencies and incompatible packages
           // (e.g. dependencies without a package.json file)

--- a/test/__snapshots__/BootstrapCommand.js.snap
+++ b/test/__snapshots__/BootstrapCommand.js.snap
@@ -134,6 +134,11 @@ Array [
     "dest": "packages/package-4/node_modules/.bin/package3cli2",
     "type": "exec",
   },
+  Object {
+    "_src": "packages/package-1",
+    "dest": "packages/package-5/node_modules/@test/package-1",
+    "type": "junction",
+  },
 ]
 `;
 

--- a/test/fixtures/BootstrapCommand/basic/packages/package-5/package.json
+++ b/test/fixtures/BootstrapCommand/basic/packages/package-5/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-5",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@test/package-1": "^1.0.0"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make `lerna bootstrap` symlink `peerDependencies` in the same monorepo. 

## Motivation and Context
Babel is adding a peerDependency on `@babel/core` to all of our plugins, and currently Lerna just ignores that instead of linking it.

## How Has This Been Tested?
`npm link lerna`ed into Babel and bootstrap added the symlinks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I don't see where this would be a breaking change, but I guess technically it is possible that someone was relying on the symlink _not_ being added?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
