### PR TITLE
Keep non-patch subject parts when importing repository

### DIFF
--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -171,7 +171,7 @@ export default class ImportCommand extends Command {
       //
       // Fall back to three-way merge, which can help with duplicate commits
       // due to merge history.
-      ChildProcessUtilities.exec("git", ["am", "-3"], this.execOpts, (err) => {
+      ChildProcessUtilities.exec("git", ["am", "-3", "--keep-non-patch"], this.execOpts, (err) => {
         if (err) {
           const isEmptyCommit = err.stdout.indexOf("Patch is empty.") === 0;
           if (isEmptyCommit) {

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -230,5 +230,19 @@ describe("ImportCommand", () => {
         expect(err.message).toBe("Local repository has un-committed changes");
       }
     });
+
+    it("does not remove custom subject prefixes in [brackets]", async () => {
+      const newFilePath = path.join(testDir, "packages", path.basename(externalDir), "new-file");
+
+      await execa("git", ["mv", "old-file", "new-file"], { cwd: externalDir });
+      await execa("git", ["commit", "--no-gpg-sign", "-m", "[ISSUE-10] Moved old-file to new-file"],
+        { cwd: externalDir });
+
+      await lernaImport(externalDir);
+
+      expect(await lastCommitInDir(testDir)).toBe("[ISSUE-10] Moved old-file to new-file");
+      expect(await pathExists(newFilePath)).toBe(true);
+    });
+
   });
 });


### PR DESCRIPTION
## Description

Currently when you import a repo that follows a commit message convention that prefixes commits with something between brackets; e.g. `[TICKET-123] something changed`, the prefix is stripped due to how `git am` (or actually `git mailinfo`) works.

## Motivation and Context

Since these prefixes are relevant, since they often refer to a project management system, or define the category of the commit, they should not be stripped. 

Especially since the README states the following:

> Original commit authors, dates and **messages** are preserved.

## How Has This Been Tested?

I ran the `git am` command in the `ImportCommand.js`, and tested with the command arguments, where the `--keep-non-patch` argument (forwarded as `git mailinfo -b ...`) resulted in the desired effect of only the `[PATCH]` prefix being stripped, and other prefixes remained.

~I still have to try and see if I can add an assertion to the tests for this behavior.~
_Added a test._

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
