### PR TITLE
fallback to https://registry.npmjs.org/ when no registry is specified

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -157,11 +157,9 @@ export default class NpmUtilities {
       cwd: directory,
     };
 
-    if (registry) {
-      opts.env = Object.assign({}, process.env, {
-        npm_config_registry: registry,
-      });
-    }
+    opts.env = Object.assign({}, process.env, {
+      npm_config_registry: registry || 'https://registry.npmjs.org/',
+    });
 
     log.silly("getExecOpts", opts);
     return opts;

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -152,13 +152,13 @@ export default class NpmUtilities {
     ChildProcessUtilities.exec("npm", ["publish", "--tag", tag.trim()], opts, callback);
   }
 
-  static getExecOpts(directory, registry) {
+  static getExecOpts(directory) {
     const opts = {
       cwd: directory,
     };
 
     opts.env = Object.assign({}, process.env, {
-      npm_config_registry: registry || 'https://registry.npmjs.org/',
+      npm_config_registry: "https://registry.npmjs.org/",
     });
 
     log.silly("getExecOpts", opts);

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -229,18 +229,6 @@ describe("NpmUtilities", () => {
       process.env = originalEnv;
     });
 
-    it("should handle environment variables properly", () => {
-      process.env = mockEnv;
-      const opts = NpmUtilities.getExecOpts("test_dir", "https://my-secure-registry/npm");
-      const want = {
-        cwd: "test_dir",
-        env: Object.assign({}, mockEnv, {
-          npm_config_registry: "https://my-secure-registry/npm"
-        })
-      };
-      expect(opts).toEqual(want);
-    });
-
     it("should handle missing environment variables", () => {
       process.env = mockEnv;
       const opts = NpmUtilities.getExecOpts("test_dir");

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -134,6 +134,7 @@ describe("NpmUtilities", () => {
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
         cwd: directory,
+        env: expect.any(Object),
       };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
@@ -153,6 +154,7 @@ describe("NpmUtilities", () => {
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
         cwd: directory,
+        env: expect.any(Object),
       };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
@@ -175,6 +177,7 @@ describe("NpmUtilities", () => {
         ["run", "foo", "--bar", "baz"],
         {
           cwd: pkg.location,
+          env: expect.any(Object),
         },
         "qux",
         expect.any(Function)
@@ -243,6 +246,9 @@ describe("NpmUtilities", () => {
       const opts = NpmUtilities.getExecOpts("test_dir");
       const want = {
         cwd: "test_dir",
+        env: Object.assign({}, mockEnv, {
+          npm_config_registry: "https://registry.npmjs.org/"
+        })
       };
       expect(opts).toEqual(want);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sets https://registry.npmjs.org/ as a default registry when no one is specified

## Motivation and Context
I'm getting my feet wet in Lerna code :)
fix #896
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
yarn test:watch NpmUtilities
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
