### PR TITLE
feat: `--allow-branch` publish option now also accepts an `array` of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ This can be configured in lerna.json, as well:
 
 #### --allow-branch [glob]
 
-Lerna allows you to specify a glob in your `lerna.json` that your current branch needs to match to be publishable.
+Lerna allows you to specify a glob or an array of globs in your `lerna.json` that your current branch needs to match to be publishable.
 You can use this flag to override this setting.
 If your `lerna.json` contains something like this:
 
@@ -498,6 +498,19 @@ If your `lerna.json` contains something like this:
   "command": {
     "publish": {
       "allowBranch": "master"
+    }
+  }
+}
+```
+
+```json
+{
+  "command": {
+    "publish": {
+      "allowBranch": [
+        "master",
+        "feature/*"
+      ]
     }
   }
 }

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -140,8 +140,7 @@ export const builder = {
   "allow-branch": {
     group: "Command Options:",
     describe: "Specify which branches to allow publishing from.",
-    type: "string",
-    default: undefined,
+    type: "array",
   },
 };
 
@@ -200,7 +199,10 @@ export default class PublishCommand extends Command {
       }
 
       const currentBranch = GitUtilities.getCurrentBranch(this.execOpts);
-      if (this.options.allowBranch && !minimatch(currentBranch, this.options.allowBranch)) {
+      if (
+        this.options.allowBranch &&
+        ![].concat(this.options.allowBranch).some(x => minimatch(currentBranch, x))
+      ) {
         throw new ValidationError(
           "ENOTALLOWED",
           dedent`

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -1077,6 +1077,13 @@ describe("PublishCommand", () => {
         const { exitCode } = await run(testDir)("--allow-branch", "feature/*");
         expect(exitCode).toBe(0);
       });
+
+      it("should accept a branch that matches one of the items passed", async () => {
+        GitUtilities.getCurrentBranch.mockReturnValueOnce("feature/awesome");
+
+        const { exitCode } = await run(testDir)("--allow-branch", "master","feature/*");
+        expect(exitCode).toBe(0);
+      });
     });
 
     describe("lerna.json", () => {


### PR DESCRIPTION
## Description
`--allow-branch` publish option now also accepts an `array` of `globs`

## Motivation and Context
I want to be able to publish from 2 branches patterns, example
`master` & `release/*` at the same time without the need of passing the cli arguments each time.

## How Has This Been Tested?
Unit test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ x I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
