### PR TITLE
Add `--stream` option to `lerna exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ $ lerna exec -- protractor conf.js
 Run an arbitrary command in each package.
 A double-dash (`--`) is necessary to pass dashed flags to the spawned command, but is not necessary when all the arguments are positional.
 
-`lerna exec` respects the `--concurrency`, `--scope`, `--ignore`, and `--parallel` flags (see [Flags](#flags)).
+`lerna exec` respects the `--concurrency`, `--scope`, `--ignore`, `--stream` and `--parallel` flags (see [Flags](#flags)).
 
 ```sh
 $ lerna exec --scope my-component -- ls -la

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -164,5 +164,16 @@ describe("ExecCommand", () => {
         "packages/package-2 ls",
       ]);
     });
+
+    it("executes a command in all packages with --stream", async () => {
+      ChildProcessUtilities.spawnStreaming = jest.fn(callsBack());
+
+      await lernaExec("--stream", "ls");
+
+      expect(execInPackagesStreaming(testDir)).toEqual([
+        "packages/package-1 ls",
+        "packages/package-2 ls",
+      ]);
+    });
   });
 });

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -199,7 +199,7 @@ describe("NpmUtilities", () => {
     });
 
     it("trims trailing whitespace in tag parameter", () => {
-      NpmUtilities.publishTaggedInDir("trailing-tag  ", directory, callback);
+      NpmUtilities.publishTaggedInDir("trailing-tag ", directory, callback);
 
       const actualtag = ChildProcessUtilities.exec.mock.calls[0][1][2];
       expect(actualtag).toBe("trailing-tag");

--- a/test/integration/__snapshots__/lerna-exec.test.js.snap
+++ b/test/integration/__snapshots__/lerna-exec.test.js.snap
@@ -12,6 +12,10 @@ exports[`stderr: exec-test --scope 1`] = `
 lerna info scope package-1"
 `;
 
+exports[`stderr: test --stream 1`] = `"lerna info version __TEST_VERSION__"`;
+
+exports[`stderr: test --stream 2`] = `"lerna info version __TEST_VERSION__"`;
+
 exports[`stderr: without -- 1`] = `"lerna info version __TEST_VERSION__"`;
 
 exports[`stdout: echo LERNA_PACKAGE_NAME 1`] = `

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -109,6 +109,44 @@ describe("lerna exec", () => {
     expect(stdout).toMatch("package-2: package.json");
   });
 
+  test.concurrent("<cmd> --stream", async () => {
+    const cwd = await initFixture("ExecCommand/basic");
+    const args = [
+      "exec",
+      EXEC_TEST_COMMAND,
+      "--stream",
+      "-C",
+    ];
+
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd, env });
+    expect(stderr).toMatchSnapshot("stderr: test --stream");
+
+    // order is non-deterministic, so assert individually
+    expect(stdout).toMatch("package-1: file-1.js");
+    expect(stdout).toMatch("package-1: package.json");
+    expect(stdout).toMatch("package-2: file-2.js");
+    expect(stdout).toMatch("package-2: package.json");
+  });
+
+  test.concurrent("--stream <cmd>", async () => {
+    const cwd = await initFixture("ExecCommand/basic");
+    const args = [
+      "exec",
+      "--stream",
+      EXEC_TEST_COMMAND,
+      "-C",
+    ];
+
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd, env });
+    expect(stderr).toMatchSnapshot("stderr: test --stream");
+
+    // order is non-deterministic, so assert individually
+    expect(stdout).toMatch("package-1: file-1.js");
+    expect(stdout).toMatch("package-1: package.json");
+    expect(stdout).toMatch("package-2: file-2.js");
+    expect(stdout).toMatch("package-2: package.json");
+  });
+
   test.concurrent("--bail=false <cmd>", async () => {
     const cwd = await initFixture("ExecCommand/basic");
     const args = [


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
At the moment when you run `lerna exec --parallel` You will have detailed information on where the command is running by the means of `Stout`, example each log message will be prefixed by the package name.

However, this is not the case when --parallel flag is not used. I want to make these consistant. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested the changes by linking

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [x] All new and existing tests passed.
