### PR TITLE
run/publish: Use npmClient instead of hardcoded npm

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -122,26 +122,26 @@ export default class NpmUtilities {
     return ChildProcessUtilities.execSync("npm", ["dist-tag", "ls", packageName], opts).indexOf(tag) >= 0;
   }
 
-  static runScriptInDir(script, args, directory, callback) {
+  static runScriptInDir(script, {args, directory, npmClient}, callback) {
     log.silly("runScriptInDir", script, args, path.basename(directory));
 
     const opts = NpmUtilities.getExecOpts(directory);
-    ChildProcessUtilities.exec("npm", ["run", script, ...args], opts, callback);
+    ChildProcessUtilities.exec(npmClient, ["run", script, ...args], opts, callback);
   }
 
-  static runScriptInDirSync(script, args, directory, callback) {
+  static runScriptInDirSync(script, {args, directory, npmClient}, callback) {
     log.silly("runScriptInDirSync", script, args, path.basename(directory));
 
     const opts = NpmUtilities.getExecOpts(directory);
-    ChildProcessUtilities.execSync("npm", ["run", script, ...args], opts, callback);
+    ChildProcessUtilities.execSync(npmClient, ["run", script, ...args], opts, callback);
   }
 
-  static runScriptInPackageStreaming(script, args, pkg, callback) {
+  static runScriptInPackageStreaming(script, {args, pkg, npmClient}, callback) {
     log.silly("runScriptInPackageStreaming", [script, args, pkg.name]);
 
     const opts = NpmUtilities.getExecOpts(pkg.location);
     ChildProcessUtilities.spawnStreaming(
-      "npm", ["run", script, ...args], opts, pkg.name, callback
+      npmClient, ["run", script, ...args], opts, pkg.name, callback
     );
   }
 

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -147,6 +147,7 @@ export default class NpmUtilities {
 
   static publishTaggedInDir(tag, directory, {client = 'npm', registry}, callback) {
     log.silly("publishTaggedInDir", tag, path.basename(directory));
+
     const opts = NpmUtilities.getExecOpts(directory, registry);
     ChildProcessUtilities.exec(client, ["publish", "--tag", tag.trim()], opts, callback);
   }

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -101,29 +101,23 @@ export default class NpmUtilities {
   }
 
 
-  static addDistTag(directory, packageName, version, tag, npmConfig) {
+  static addDistTag(directory, packageName, version, tag, {client = 'npm', registry} = {}) {
     log.silly("addDistTag", tag, version, packageName);
-    const npmClient = (npmConfig && npmConfig.client) || 'npm';
-    const npmRegistry = (npmConfig && npmConfig.registry) || undefined;
-    const opts = NpmUtilities.getExecOpts(directory, npmRegistry);
-    ChildProcessUtilities.execSync(npmClient, ["dist-tag", "add", `${packageName}@${version}`, tag], opts);
+    const opts = NpmUtilities.getExecOpts(directory, registry);
+    ChildProcessUtilities.execSync(client, ["dist-tag", "add", `${packageName}@${version}`, tag], opts);
   }
 
-  static removeDistTag(directory, packageName, tag, npmConfig) {
+  static removeDistTag(directory, packageName, tag, {client = 'npm', registry} = {}) {
     log.silly("removeDistTag", tag, packageName);
-    const npmClient = (npmConfig && npmConfig.client) || 'npm';
-    const npmRegistry = (npmConfig && npmConfig.registry) || undefined;
-    const opts = NpmUtilities.getExecOpts(directory, npmRegistry);
-    ChildProcessUtilities.execSync(npmClient, ["dist-tag", "rm", packageName, tag], opts);
+    const opts = NpmUtilities.getExecOpts(directory, registry);
+    ChildProcessUtilities.execSync(client, ["dist-tag", "rm", packageName, tag], opts);
   }
 
-  static checkDistTag(directory, packageName, tag, npmConfig) {
+  static checkDistTag(directory, packageName, tag, {client = 'npm', registry} = {}) {
     log.silly("checkDistTag", tag, packageName);
-    const npmClient = (npmConfig && npmConfig.client) || 'npm';
-    const npmRegistry = (npmConfig && npmConfig.registry) || undefined;
-    const opts = NpmUtilities.getExecOpts(directory, npmRegistry);
+    const opts = NpmUtilities.getExecOpts(directory, registry);
     return ChildProcessUtilities
-      .execSync(npmClient, ["dist-tag", "ls", packageName], opts)
+      .execSync(client, ["dist-tag", "ls", packageName], opts)
       .indexOf(tag) >= 0;
 
   }
@@ -151,12 +145,10 @@ export default class NpmUtilities {
     );
   }
 
-  static publishTaggedInDir(tag, directory, npmConfig, callback) {
+  static publishTaggedInDir(tag, directory, {client = 'npm', registry}, callback) {
     log.silly("publishTaggedInDir", tag, path.basename(directory));
-    const npmClient = (npmConfig && npmConfig.client) || 'npm';
-    const npmRegistry = (npmConfig && npmConfig.registry) || undefined;
-    const opts = NpmUtilities.getExecOpts(directory, npmRegistry);
-    ChildProcessUtilities.exec(npmClient, ["publish", "--tag", tag.trim()], opts, callback);
+    const opts = NpmUtilities.getExecOpts(directory, registry);
+    ChildProcessUtilities.exec(client, ["publish", "--tag", tag.trim()], opts, callback);
   }
 
   static getExecOpts(directory, registry) {

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -101,24 +101,22 @@ export default class NpmUtilities {
   }
 
 
-  static addDistTag(directory, packageName, version, tag, {client = 'npm', registry} = {}) {
+  static addDistTag(directory, packageName, version, tag, registry) {
     log.silly("addDistTag", tag, version, packageName);
     const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.execSync(client, ["dist-tag", "add", `${packageName}@${version}`, tag], opts);
+    ChildProcessUtilities.execSync("npm", ["dist-tag", "add", `${packageName}@${version}`, tag], opts);
   }
 
-  static removeDistTag(directory, packageName, tag, {client = 'npm', registry} = {}) {
+  static removeDistTag(directory, packageName, tag, registry) {
     log.silly("removeDistTag", tag, packageName);
     const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.execSync(client, ["dist-tag", "rm", packageName, tag], opts);
+    ChildProcessUtilities.execSync("npm", ["dist-tag", "rm", packageName, tag], opts);
   }
 
-  static checkDistTag(directory, packageName, tag, {client = 'npm', registry} = {}) {
+  static checkDistTag(directory, packageName, tag, registry) {
     log.silly("checkDistTag", tag, packageName);
     const opts = NpmUtilities.getExecOpts(directory, registry);
-    return ChildProcessUtilities
-      .execSync(client, ["dist-tag", "ls", packageName], opts)
-      .indexOf(tag) >= 0;
+    return ChildProcessUtilities.execSync("npm", ["dist-tag", "ls", packageName], opts).indexOf(tag) >= 0;
 
   }
 

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -101,25 +101,31 @@ export default class NpmUtilities {
   }
 
 
-  static addDistTag(directory, packageName, version, tag, registry) {
+  static addDistTag(directory, packageName, version, tag, npmConfig) {
     log.silly("addDistTag", tag, version, packageName);
-
-    const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.execSync("npm", ["dist-tag", "add", `${packageName}@${version}`, tag], opts);
+    const npmClient = (npmConfig && npmConfig.client) || 'npm';
+    const npmRegistry = (npmConfig && npmConfig.registry) || undefined;
+    const opts = NpmUtilities.getExecOpts(directory, npmRegistry);
+    ChildProcessUtilities.execSync(npmClient, ["dist-tag", "add", `${packageName}@${version}`, tag], opts);
   }
 
-  static removeDistTag(directory, packageName, tag, registry) {
+  static removeDistTag(directory, packageName, tag, npmConfig) {
     log.silly("removeDistTag", tag, packageName);
-
-    const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.execSync("npm", ["dist-tag", "rm", packageName, tag], opts);
+    const npmClient = (npmConfig && npmConfig.client) || 'npm';
+    const npmRegistry = (npmConfig && npmConfig.registry) || undefined;
+    const opts = NpmUtilities.getExecOpts(directory, npmRegistry);
+    ChildProcessUtilities.execSync(npmClient, ["dist-tag", "rm", packageName, tag], opts);
   }
 
-  static checkDistTag(directory, packageName, tag, registry) {
+  static checkDistTag(directory, packageName, tag, npmConfig) {
     log.silly("checkDistTag", tag, packageName);
+    const npmClient = (npmConfig && npmConfig.client) || 'npm';
+    const npmRegistry = (npmConfig && npmConfig.registry) || undefined;
+    const opts = NpmUtilities.getExecOpts(directory, npmRegistry);
+    return ChildProcessUtilities
+      .execSync(npmClient, ["dist-tag", "ls", packageName], opts)
+      .indexOf(tag) >= 0;
 
-    const opts = NpmUtilities.getExecOpts(directory, registry);
-    return ChildProcessUtilities.execSync("npm", ["dist-tag", "ls", packageName], opts).indexOf(tag) >= 0;
   }
 
   static runScriptInDir(script, {args, directory, npmClient}, callback) {
@@ -145,11 +151,12 @@ export default class NpmUtilities {
     );
   }
 
-  static publishTaggedInDir(tag, directory, registry, callback) {
+  static publishTaggedInDir(tag, directory, npmConfig, callback) {
     log.silly("publishTaggedInDir", tag, path.basename(directory));
-
-    const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.exec("npm", ["publish", "--tag", tag.trim()], opts, callback);
+    const npmClient = (npmConfig && npmConfig.client) || 'npm';
+    const npmRegistry = (npmConfig && npmConfig.registry) || undefined;
+    const opts = NpmUtilities.getExecOpts(directory, npmRegistry);
+    ChildProcessUtilities.exec(npmClient, ["publish", "--tag", tag.trim()], opts, callback);
   }
 
   static getExecOpts(directory, registry) {

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -103,21 +103,23 @@ export default class NpmUtilities {
 
   static addDistTag(directory, packageName, version, tag, registry) {
     log.silly("addDistTag", tag, version, packageName);
+
     const opts = NpmUtilities.getExecOpts(directory, registry);
     ChildProcessUtilities.execSync("npm", ["dist-tag", "add", `${packageName}@${version}`, tag], opts);
   }
 
   static removeDistTag(directory, packageName, tag, registry) {
     log.silly("removeDistTag", tag, packageName);
+
     const opts = NpmUtilities.getExecOpts(directory, registry);
     ChildProcessUtilities.execSync("npm", ["dist-tag", "rm", packageName, tag], opts);
   }
 
   static checkDistTag(directory, packageName, tag, registry) {
     log.silly("checkDistTag", tag, packageName);
+
     const opts = NpmUtilities.getExecOpts(directory, registry);
     return ChildProcessUtilities.execSync("npm", ["dist-tag", "ls", packageName], opts).indexOf(tag) >= 0;
-
   }
 
   static runScriptInDir(script, {args, directory, npmClient}, callback) {

--- a/src/Package.js
+++ b/src/Package.js
@@ -91,7 +91,7 @@ export default class Package {
     log.silly("runScript", script, this.name);
 
     if (this.scripts[script]) {
-      NpmUtilities.runScriptInDir(script, [], this.location, callback);
+      NpmUtilities.runScriptInDir(script, {args: [], directory: this.location, npmClient: 'npm'}, callback);
     } else {
       callback();
     }
@@ -106,7 +106,11 @@ export default class Package {
     log.silly("runScriptSync", script, this.name);
 
     if (this.scripts[script]) {
-      NpmUtilities.runScriptInDirSync(script, [], this.location, callback);
+      NpmUtilities.runScriptInDirSync(script, {
+        args: [], 
+        directory: this.location, 
+        npmClient: 'npm'
+      }, callback);
     } else {
       callback();
     }

--- a/src/Package.js
+++ b/src/Package.js
@@ -92,8 +92,8 @@ export default class Package {
 
     if (this.scripts[script]) {
       NpmUtilities.runScriptInDir(script, {
-        args: [], 
-        directory: this.location, 
+        args: [],
+        directory: this.location,
         npmClient: 'npm'
       }, callback);
     } else {

--- a/src/Package.js
+++ b/src/Package.js
@@ -91,7 +91,11 @@ export default class Package {
     log.silly("runScript", script, this.name);
 
     if (this.scripts[script]) {
-      NpmUtilities.runScriptInDir(script, {args: [], directory: this.location, npmClient: 'npm'}, callback);
+      NpmUtilities.runScriptInDir(script, {
+        args: [], 
+        directory: this.location, 
+        npmClient: 'npm'
+      }, callback);
     } else {
       callback();
     }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -800,18 +800,18 @@ export default class PublishCommand extends Command {
   updateTag(pkg) {
     const distTag = this.getDistTag();
 
-    if (NpmUtilities.checkDistTag(pkg.location, pkg.name, "lerna-temp", this.npmConfig.registry)) {
-      NpmUtilities.removeDistTag(pkg.location, pkg.name, "lerna-temp", this.npmConfig.registry);
+    if (NpmUtilities.checkDistTag(pkg.location, pkg.name, "lerna-temp", this.npmRegistry)) {
+      NpmUtilities.removeDistTag(pkg.location, pkg.name, "lerna-temp", this.npmRegistry);
     }
 
     /* eslint-disable max-len */
     // TODO: fix this API to be less verbose with parameters
     if (this.options.npmTag) {
-      NpmUtilities.addDistTag(pkg.location, pkg.name, this.updatesVersions[pkg.name], distTag, this.npmConfig.registry);
+      NpmUtilities.addDistTag(pkg.location, pkg.name, this.updatesVersions[pkg.name], distTag, this.npmRegistry);
     } else if (this.options.canary) {
-      NpmUtilities.addDistTag(pkg.location, pkg.name, pkg.version, distTag, this.npmConfig.registry);
+      NpmUtilities.addDistTag(pkg.location, pkg.name, pkg.version, distTag, this.npmRegistry);
     } else {
-      NpmUtilities.addDistTag(pkg.location, pkg.name, this.updatesVersions[pkg.name], distTag, this.npmConfig.registry);
+      NpmUtilities.addDistTag(pkg.location, pkg.name, this.updatesVersions[pkg.name], distTag, this.npmRegistry);
     }
     /* eslint-enable max-len */
   }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -727,7 +727,7 @@ export default class PublishCommand extends Command {
       const run = (cb) => {
         tracker.verbose("publishing", pkg.name);
 
-        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmConfig.registry, (err) => {
+        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmConfig, (err) => {
           err = err && err.stack || err;
 
           if (!err ||

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -182,7 +182,7 @@ export default class PublishCommand extends Command {
 
     this.npmConfig = {
       client: this.options.npmClient || 'npm',
-      registry: this.registry
+      registry: this.npmRegistry
     }
 
     if (this.options.useGitVersion && !this.options.exact) {
@@ -727,7 +727,7 @@ export default class PublishCommand extends Command {
       const run = (cb) => {
         tracker.verbose("publishing", pkg.name);
 
-        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmConfig, (err) => {
+        NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmConfig.registry, (err) => {
           err = err && err.stack || err;
 
           if (!err ||
@@ -800,18 +800,18 @@ export default class PublishCommand extends Command {
   updateTag(pkg) {
     const distTag = this.getDistTag();
 
-    if (NpmUtilities.checkDistTag(pkg.location, pkg.name, "lerna-temp", this.npmConfig)) {
-      NpmUtilities.removeDistTag(pkg.location, pkg.name, "lerna-temp", this.npmConfig);
+    if (NpmUtilities.checkDistTag(pkg.location, pkg.name, "lerna-temp", this.npmConfig.registry)) {
+      NpmUtilities.removeDistTag(pkg.location, pkg.name, "lerna-temp", this.npmConfig.registry);
     }
 
     /* eslint-disable max-len */
     // TODO: fix this API to be less verbose with parameters
     if (this.options.npmTag) {
-      NpmUtilities.addDistTag(pkg.location, pkg.name, this.updatesVersions[pkg.name], distTag, this.npmConfig);
+      NpmUtilities.addDistTag(pkg.location, pkg.name, this.updatesVersions[pkg.name], distTag, this.npmConfig.registry);
     } else if (this.options.canary) {
-      NpmUtilities.addDistTag(pkg.location, pkg.name, pkg.version, distTag, this.npmConfig);
+      NpmUtilities.addDistTag(pkg.location, pkg.name, pkg.version, distTag, this.npmConfig.registry);
     } else {
-      NpmUtilities.addDistTag(pkg.location, pkg.name, this.updatesVersions[pkg.name], distTag, this.npmConfig);
+      NpmUtilities.addDistTag(pkg.location, pkg.name, this.updatesVersions[pkg.name], distTag, this.npmConfig.registry);
     }
     /* eslint-enable max-len */
   }

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -29,7 +29,7 @@ export const builder = {
   },
   "npm-client": {
     group: "Command Options:",
-    describe: "Executable used to install dependencies (npm, yarn, pnpm, ...)",
+    describe: "Executable used to run scripts (npm, yarn, pnpm, ...)",
     type: "string",
     requiresArg: true,
   },

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -49,7 +49,7 @@ const installedPackagesInDirectories = (testDir) =>
 
 const ranScriptsInDirectories = (testDir) =>
   NpmUtilities.runScriptInDir.mock.calls.reduce((obj, args) => {
-    const location = normalizeRelativeDir(testDir, args[2]);
+    const location = normalizeRelativeDir(testDir, args[1].directory);
     const script = args[0];
 
     if (!obj[location]) {

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -226,7 +226,7 @@ describe("NpmUtilities", () => {
     });
 
     it("trims trailing whitespace in tag parameter", () => {
-      NpmUtilities.publishTaggedInDir("trailing-tag ", directory, callback);
+      NpmUtilities.publishTaggedInDir("trailing-tag ", directory, {}, callback);
 
       const actualtag = ChildProcessUtilities.exec.mock.calls[0][1][2];
       expect(actualtag).toBe("trailing-tag");
@@ -234,7 +234,7 @@ describe("NpmUtilities", () => {
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/publishTaggedInDir";
-      NpmUtilities.publishTaggedInDir("published-tag", directory, registry, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, {registry}, callback);
 
       const cmd = "npm";
       const args = ["publish", "--tag", "published-tag"];

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -51,12 +51,21 @@ describe("NpmUtilities", () => {
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/add";
-      NpmUtilities.addDistTag(directory, packageName, version, tag, registry);
+      NpmUtilities.addDistTag(directory, packageName, version, tag, {registry});
 
       const cmd = "npm";
       const args = ["dist-tag", "add", "foo-pkg@1.0.0", "added-tag"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
+    });
+
+    it("supports custom client", () => {
+      const client = "yarn";
+      NpmUtilities.addDistTag(directory, packageName, version, tag, {client});
+
+      const args = ["dist-tag", "add", "foo-pkg@1.0.0", "added-tag"];
+      const opts = { directory };
+      expect(ChildProcessUtilities.execSync).lastCalledWith(client, args, opts);
     });
   });
 
@@ -79,12 +88,21 @@ describe("NpmUtilities", () => {
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/remove";
-      NpmUtilities.removeDistTag(directory, packageName, tag, registry);
+      NpmUtilities.removeDistTag(directory, packageName, tag, {registry});
 
       const cmd = "npm";
       const args = ["dist-tag", "rm", "bar-pkg", "removed-tag"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
+    });
+
+    it("supports custom client", () => {
+      const client = "yarn";
+      NpmUtilities.removeDistTag(directory, packageName, tag, {client});
+
+      const args = ["dist-tag", "rm", "bar-pkg", "removed-tag"];
+      const opts = { directory };
+      expect(ChildProcessUtilities.execSync).lastCalledWith(client, args, opts);
     });
   });
 
@@ -112,49 +130,60 @@ describe("NpmUtilities", () => {
       const registry = "https://custom-registry/check";
       ChildProcessUtilities.execSync.mockImplementation(() => "target-tag");
 
-      expect(NpmUtilities.checkDistTag(directory, packageName, "target-tag", registry)).toBe(true);
+      expect(NpmUtilities.checkDistTag(directory, packageName, "target-tag", {registry})).toBe(true);
 
       const cmd = "npm";
       const args = ["dist-tag", "ls", "baz-pkg"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
     });
+
+    it("supports custom client", () => {
+      const client = "yarn";
+      ChildProcessUtilities.execSync.mockImplementation(() => "target-tag");
+
+      expect(NpmUtilities.checkDistTag(directory, packageName, "target-tag", {client})).toBe(true);
+
+      const args = ["dist-tag", "ls", "baz-pkg"];
+      const opts = { directory };
+      expect(ChildProcessUtilities.execSync).lastCalledWith(client, args, opts);
+    });
   });
 
   describe(".runScriptInDir()", () => {
     it("runs an npm script in a directory", () => {
       const script = "foo";
-      const config = {
+      const options = {
         args: ["--bar", "baz"],
         directory: "/test/runScriptInDir",
         npmClient: 'npm'
       }
       const callback = () => {};
 
-      NpmUtilities.runScriptInDir(script, config, callback);
+      NpmUtilities.runScriptInDir(script, options, callback);
 
       const cmd = "npm";
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
-        cwd: config.directory,
+        cwd: options.directory,
       };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
     it("support different npmClient", () => {
       const script = "foo";
-      const config = {
+      const options = {
         args: ["--bar", "baz"],
         directory: "/test/runScriptInDir",
         npmClient: 'yarn'
       }
       const callback = () => {};
 
-      NpmUtilities.runScriptInDir(script, config, callback);
+      NpmUtilities.runScriptInDir(script, options, callback);
 
       const cmd = "yarn";
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
-        cwd: config.directory,
+        cwd: options.directory,
       };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
@@ -234,12 +263,21 @@ describe("NpmUtilities", () => {
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/publishTaggedInDir";
-      NpmUtilities.publishTaggedInDir("published-tag", directory, registry, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, {registry}, callback);
 
       const cmd = "npm";
       const args = ["publish", "--tag", "published-tag"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
+    });
+
+    it("supports custom client", () => {
+      const client = "yarn";
+      NpmUtilities.publishTaggedInDir("published-tag", directory, {client}, callback);
+
+      const args = ["publish", "--tag", "published-tag"];
+      const opts = { directory };
+      expect(ChildProcessUtilities.exec).lastCalledWith(client, args, opts, expect.any(Function));
     });
   });
 

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -124,16 +124,37 @@ describe("NpmUtilities", () => {
   describe(".runScriptInDir()", () => {
     it("runs an npm script in a directory", () => {
       const script = "foo";
-      const args = ["--bar", "baz"];
-      const directory = "/test/runScriptInDir";
+      const config = {
+        args: ["--bar", "baz"],
+        directory: "/test/runScriptInDir",
+        npmClient: 'npm'
+      }
       const callback = () => {};
 
-      NpmUtilities.runScriptInDir(script, args, directory, callback);
+      NpmUtilities.runScriptInDir(script, config, callback);
 
       const cmd = "npm";
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
-        cwd: directory,
+        cwd: config.directory,
+      };
+      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
+    });
+    it("support different npmClient", () => {
+      const script = "foo";
+      const config = {
+        args: ["--bar", "baz"],
+        directory: "/test/runScriptInDir",
+        npmClient: 'yarn'
+      }
+      const callback = () => {};
+
+      NpmUtilities.runScriptInDir(script, config, callback);
+
+      const cmd = "yarn";
+      const scriptArgs = ["run", "foo", "--bar", "baz"];
+      const opts = {
+        cwd: config.directory,
       };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
@@ -142,17 +163,20 @@ describe("NpmUtilities", () => {
   describe(".runScriptInDirSync()", () => {
     it("runs an npm script syncrhonously in a directory", () => {
       const script = "foo";
-      const args = ["--bar", "baz"];
-      const directory = "/test/runScriptInDirSync";
+      const config = {
+        args: ["--bar", "baz"],
+        directory: "/test/runScriptInDirSync",
+        npmClient: 'npm'
+      }
       const callback = () => {
       };
 
-      NpmUtilities.runScriptInDirSync(script, args, directory, callback);
+      NpmUtilities.runScriptInDirSync(script, config, callback);
 
       const cmd = "npm";
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
-        cwd: directory,
+        cwd: config.directory,
       };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
@@ -161,20 +185,23 @@ describe("NpmUtilities", () => {
   describe(".runScriptInPackageStreaming()", () => {
     it("runs an npm script in a package with streaming", () => {
       const script = "foo";
-      const args = ["--bar", "baz"];
-      const pkg = {
-        name: "qux",
-        location: "/test/runScriptInPackageStreaming",
-      };
+      const config = {
+        args: ["--bar", "baz"],
+        pkg: {
+          name: "qux",
+          location: "/test/runScriptInPackageStreaming",
+        },
+        npmClient: 'npm'
+      }
       const callback = () => {};
 
-      NpmUtilities.runScriptInPackageStreaming(script, args, pkg, callback);
+      NpmUtilities.runScriptInPackageStreaming(script, config, callback);
 
       expect(ChildProcessUtilities.spawnStreaming).lastCalledWith(
         "npm",
         ["run", "foo", "--bar", "baz"],
         {
-          cwd: pkg.location,
+          cwd: config.pkg.location,
         },
         "qux",
         expect.any(Function)

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -51,21 +51,12 @@ describe("NpmUtilities", () => {
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/add";
-      NpmUtilities.addDistTag(directory, packageName, version, tag, {registry});
+      NpmUtilities.addDistTag(directory, packageName, version, tag, registry);
 
       const cmd = "npm";
       const args = ["dist-tag", "add", "foo-pkg@1.0.0", "added-tag"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
-    });
-
-    it("supports custom client", () => {
-      const client = "yarn";
-      NpmUtilities.addDistTag(directory, packageName, version, tag, {client});
-
-      const args = ["dist-tag", "add", "foo-pkg@1.0.0", "added-tag"];
-      const opts = { directory };
-      expect(ChildProcessUtilities.execSync).lastCalledWith(client, args, opts);
     });
   });
 
@@ -88,21 +79,12 @@ describe("NpmUtilities", () => {
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/remove";
-      NpmUtilities.removeDistTag(directory, packageName, tag, {registry});
+      NpmUtilities.removeDistTag(directory, packageName, tag, registry);
 
       const cmd = "npm";
       const args = ["dist-tag", "rm", "bar-pkg", "removed-tag"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
-    });
-
-    it("supports custom client", () => {
-      const client = "yarn";
-      NpmUtilities.removeDistTag(directory, packageName, tag, {client});
-
-      const args = ["dist-tag", "rm", "bar-pkg", "removed-tag"];
-      const opts = { directory };
-      expect(ChildProcessUtilities.execSync).lastCalledWith(client, args, opts);
     });
   });
 
@@ -130,23 +112,12 @@ describe("NpmUtilities", () => {
       const registry = "https://custom-registry/check";
       ChildProcessUtilities.execSync.mockImplementation(() => "target-tag");
 
-      expect(NpmUtilities.checkDistTag(directory, packageName, "target-tag", {registry})).toBe(true);
+      expect(NpmUtilities.checkDistTag(directory, packageName, "target-tag", registry)).toBe(true);
 
       const cmd = "npm";
       const args = ["dist-tag", "ls", "baz-pkg"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, args, opts);
-    });
-
-    it("supports custom client", () => {
-      const client = "yarn";
-      ChildProcessUtilities.execSync.mockImplementation(() => "target-tag");
-
-      expect(NpmUtilities.checkDistTag(directory, packageName, "target-tag", {client})).toBe(true);
-
-      const args = ["dist-tag", "ls", "baz-pkg"];
-      const opts = { directory };
-      expect(ChildProcessUtilities.execSync).lastCalledWith(client, args, opts);
     });
   });
 
@@ -263,21 +234,12 @@ describe("NpmUtilities", () => {
 
     it("supports custom registry", () => {
       const registry = "https://custom-registry/publishTaggedInDir";
-      NpmUtilities.publishTaggedInDir("published-tag", directory, {registry}, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, registry, callback);
 
       const cmd = "npm";
       const args = ["publish", "--tag", "published-tag"];
       const opts = { directory, registry };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
-    });
-
-    it("supports custom client", () => {
-      const client = "yarn";
-      NpmUtilities.publishTaggedInDir("published-tag", directory, {client}, callback);
-
-      const args = ["publish", "--tag", "published-tag"];
-      const opts = { directory };
-      expect(ChildProcessUtilities.exec).lastCalledWith(client, args, opts, expect.any(Function));
     });
   });
 

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -246,7 +246,7 @@ describe("NpmUtilities", () => {
     afterEach(resetExecOpts);
 
     it("runs npm publish in a directory with --tag support", () => {
-      NpmUtilities.publishTaggedInDir("published-tag", directory, undefined, callback);
+      NpmUtilities.publishTaggedInDir("published-tag", directory, {}, callback);
 
       const cmd = "npm";
       const args = ["publish", "--tag", "published-tag"];

--- a/test/Package.js
+++ b/test/Package.js
@@ -182,8 +182,10 @@ describe("Package", () => {
         try {
           expect(NpmUtilities.runScriptInDir).lastCalledWith(
             "my-script",
-            [],
-            pkg.location,
+           {  args: [],
+              directory: pkg.location,
+              npmClient: 'npm'
+            },
             expect.any(Function)
           );
 
@@ -203,8 +205,10 @@ describe("Package", () => {
 
       expect(NpmUtilities.runScriptInDirSync).lastCalledWith(
         "my-script",
-        [],
-        pkg.location,
+        { args: [],
+          directory: pkg.location,
+          npmClient: 'npm'
+        },
         expect.any(Function)
       );
     });

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -1141,8 +1141,10 @@ describe("PublishCommand", () => {
       scripts.forEach(script => {
         expect(NpmUtilities.runScriptInDirSync).toHaveBeenCalledWith(
           script,
-          [],
-          path.resolve(testDir, "packages", "package-1"),
+          { args: [],
+            directory: path.resolve(testDir, "packages", "package-1"),
+            npmClient: 'npm'
+          },
           expect.any(Function)
         );
       });
@@ -1153,8 +1155,10 @@ describe("PublishCommand", () => {
       scripts.forEach(script => {
         expect(NpmUtilities.runScriptInDirSync).not.toHaveBeenCalledWith(
           script,
-          [],
-          path.resolve(testDir, "packages", "package-2"),
+          { args: [],
+            directory: path.resolve(testDir, "packages", "package-2"),
+            npmClient: 'npm'
+          },
           expect.any(Function)
         );
       });

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -26,19 +26,17 @@ log.level = "silent";
 const ranInPackages = (testDir) =>
   NpmUtilities.runScriptInDir.mock.calls.reduce((arr, args) => {
     const script = args[0];
-    const params = args[1];
-    const dir = normalizeRelativeDir(testDir, args[2]);
-    arr.push([dir, script].concat(params).join(" "));
+    const dir = normalizeRelativeDir(testDir, args[1].directory);
+    arr.push([dir, script].concat(args[1].args).join(" "));
     return arr;
   }, []);
 
 const ranInPackagesStreaming = (testDir) =>
   NpmUtilities.runScriptInPackageStreaming.mock.calls.reduce((arr, args) => {
     const script = args[0];
-    const params = args[1];
-    const pkg = args[2];
+    const pkg = args[1].pkg;
     const dir = normalizeRelativeDir(testDir, pkg.location);
-    arr.push([dir, script].concat(params).join(" "));
+    arr.push([dir, script].concat(args[1].args).join(" "));
     return arr;
   }, []);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Contribute to Lerna by solving an issue where `npm` is the hard-coded npm client while a user can choose to use `yarn`
Issue #1057 

## How Has This Been Tested?
Ran all the "yarn test" options
Added tests to verify the configuration params I added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change) - **Possibly if someone is using yarn as their client but actually they depend on npm running under the hood**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
