### PR TITLE
Add support for root-level version lifecycle

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -662,6 +662,9 @@ export default class PublishCommand extends Command {
     this.updates.forEach((update) => {
       this.runSyncScriptInPackage(update.package, "postversion");
     });
+
+    // run postversion, if set in the root directory
+    this.runSyncScriptInPackage(this.repository.package, "postversion");
   }
 
   gitCommitAndTagVersionForUpdates() {


### PR DESCRIPTION
## Description
This change introduces an optional, root-level `postversion` script that can be run when publishing. This happens after all per-package `postversion` scripts have been called.

## Motivation and Context
Currently, `postversion` hooks can only be run per-package. It's useful to have a `postversion` hook immediately before publishing _and_ after version bumping to rebuild or do anything else which might need to use the updated global version number. In my particular circumstance, I'm using Rollup to build all the packages at the top-level and not relying on `lerna run` (for performance and memory reasons). While my circumstance is admittedly somewhat specific, the utility of adding a hook here seems pretty generalized. 

## How Has This Been Tested?
It has been run locally within a project by running `lerna publish --skip-npm` within a project.  This triggers `postversion` if it's set in the root-level **package.json** scripts. It has been run with and without the hook and performs as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
