### PR TITLE
Normalize path used for `git add` in respect to OS/environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "safe-buffer": "^5.1.1",
     "semver": "^5.4.1",
     "signal-exit": "^3.0.2",
+    "slash": "^1.0.0",
     "strong-log-transformer": "^1.0.6",
     "temp-write": "^3.3.0",
     "write-file-atomic": "^2.3.0",

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -38,7 +38,8 @@ export default class GitUtilities {
 
   static addFile(file, opts) {
     log.silly("addFile", file);
-    ChildProcessUtilities.execSync("git", ["add", file], opts);
+    const portablePath = path.relative(opts.cwd, path.resolve(opts.cwd, file)).replace(/\\/g, '/');
+    ChildProcessUtilities.execSync("git", ["add", portablePath], opts);
   }
 
   static commit(message, opts) {

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -2,6 +2,7 @@ import { EOL } from "os";
 import log from "npmlog";
 import path from "path";
 import tempWrite from "temp-write";
+import slash from "slash"
 
 import ChildProcessUtilities from "./ChildProcessUtilities";
 
@@ -38,7 +39,8 @@ export default class GitUtilities {
 
   static addFile(file, opts) {
     log.silly("addFile", file);
-    const portablePath = path.relative(opts.cwd, path.resolve(opts.cwd, file)).replace(/\\/g, '/');
+    const relativePath = path.relative(opts.cwd, path.resolve(opts.cwd, file));
+    const portablePath = slash(relativePath);
     ChildProcessUtilities.execSync("git", ["add", portablePath], opts);
   }
 

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -65,6 +65,23 @@ describe("GitUtilities", () => {
         "git", ["add", "foo"], opts
       );
     });
+    it("works with absolute path for cwd", () => {
+      const cwd = path.resolve("test");
+      const opts = { cwd };
+      GitUtilities.addFile("foo", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["add", "foo"], opts
+      );
+    });
+    it("works with absolute paths for file and cwd", () => {
+      const cwd = path.resolve("test");
+      const file = path.resolve("test", "foo");
+      const opts = { cwd };
+      GitUtilities.addFile(file, opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["add", "foo"], opts
+      );
+    });
   });
 
   describe(".commit()", () => {

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -83,6 +83,13 @@ describe("GitUtilities", () => {
         "git", ["add", "foo"], opts
       );
     });
+    it("uses a POSIX path in the Git command, given a Windows file path", () => {
+      const opts = { cwd: "test" };
+      GitUtilities.addFile("foo\\bar", opts);
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git", ["add", "foo/bar"], opts
+      );
+    })
   });
 
   describe(".commit()", () => {

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -67,15 +67,16 @@ describe("GitUtilities", () => {
     });
     it("works with absolute path for cwd", () => {
       const cwd = path.resolve("test");
+      const file = "foo";
       const opts = { cwd };
-      GitUtilities.addFile("foo", opts);
+      GitUtilities.addFile(file, opts);
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git", ["add", "foo"], opts
       );
     });
     it("works with absolute paths for file and cwd", () => {
       const cwd = path.resolve("test");
-      const file = path.resolve("test", "foo");
+      const file = path.resolve(cwd, "foo");
       const opts = { cwd };
       GitUtilities.addFile(file, opts);
       expect(ChildProcessUtilities.execSync).lastCalledWith(


### PR DESCRIPTION
## Description

Added code to transform file paths used in `git add` to OS- (POSIX vs Windows) neutral form, for improved portability. 

## Motivation and Context

See issue #1133

## How Has This Been Tested?

Added two tests to the `GitUtilities` test suite.

Also `npm link`ed the package to my monorepo project to verify that my changes resolve the problem in #1133

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

> All new and existing tests passed

Actually some tests were failing on my Windows 7 Pro system after a fresh clone and install. Ignoring those, yes, all new and existing tests passed. I expect tests to pass on CI.