### PR TITLE
Add --changelog-preset option to customize --conventional-commits output

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,16 @@ $ lerna publish --conventional-commits
 
 When run with this flag, `publish` will use the [Conventional Commits Specification](https://conventionalcommits.org/) to [determine the version bump](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump) and [generate CHANGELOG](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli)
 
+#### --changelog-preset
+
+```sh
+$ lerna publish --conventional-commits --changelog-preset=angular-bitbucket
+```
+
+By default, the changelog preset is set to `angular`. In some cases you might want to change either use a another preset or a custom one.
+
+Presets are names of built-in or installable configuration for conventional changelog.
+
 #### --git-remote [remote]
 
 ```sh

--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -23,7 +23,7 @@ export default class ConventionalCommitUtilities {
       RECOMMEND_CLI,
       "-l", pkg.name,
       "--commit-path", pkg.location,
-      "-p", "angular",
+      "-p", ConventionalCommitUtilities.changelogPreset(opts),
     ];
     return ConventionalCommitUtilities.recommendVersion(pkg, opts, "recommendIndependentVersion", args);
   }
@@ -32,7 +32,7 @@ export default class ConventionalCommitUtilities {
     const args = [
       RECOMMEND_CLI,
       "--commit-path", pkg.location,
-      "-p", "angular",
+      "-p", ConventionalCommitUtilities.changelogPreset(opts),
     ];
     return ConventionalCommitUtilities.recommendVersion(pkg, opts, "recommendFixedVersion", args);
   }
@@ -53,7 +53,7 @@ export default class ConventionalCommitUtilities {
       "-l", pkg.name,
       "--commit-path", pkg.location,
       "--pkg", pkgJsonLocation,
-      "-p", "angular",
+      "-p", ConventionalCommitUtilities.changelogPreset(opts),
     ];
     ConventionalCommitUtilities.updateChangelog(pkg, opts, "updateIndependentChangelog", args);
   }
@@ -64,7 +64,7 @@ export default class ConventionalCommitUtilities {
       CHANGELOG_CLI,
       "--commit-path", pkg.location,
       "--pkg", pkgJsonLocation,
-      "-p", "angular",
+      "-p", ConventionalCommitUtilities.changelogPreset(opts),
     ];
     ConventionalCommitUtilities.updateChangelog(pkg, opts, "updateFixedChangelog", args);
   }
@@ -72,7 +72,7 @@ export default class ConventionalCommitUtilities {
   static updateFixedRootChangelog(pkg, opts) {
     const args = [
       CHANGELOG_CLI,
-      "-p", "angular",
+      "-p", ConventionalCommitUtilities.changelogPreset(opts),
       "--context", path.resolve(__dirname, "..", "lib", "ConventionalChangelogContext.js"),
     ];
     ConventionalCommitUtilities.updateChangelog(pkg, opts, "updateFixedRootChangelog", args);
@@ -80,7 +80,6 @@ export default class ConventionalCommitUtilities {
 
   static updateChangelog(pkg, opts, type, args) {
     log.silly(type, "for %s at %s", pkg.name, pkg.location);
-
 
     const changelogLocation = ConventionalCommitUtilities.changelogLocation(pkg);
 
@@ -95,7 +94,7 @@ export default class ConventionalCommitUtilities {
     // When force publishing, it is possible that there will be no actual changes, only a version bump.
     // Add a note to indicate that only a version bump has occurred.
     if (!newEntry.split("\n").some((line) => line.startsWith("*"))) {
-      newEntry =  dedent(
+      newEntry = dedent(
         `
         ${newEntry}
         
@@ -128,5 +127,9 @@ export default class ConventionalCommitUtilities {
 
   static changelogLocation(pkg) {
     return path.join(pkg.location, CHANGELOG_NAME);
+  }
+
+  static changelogPreset(opts) {
+    return opts && opts.changelogPreset ? opts.changelogPreset : "angular";
   }
 }

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -39,7 +39,7 @@ chalk.enabled = false;
 
 const execOpts = (testDir) =>
   expect.objectContaining({
-    cwd: testDir,
+    cwd: testDir
   });
 
 const consoleOutput = () =>
@@ -641,9 +641,9 @@ describe("PublishCommand", () => {
     });
   });
 
-    /** =========================================================================
-   * CD VERSION - REPUBLISH PRERELEASED
-   * ======================================================================= */
+  /** =========================================================================
+ * CD VERSION - REPUBLISH PRERELEASED
+ * ======================================================================= */
 
   describe("CD VERSION - REPUBLISH PRERELEASED ", () => {
     let testDir;
@@ -878,7 +878,7 @@ describe("PublishCommand", () => {
 
       it("should use conventional-commits utility to guess version bump and generate CHANGELOG", () => {
         return run(testDir)(
-          "--conventional-commits"
+          "--conventional-commits",
         ).then(() => {
           expect(gitAddedFiles(testDir))
             .toMatchSnapshot("[independent --conventional-commits] git adds changed files");
@@ -905,6 +905,33 @@ describe("PublishCommand", () => {
           });
         });
       });
+
+      it("accepts --changelog-preset option", () => {
+        return run(testDir)(
+          "--conventional-commits",
+          "--changelog-preset",
+          "foo-bar"
+        ).then(() => {
+          const name = "package-3";
+          const version = "3.0.0";
+          const location = path.join(testDir, "packages", name);
+
+          expect(ConventionalCommitUtilities.recommendIndependentVersion).toBeCalledWith(
+            expect.objectContaining({ name, version }),
+            expect.objectContaining({
+              cwd: testDir,
+              changelogPreset: "foo-bar",
+            })
+          );
+          expect(ConventionalCommitUtilities.updateIndependentChangelog).toBeCalledWith(
+            expect.objectContaining({ name, location }),
+            expect.objectContaining({
+              cwd: testDir,
+              changelogPreset: "foo-bar",
+            })
+          );
+        });
+      });
     });
 
     describe("fixed mode", () => {
@@ -924,7 +951,7 @@ describe("PublishCommand", () => {
 
       it("should use conventional-commits utility to guess version bump and generate CHANGELOG", () => {
         return run(testDir)(
-          "--conventional-commits"
+          "--conventional-commits",
         ).then(() => {
           expect(gitAddedFiles(testDir))
             .toMatchSnapshot("[fixed --conventional-commits] git adds changed files");
@@ -957,6 +984,33 @@ describe("PublishCommand", () => {
               location: path.join(testDir)
             }),
             execOpts(testDir)
+          );
+        });
+      });
+
+      it("accepts --changelog-preset option", () => {
+        return run(testDir)(
+          "--conventional-commits",
+          "--changelog-preset",
+          "baz-qux"
+        ).then(() => {
+          const name = "package-5";
+          const version = "1.0.0";
+          const location = path.join(testDir, "packages", name);
+
+          expect(ConventionalCommitUtilities.recommendFixedVersion).toBeCalledWith(
+            expect.objectContaining({ name, version, location }),
+            expect.objectContaining({
+              cwd: testDir,
+              changelogPreset: "baz-qux",
+            })
+          );
+          expect(ConventionalCommitUtilities.updateFixedChangelog).toBeCalledWith(
+            expect.objectContaining({ name, location }),
+            expect.objectContaining({
+              cwd: testDir,
+              changelogPreset: "baz-qux",
+            })
           );
         });
       });


### PR DESCRIPTION
…gular`


## Description
Lerna uses `angular` as changelog preset, in my case my lerna repo is hosted on a private `bitbucket` server. For the `angular` preset is built for usage with `github` in my case I want to use some other preset such as `angular-bitbucket`


## Motivation and Context
this issue has already been highlighted in  #850

## How Has This Been Tested?
Unit Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
