### PR TITLE
fix(NpmUtilities): include process.env in getExecOpts

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -155,11 +155,12 @@ export default class NpmUtilities {
   static getExecOpts(directory, registry) {
     const opts = {
       cwd: directory,
+      env: Object.assign({}, process.env)
     };
 
     if (registry) {
-      opts.env = Object.assign({}, process.env, {
-        npm_config_registry: registry,
+      opts.env = Object.assign({}, opts.env, {
+        npm_config_registry: registry
       });
     }
 

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -122,24 +122,44 @@ describe("NpmUtilities", () => {
   });
 
   describe(".runScriptInDir()", () => {
+    const originalEnv = Object.assign({}, process.env);
+    const mockEnv = {
+      mock_value: 1,
+    };
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
     it("runs an npm script in a directory", () => {
       const script = "foo";
       const args = ["--bar", "baz"];
       const directory = "/test/runScriptInDir";
       const callback = () => {};
 
+      process.env = mockEnv;
       NpmUtilities.runScriptInDir(script, args, directory, callback);
 
       const cmd = "npm";
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
         cwd: directory,
+        env: mockEnv
       };
       expect(ChildProcessUtilities.exec).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
   });
 
   describe(".runScriptInDirSync()", () => {
+    const originalEnv = Object.assign({}, process.env);
+    const mockEnv = {
+      mock_value: 1,
+    };
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
     it("runs an npm script syncrhonously in a directory", () => {
       const script = "foo";
       const args = ["--bar", "baz"];
@@ -147,18 +167,29 @@ describe("NpmUtilities", () => {
       const callback = () => {
       };
 
+      process.env = mockEnv;
       NpmUtilities.runScriptInDirSync(script, args, directory, callback);
 
       const cmd = "npm";
       const scriptArgs = ["run", "foo", "--bar", "baz"];
       const opts = {
         cwd: directory,
+        env: mockEnv
       };
       expect(ChildProcessUtilities.execSync).lastCalledWith(cmd, scriptArgs, opts, expect.any(Function));
     });
   });
 
   describe(".runScriptInPackageStreaming()", () => {
+    const originalEnv = Object.assign({}, process.env);
+    const mockEnv = {
+      mock_value: 1,
+    };
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
     it("runs an npm script in a package with streaming", () => {
       const script = "foo";
       const args = ["--bar", "baz"];
@@ -168,6 +199,7 @@ describe("NpmUtilities", () => {
       };
       const callback = () => {};
 
+      process.env = mockEnv;
       NpmUtilities.runScriptInPackageStreaming(script, args, pkg, callback);
 
       expect(ChildProcessUtilities.spawnStreaming).lastCalledWith(
@@ -175,6 +207,7 @@ describe("NpmUtilities", () => {
         ["run", "foo", "--bar", "baz"],
         {
           cwd: pkg.location,
+          env: mockEnv
         },
         "qux",
         expect.any(Function)
@@ -228,6 +261,16 @@ describe("NpmUtilities", () => {
 
     it("should handle environment variables properly", () => {
       process.env = mockEnv;
+      const opts = NpmUtilities.getExecOpts("test_dir");
+      const want = {
+        cwd: "test_dir",
+        env: mockEnv
+      };
+      expect(opts).toEqual(want);
+    });
+
+    it("should handle add registry environment variable if passed", () => {
+      process.env = mockEnv;
       const opts = NpmUtilities.getExecOpts("test_dir", "https://my-secure-registry/npm");
       const want = {
         cwd: "test_dir",
@@ -243,6 +286,7 @@ describe("NpmUtilities", () => {
       const opts = NpmUtilities.getExecOpts("test_dir");
       const want = {
         cwd: "test_dir",
+        env: mockEnv
       };
       expect(opts).toEqual(want);
     });


### PR DESCRIPTION
## Description
Adds missing `env` option passed to `childProcess.exec`

## Motivation and Context
Currently, the `getExecOpts` command in `NpmUtilties` only includes the `process.env` variables if there is a registry option set. This ensures they are always passed down regardless.

## How Has This Been Tested?
Adjusted existing unit tests to over these cases and ran locally against a repo I know to be working with the `--registry` setting

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
