### PR TITLE
Support publish command using npmClient config parmas

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "preintegration": "npm pack",
     "integration": "cross-env LC_ALL=en-US jest --config test/config/integration.json",
     "lint": "eslint . --ignore-path .gitignore",
-    "prepublish": "npm run build",
     "pretest": "npm run lint -- --cache",
     "test": "cross-env LC_ALL=en-US jest",
     "test:watch": "cross-env LC_ALL=en-US jest --watchAll --no-watchman",

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -17,8 +17,10 @@ function execInstall(directory, {
   // build command, arguments, and options
   const opts = NpmUtilities.getExecOpts(directory, registry);
   const args = ["install"];
-  let cmd = npmClient || "npm";
-
+  let cmd = "npm";
+  if (npmClient) {
+      cmd = npmClient;
+  }
   if (npmGlobalStyle) {
     cmd = "npm";
     args.push("--global-style");
@@ -145,11 +147,12 @@ export default class NpmUtilities {
     );
   }
 
-  static publishTaggedInDir(tag, directory, registry, callback) {
+  static publishTaggedInDir(tag, directory, registry, config, callback) {
     log.silly("publishTaggedInDir", tag, path.basename(directory));
 
     const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.exec("npm", ["publish", "--tag", tag.trim()], opts, callback);
+    const cmd = config.npmClient || 'cmd';
+    ChildProcessUtilities.exec(cmd, ["publish", "--tag", tag.trim()], opts, callback);
   }
 
   static getExecOpts(directory, registry) {

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -126,7 +126,6 @@ export default class NpmUtilities {
 
   static runScriptInDir(script, args, directory, callback) {
     log.silly("runScriptInDir", script, args, path.basename(directory));
-
     const opts = NpmUtilities.getExecOpts(directory);
     ChildProcessUtilities.exec("npm", ["run", script, ...args], opts, callback);
   }
@@ -149,9 +148,14 @@ export default class NpmUtilities {
 
   static publishTaggedInDir(tag, directory, registry, config, callback) {
     log.silly("publishTaggedInDir", tag, path.basename(directory));
-
     const opts = NpmUtilities.getExecOpts(directory, registry);
-    const cmd = config.npmClient || 'cmd';
+    let cmd = 'npm';
+    if (typeof config === 'function') {
+        callback = config;
+    }
+    if (typeof config === 'object' && config.npmClient) {
+        cmd = config.npmClient;
+    }
     ChildProcessUtilities.exec(cmd, ["publish", "--tag", tag.trim()], opts, callback);
   }
 

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -67,7 +67,6 @@ export default class UpdatedPackagesCollector {
         since = GitUtilities.getLastTag(execOpts);
       }
     }
-
     this.logger.info("", `Comparing with ${since || "initial commit"}.`);
 
     const updatedPackages = {};
@@ -211,7 +210,6 @@ export default class UpdatedPackagesCollector {
         });
       });
     }
-
     return !!changedFiles.length;
   }
 }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -716,7 +716,7 @@ export default class PublishCommand extends Command {
       const run = (cb) => {
         tracker.verbose("publishing", pkg.name);
 
-        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmRegistry, (err) => {
+        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmRegistry, this.options, (err) => {
           err = err && err.stack || err;
 
           if (!err ||


### PR DESCRIPTION
## Description
I change some code to support users define custom publish npm client (CNPM Yarn eg.). 

## Motivation and Context
We have our own npm registry and npm clint. But we meet some erros when lerna publish the packages So I made some changes in the NpmUtilities.js to support custom npm client.

## How Has This Been Tested?
All tests passed!


