### PR TITLE
fix: Error: Preset: "custom-preset" does not exist

### DIFF
--- a/src/ConventionalCommitUtilities.js
+++ b/src/ConventionalCommitUtilities.js
@@ -19,20 +19,24 @@ const CHANGELOG_CLI = require.resolve("conventional-changelog-cli/cli");
 
 export default class ConventionalCommitUtilities {
   static recommendIndependentVersion(pkg, opts) {
+    // `-p` here is overridden because `conventional-recommended-bump`
+    // cannot accept custom preset.
     const args = [
       RECOMMEND_CLI,
       "-l", pkg.name,
       "--commit-path", pkg.location,
-      "-p", ConventionalCommitUtilities.changelogPreset(opts),
+      "-p", "angular",
     ];
     return ConventionalCommitUtilities.recommendVersion(pkg, opts, "recommendIndependentVersion", args);
   }
 
   static recommendFixedVersion(pkg, opts) {
+    // `-p` here is overridden because `conventional-recommended-bump`
+    // cannot accept custom preset.
     const args = [
       RECOMMEND_CLI,
       "--commit-path", pkg.location,
-      "-p", ConventionalCommitUtilities.changelogPreset(opts),
+      "-p", "angular",
     ];
     return ConventionalCommitUtilities.recommendVersion(pkg, opts, "recommendFixedVersion", args);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 `conventional-recommended-bump` cannot accept custom preset and thus this should always be `angular` or `eslint` https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump/presets

When pass a custom preset is passed it this shouldn't be passed to `conventional-recommended-bump` because an error will be thrown `Error: Preset: "custom-preset" does not exist `

## Motivation and Context
Described above.

## How Has This Been Tested?
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

  
  