### PR TITLE
fix: pass process.env to sub commands

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -157,11 +157,10 @@ export default class NpmUtilities {
       cwd: directory,
     };
 
-    if (registry) {
-      opts.env = Object.assign({}, process.env, {
-        npm_config_registry: registry,
-      });
-    }
+    // pass environment variables to sub commands
+    opts.env = Object.assign({}, process.env, registry ? {
+      npm_config_registry: registry,
+    } : {});
 
     log.silly("getExecOpts", opts);
     return opts;

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -134,6 +134,7 @@ describe("NpmUtilities", () => {
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
         cwd: directory,
+        env: process.env,
       };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
@@ -153,6 +154,7 @@ describe("NpmUtilities", () => {
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
         cwd: directory,
+        env: process.env,
       };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
@@ -175,6 +177,7 @@ describe("NpmUtilities", () => {
         ["run", "foo", "--bar", "baz"],
         {
           cwd: pkg.location,
+          env: process.env,
         },
         "qux",
         expect.any(Function)
@@ -243,6 +246,7 @@ describe("NpmUtilities", () => {
       const opts = NpmUtilities.getExecOpts("test_dir");
       const want = {
         cwd: "test_dir",
+        env: mockEnv
       };
       expect(opts).toEqual(want);
     });


### PR DESCRIPTION
Closes #721

## Additional Rationale

I'd expect passing down process.env to sub commands to be the default behavior.

For instance in my monorepo project I'd do something like 

```
TEST_BROWSERS=Chrome lerna run test
```

to execute the test cases in all sub-projects against the `Chrome` browser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
