### PR TITLE
Set chmod for linked binaries

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -22,6 +22,16 @@ function trailingSlash(filePath) {
 }
 
 export default class FileSystemUtilities {
+  static chmod(filePath, mode, cb) {
+    log.silly("chmod", filePath, mode);
+    fs.chmod(filePath, mode, cb);
+  }
+
+  static chmodSync(filePath, mode) {
+    log.silly("chmodSync", filePath, mode);
+    fs.chmodSync(filePath, mode);
+  }
+
   static mkdirp(filePath, callback) {
     log.silly("mkdirp", filePath);
     fs.ensureDir(filePath, callback);

--- a/src/Package.js
+++ b/src/Package.js
@@ -25,6 +25,10 @@ export default class Package {
     return path.join(this._location, "node_modules");
   }
 
+  get binLocation() {
+    return path.join(this.nodeModulesLocation, ".bin");
+  }
+
   get version() {
     return this._package.version;
   }

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -370,8 +370,8 @@ export default class PackageUtilities {
             return cb();
           }
 
-          const mode = (stats.mode & parseInt('777', '0')).toString('8');
-          if (mode[0] === '7') {
+          const mode = (stats.mode & parseInt("777", "0")).toString("8");
+          if (mode[0] === "7") {
             return cb();
           }
           FileSystemUtilities.chmod(src, "755", cb)

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -364,7 +364,7 @@ export default class PackageUtilities {
       .reduce((acc, {src, dst}) => {
         const link = (cb) => FileSystemUtilities.symlink(src, dst, "exec", cb);
         const chmod = (cb) => FileSystemUtilities.chmod(src, "755", cb);
-        const actions = FileSystemUtilities.existsSync(src) ? [link, chmod] : [link];
+        const actions = FileSystemUtilities.existsSync(src) ? [link, chmod] : [];
 
         acc.push((cb) => async.series(actions, cb));
         return acc;

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -374,6 +374,7 @@ export default class PackageUtilities {
           if (mode[0] === "7") {
             return cb();
           }
+          console.log(src);
           FileSystemUtilities.chmod(src, "755", cb)
         };
         const exec = (cb) => async.series([link, chmod], cb);

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -363,7 +363,8 @@ export default class PackageUtilities {
       }))
       .reduce((acc, {src, dst}) => {
         const link = cb => FileSystemUtilities.symlink(src, dst, "exec", cb);
-        const exec = (cb) => async.series([link], cb);
+        const chmod = cb => FileSystemUtilities.chmod(src, "755", cb);
+        const exec = (cb) => async.series([link, chmod], cb);
         acc.push(exec);
         return acc;
       }, []);

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -374,7 +374,7 @@ export default class PackageUtilities {
           if (mode[0] === '7') {
             return cb();
           }
-          FileSystemUtilities.chmod(dst, "755", cb)
+          FileSystemUtilities.chmod(src, "755", cb)
         };
         const exec = (cb) => async.series([link, chmod], cb);
         acc.push(exec);

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -437,8 +437,7 @@ export default class BootstrapCommand extends Command {
               if (bin) {
                 async.series(dependents.map((pkg) => (cb) => {
                   const src  = this.hoistedDirectory(name);
-                  const dest = pkg.nodeModulesLocation;
-                  PackageUtilities.createBinaryLink(src, dest, name, bin, cb);
+                  PackageUtilities.createBinaryLink(src, pkg, cb);
                 }), cb);
               } else {
                 cb();

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -484,7 +484,7 @@ describe("PackageUtilities", () => {
       const secondSrcRef = path.join(testDir, "packages/package-3")
       const dest = path.join(testDir, "packages/package-4");
 
-      const cb = () => {
+      const finish = () => {
         expect(dest).toHaveBinaryLink(['links-2', 'links3cli1', 'links3cli2']);
         done();
       };
@@ -492,7 +492,7 @@ describe("PackageUtilities", () => {
       async.series([
         (cb) => PackageUtilities.createBinaryLink(firstSrcRef, dest, cb),
         (cb) => PackageUtilities.createBinaryLink(secondSrcRef, dest, cb),
-      ], cb);
+      ], finish);
     });
   });
 });

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -397,7 +397,7 @@ describe("PackageUtilities", () => {
     });
   });
 
-  describe.only(".createBinaryLink()", () => {
+  describe(".createBinaryLink()", () => {
     it("should work with references", async (done) => {
       const testDir = await initFixture("PackageUtilities/links");
       const srcRef = path.join(testDir, "packages/package-2");

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -1,5 +1,4 @@
 import async from "async";
-import fs from "fs";
 import log from "npmlog";
 import path from "path";
 import readPkg from "read-pkg";
@@ -10,12 +9,15 @@ import Repository from "../src/Repository";
 
 // helpers
 import initFixture from "./helpers/initFixture";
+import pkgMatchers from "./helpers/pkgMatchers";
 
 // file under test
 import PackageUtilities from "../src/PackageUtilities";
 
 // silence logs
 log.level = "silent";
+
+expect.extend(pkgMatchers);
 
 describe("PackageUtilities", () => {
   describe(".getPackages()", () => {
@@ -439,14 +441,11 @@ describe("PackageUtilities", () => {
 
     it("should create a link string bin entry", async (done) => {
       const testDir = await initFixture("PackageUtilities/links");
-      const srcRef = path.join(testDir, "packages/package-2");
-      const destRef = path.join(testDir, "packages/package-3");
-      const src = new Package(await readPkg(srcRef), srcRef);
-      const dest = new Package(await readPkg(destRef), destRef);
+      const src = path.join(testDir, "packages/package-2");
+      const dest = path.join(testDir, "packages/package-3");
 
       const cb = () => {
-        const links = fs.readdirSync(dest.binLocation);
-        expect(links).toEqual(['links-2']);
+        expect(dest).toHaveBinaryLink('links-2');
         done();
       };
 
@@ -455,14 +454,11 @@ describe("PackageUtilities", () => {
 
     it("should create links for object bin entry", async (done) => {
       const testDir = await initFixture("PackageUtilities/links");
-      const srcRef = path.join(testDir, "packages/package-3");
-      const destRef = path.join(testDir, "packages/package-4");
-      const src = new Package(await readPkg(srcRef), srcRef);
-      const dest = new Package(await readPkg(destRef), destRef);
+      const src = path.join(testDir, "packages/package-3");
+      const dest = path.join(testDir, "packages/package-4");
 
       const cb = () => {
-        const links = fs.readdirSync(dest.binLocation);
-        expect(links).toEqual(['links3cli1', 'links3cli2']);
+        expect(dest).toHaveBinaryLink(['links3cli1', 'links3cli2']);
         done();
       };
 
@@ -471,16 +467,11 @@ describe("PackageUtilities", () => {
 
     it("should make links targets executable", async (done) => {
       const testDir = await initFixture("PackageUtilities/links");
-      const srcRef = path.join(testDir, "packages/package-3");
-      const destRef = path.join(testDir, "packages/package-4");
-      const src = new Package(await readPkg(srcRef), srcRef);
-      const dest = new Package(await readPkg(destRef), destRef);
+      const src = path.join(testDir, "packages/package-3");
+      const dest = path.join(testDir, "packages/package-4");
 
       const cb = () => {
-        const cli1Mode = fs.statSync(path.join(src.location, 'cli1.js')).mode;
-        const cli2Mode = fs.statSync(path.join(src.location, 'cli2.js')).mode;
-        expect((cli1Mode & parseInt('777', 8)).toString(8)).toBe('755');
-        expect((cli2Mode & parseInt('777', 8)).toString(8)).toBe('755');
+        expect(src).toHaveExecutable(['cli1.js', 'cli2.js'])
         done();
       };
 
@@ -491,12 +482,10 @@ describe("PackageUtilities", () => {
       const testDir = await initFixture("PackageUtilities/links");
       const firstSrcRef = path.join(testDir, "packages/package-2");
       const secondSrcRef = path.join(testDir, "packages/package-3")
-      const destRef = path.join(testDir, "packages/package-4");
-      const dest = new Package(await readPkg(destRef), destRef);
+      const dest = path.join(testDir, "packages/package-4");
 
       const cb = () => {
-        const links = fs.readdirSync(dest.binLocation);
-        expect(links).toEqual(['links-2', 'links3cli1', 'links3cli2']);
+        expect(dest).toHaveBinaryLink(['links-2', 'links3cli1', 'links3cli2']);
         done();
       };
 

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -462,7 +462,7 @@ describe("PackageUtilities", () => {
 
       const cb = () => {
         const links = fs.readdirSync(dest.binLocation);
-        expect(links).toEqual(['links3cli1', 'links3cli2', 'links3cli3']);
+        expect(links).toEqual(['links3cli1', 'links3cli2']);
         done();
       };
 
@@ -496,7 +496,7 @@ describe("PackageUtilities", () => {
 
       const cb = () => {
         const links = fs.readdirSync(dest.binLocation);
-        expect(links).toEqual(['links-2', 'links3cli1', 'links3cli2', 'links3cli3']);
+        expect(links).toEqual(['links-2', 'links3cli1', 'links3cli2']);
         done();
       };
 

--- a/test/fixtures/PackageUtilities/links/lerna.json
+++ b/test/fixtures/PackageUtilities/links/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PackageUtilities/links/package.json
+++ b/test/fixtures/PackageUtilities/links/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/PackageUtilities/links/packages/package-1/package.json
+++ b/test/fixtures/PackageUtilities/links/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@package-utilities/links-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PackageUtilities/links/packages/package-2/cli.js
+++ b/test/fixtures/PackageUtilities/links/packages/package-2/cli.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/PackageUtilities/links/packages/package-2/package.json
+++ b/test/fixtures/PackageUtilities/links/packages/package-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@package-utilities/links-2",
+  "version": "1.0.0",
+  "bin": "cli.js",
+  "dependencies": {
+    "@package-utilities/links-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/links/packages/package-3/cli1.js
+++ b/test/fixtures/PackageUtilities/links/packages/package-3/cli1.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/PackageUtilities/links/packages/package-3/cli2.js
+++ b/test/fixtures/PackageUtilities/links/packages/package-3/cli2.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hello, world!");

--- a/test/fixtures/PackageUtilities/links/packages/package-3/package.json
+++ b/test/fixtures/PackageUtilities/links/packages/package-3/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "links-3",
+  "version": "1.0.0",
+  "bin": {
+    "links3cli1": "cli1.js",
+    "links3cli2": "cli2.js",
+    "links3cli3": "cli3.js"
+  },
+  "devDependencies": {
+    "@package-utilities/links-1": "^1.0.0",
+    "@package-utilities/links-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/links/packages/package-4/package.json
+++ b/test/fixtures/PackageUtilities/links/packages/package-4/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@package-utilities/links-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "@package-utilities/links-1": "^0.0.0",
+    "links-3": "^1.0.0"
+  }
+}

--- a/test/helpers/pkgMatchers.js
+++ b/test/helpers/pkgMatchers.js
@@ -1,4 +1,54 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import readPkg from "read-pkg";
 import semver from "semver";
+
+import Package from "../../src/Package";
+
+const toPackage = (ref) => {
+  return ref instanceof Package
+    ? ref
+    : new Package(readPkg.sync(ref), ref);
+}
+
+const matchBinaryLinks = (options = {check: false}) => {
+  return (pkgRef, raw) => {
+    const pkg = toPackage(pkgRef);
+
+    const inputs = Array.isArray(raw) ? raw : [raw];
+
+    const links = os.platform() === "win32"
+      ? inputs.reduce((acc, input) => [...acc, input, [input, 'cmd'].join('.')], [])
+      : inputs;
+
+    const expectation = `expected ${pkg.name} to link to ${links.join(', ')}`;
+
+    const found = fs.readdirSync(pkg.binLocation);
+    const missing = links.filter(link => found.indexOf(link) === -1);
+    const superfluous = found.filter(link => links.indexOf(link) === -1);
+
+    if (missing.length > 0 || superfluous.length > 0) {
+      return {
+        message: [
+          expectation,
+          missing.length > 0 ? `missing: ${missing.join(', ')}` : '',
+          superfluous.length > 0 ? `superfluous: ${superfluous.join(', ')}` : ''
+        ].filter(Boolean).join(' '),
+        pass: false
+      };
+    }
+
+    if (options.check) {
+
+    }
+
+    return {
+      message: expectation,
+      pass: true
+    };
+  };
+};
 
 const matchDependency = dependencyType => {
   return (manifest, pkg, range) => {
@@ -44,7 +94,42 @@ const matchDependency = dependencyType => {
   }
 };
 
+const mactchExecutableFile = () => {
+  return (pkgRef, raw) => {
+    const files = Array.isArray(raw) ? raw : [raw];
+    const expectation = `expected ${files.join(', ')} to be executable`;
+
+    if (os.platform() === "win32") {
+      return {
+        message: `${expectation}, skipped check on win32`,
+        pass: true
+      };
+    }
+
+    const pkg = toPackage(pkgRef);
+
+    const failed = files.filter(file => {
+      const stats = fs.statSync(path.join(pkg.location, file));
+      return (stats.mode & parseInt("777", 8)).toString('8')[0] !== "7";
+    });
+
+    const pass = failed.length === 0;
+    const verb = failed.length > 1 ? 'were' : 'was';
+
+    const message = pass
+      ? expectation
+      : `${expectation} while ${failed.join(', ')} ${verb} found to be not executable.`
+
+    return {
+      message,
+      pass
+    };
+  };
+}
+
 export default {
   toDependOn: matchDependency('dependencies'),
-  toDevDependOn: matchDependency('devDependencies')
+  toDevDependOn: matchDependency('devDependencies'),
+  toHaveExecutable: mactchExecutableFile(),
+  toHaveBinaryLink: matchBinaryLinks()
 }

--- a/test/helpers/pkgMatchers.js
+++ b/test/helpers/pkgMatchers.js
@@ -12,7 +12,7 @@ const toPackage = (ref) => {
     : new Package(readPkg.sync(ref, {normalize: false}), ref);
 }
 
-const matchBinaryLinks = (options = {check: false}) => {
+const matchBinaryLinks = () => {
   return (pkgRef, raw) => {
     const pkg = toPackage(pkgRef);
 
@@ -37,10 +37,6 @@ const matchBinaryLinks = (options = {check: false}) => {
         ].filter(Boolean).join(' '),
         pass: false
       };
-    }
-
-    if (options.check) {
-
     }
 
     return {

--- a/test/helpers/pkgMatchers.js
+++ b/test/helpers/pkgMatchers.js
@@ -90,23 +90,21 @@ const matchDependency = dependencyType => {
   }
 };
 
+const X_OK = (fs.constants || fs).X_OK;
+
 const matchExecutableFile = () => {
   return (pkgRef, raw) => {
     const files = Array.isArray(raw) ? raw : [raw];
     const expectation = `expected ${files.join(', ')} to be executable`;
 
-    if (os.platform() === "win32") {
-      return {
-        message: `${expectation}, skipped check on win32`,
-        pass: true
-      };
-    }
-
     const pkg = toPackage(pkgRef);
 
     const failed = files.filter(file => {
-      const stats = fs.statSync(path.join(pkg.location, file));
-      return (stats.mode & parseInt("777", 8)).toString('8')[0] !== "7";
+      try {
+        return fs.accessSync(path.join(pkg.location, file), X_OK);
+      } catch (_) {
+        return false;
+      }
     });
 
     const pass = failed.length === 0;

--- a/test/helpers/pkgMatchers.js
+++ b/test/helpers/pkgMatchers.js
@@ -103,7 +103,7 @@ const matchExecutableFile = () => {
       try {
         return fs.accessSync(path.join(pkg.location, file), X_OK);
       } catch (_) {
-        return false;
+        return true;
       }
     });
 

--- a/test/helpers/pkgMatchers.js
+++ b/test/helpers/pkgMatchers.js
@@ -90,7 +90,7 @@ const matchDependency = dependencyType => {
   }
 };
 
-const mactchExecutableFile = () => {
+const matchExecutableFile = () => {
   return (pkgRef, raw) => {
     const files = Array.isArray(raw) ? raw : [raw];
     const expectation = `expected ${files.join(', ')} to be executable`;
@@ -126,6 +126,6 @@ const mactchExecutableFile = () => {
 export default {
   toDependOn: matchDependency('dependencies'),
   toDevDependOn: matchDependency('devDependencies'),
-  toHaveExecutable: mactchExecutableFile(),
+  toHaveExecutable: matchExecutableFile(),
   toHaveBinaryLink: matchBinaryLinks()
 }

--- a/test/helpers/pkgMatchers.js
+++ b/test/helpers/pkgMatchers.js
@@ -9,7 +9,7 @@ import Package from "../../src/Package";
 const toPackage = (ref) => {
   return ref instanceof Package
     ? ref
-    : new Package(readPkg.sync(ref), ref);
+    : new Package(readPkg.sync(ref, {normalize: false}), ref);
 }
 
 const matchBinaryLinks = (options = {check: false}) => {


### PR DESCRIPTION
## Description

* [x] set chmod 0755 for linked binaries
* [x] refactor createBinaryLink to simpler interface

## Motivation and Context
`lerna boostrap` and `link` successfully create required symlink in dependent `node_modules/.bin/` directories. The linked files are not guaranteed to be executable, which can produce permission errors.

## How Has This Been Tested?

* [x] implement unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
