### PR TITLE
feat(exec): use `spawnStreaming` instead of `spawn` to enable `St…

### DIFF
--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -50,11 +50,11 @@ export default class ExecCommand extends Command {
     const { filteredPackages } = this;
 
     try {
-    this.batchedPackages = this.toposort
-      ? PackageUtilities.topologicallyBatchPackages(filteredPackages, {
-        rejectCycles: this.options.rejectCycles
-      })
-      : [filteredPackages];
+      this.batchedPackages = this.toposort
+        ? PackageUtilities.topologicallyBatchPackages(filteredPackages, {
+          rejectCycles: this.options.rejectCycles
+        })
+        : [filteredPackages];
     } catch (e) {
       return callback(e);
     }
@@ -100,7 +100,7 @@ export default class ExecCommand extends Command {
   }
 
   runCommandInPackage(pkg, callback) {
-    ChildProcessUtilities.spawn(this.command, this.args, this.getOpts(pkg), (err) => {
+    ChildProcessUtilities.spawnStreaming(this.command, this.args, this.getOpts(pkg), pkg.name, (err) => {
       if (err && err.code) {
         this.logger.error("exec", `Errored while executing '${err.cmd}' in '${pkg.name}'`);
       }


### PR DESCRIPTION
…dout` and `Stderr`

<!--- Provide a general summary of your changes in the Title above -->

## Description
At the moment when you run `lerna exec --parallel` You will have detailed information on where the command is running by the means of `Stout`, example each log message will be prefixed by the package name.

However, this is not the case when --parallel flag is not used. I want to make these consistant. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested the changes by linking

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
