### PR TITLE
docs: replace "command" with "commands" to avoid ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ It will configure `lerna.json` to enforce exact match for all subsequent executi
 ```json
 {
   "lerna": "2.0.0",
-  "command": {
+  "commands": {
     "init": {
       "exact": true
     }
@@ -479,7 +479,7 @@ Note that this only applies when using the default "fixed" versioning mode, as t
 This can be configured in lerna.json, as well:
 ```json
 {
-  "command": {
+  "commands": {
     "publish": {
       "message": "chore(release): publish %s"
     }
@@ -495,7 +495,7 @@ If your `lerna.json` contains something like this:
 
 ```json
 {
-  "command": {
+  "commands": {
     "publish": {
       "allowBranch": "master"
     }
@@ -778,7 +778,7 @@ Example:
   "lerna": "x.x.x",
   "version": "1.2.0",
   "exampleOption": "foo",
-  "command": {
+  "commands": {
     "init": {
       "exampleOption": "bar",
     }


### PR DESCRIPTION
This is my first time to use Lerna, but after follow the docs, I fall into the doubt of **"command" or "commands", which is the right one?**

After searched in the source code, I knew that both "command" and "commands" are supported. But I will suggest to  **always use "commands" in the docs** to avoid ambiguity for users.