### PR TITLE
Throw error in bootstrap when Yarn workspaces is misconfigured

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import async from "async";
+import dedent from "dedent";
 import getPort from "get-port";
 import path from "path";
 import semver from "semver";
@@ -8,9 +9,6 @@ import Command, {ValidationError} from "../Command";
 import FileSystemUtilities from "../FileSystemUtilities";
 import NpmUtilities from "../NpmUtilities";
 import PackageUtilities from "../PackageUtilities";
-
-const YARN_HOIST_MESSAGE = `--hoist is not supported with --npm-client=yarn, use yarn workspaces instead
-A guide is available at https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/#setting-up-workspaces`;
 
 export function handler(argv) {
   new BootstrapCommand([...argv.args], argv, argv._cwd).run()
@@ -53,8 +51,25 @@ export default class BootstrapCommand extends Command {
     const { registry, rejectCycles, npmClient, npmClientArgs, mutex, hoist } = this.options;
 
     if (npmClient === "yarn" && typeof hoist === "string") {
-      const err = new ValidationError("", YARN_HOIST_MESSAGE);
-      return callback(err);
+      return callback(
+        new ValidationError("EWORKSPACES", dedent`
+          --hoist is not supported with --npm-client=yarn, use yarn workspaces instead
+          A guide is available at https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/
+        `)
+      );
+    }
+
+    if (
+      npmClient === "yarn" &&
+      this.repository.packageJson.workspaces &&
+      this.options.useWorkspaces !== true
+    ) {
+      return callback(
+        new ValidationError("EWORKSPACES", dedent`
+          Yarn workspaces are configured in package.json, but not enabled in lerna.json!
+          Please choose one: useWorkspaces = true in lerna.json, or remove package.json workspaces config
+        `)
+      );
     }
 
     this.npmConfig = {
@@ -111,9 +126,7 @@ export default class BootstrapCommand extends Command {
   bootstrapPackages(callback) {
     this.logger.info("", `Bootstrapping ${this.filteredPackages.length} packages`);
 
-    const { useWorkspaces } = this.options;
-
-    if (useWorkspaces) {
+    if (this.options.useWorkspaces) {
       this.installRootPackageOnly(callback);
     } else {
       async.series([

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -150,12 +150,20 @@ describe("BootstrapCommand", () => {
     });
   });
 
-  describe("with --npm-client and --hoist", async () => {
-    const testDir = await initFixture("BootstrapCommand/yarn-hoist");
-    const lernaBootstrap = run(testDir);
+  describe("with --npm-client and --hoist", () => {
+    it("should throw", async () => {
+      expect.assertions(1);
 
-    it("should throw", () => {
-      expect(() => lernaBootstrap()).toThrow();
+      const testDir = await initFixture("BootstrapCommand/yarn-hoist");
+      const lernaBootstrap = run(testDir);
+
+      try {
+        await lernaBootstrap();
+      } catch (err) {
+        expect(err.message).toMatch(
+          "--hoist is not supported with --npm-client=yarn, use yarn workspaces instead"
+        );
+      }
     });
   });
 
@@ -395,6 +403,21 @@ describe("BootstrapCommand", () => {
         }),
         expect.any(Function)
       );
+    });
+
+    it("errors when package.json workspaces exists but --use-workspaces is not enabled", async () => {
+      expect.assertions(1);
+
+      const testDir = await initFixture("BootstrapCommand/yarn-workspaces");
+      const lernaBootstrap = run(testDir);
+
+      try {
+        await lernaBootstrap("--no-use-workspaces");
+      } catch (err) {
+        expect(err.message).toMatch(
+          "Yarn workspaces are configured in package.json, but not enabled in lerna.json!"
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
## Description
Bad things happen during `lerna bootstrap --npm-client yarn` when `useWorkspaces` is not enabled _and_ a `workspaces` field exists in the root package.json. Instead of silent corruption, throw an informative error when this edge-case crops up.

## Motivation and Context
Fixes #1124

## How Has This Been Tested?
additional tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
