### PR TITLE
Completely ignore peerDependencies during publish

### DIFF
--- a/src/VersionSerializer.js
+++ b/src/VersionSerializer.js
@@ -2,7 +2,7 @@ export default class VersionSerializer {
   constructor({ graphDependencies, versionParser }) {
     this._graphDependencies = graphDependencies;
     this._versionParser = versionParser;
-    this._dependenciesKeys = ["dependencies", "devDependencies", "peerDependencies"];
+    this._dependenciesKeys = ["dependencies", "devDependencies"];
     this._strippedPrefixes = new Map();
   }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -584,7 +584,6 @@ export default class PublishCommand extends Command {
       // update pkg dependencies
       this.updatePackageDepsObject(pkg, "dependencies", exact);
       this.updatePackageDepsObject(pkg, "devDependencies", exact);
-      this.updatePackageDepsObject(pkg, "peerDependencies", exact);
 
       // exec preversion script
       this.runSyncScriptInPackage(pkg, "preversion");

--- a/test/Package.js
+++ b/test/Package.js
@@ -24,7 +24,7 @@ describe("Package", () => {
         scripts: { "my-script": "echo 'hello world'" },
         dependencies: { "my-dependency": "^1.0.0" },
         devDependencies: { "my-dev-dependency": "^1.0.0" },
-        peerDependencies: { "my-peer-dependency": "^1.0.0" }
+        peerDependencies: { "my-peer-dependency": ">=1.0.0" }
       },
       "/path/to/package"
     );
@@ -75,7 +75,7 @@ describe("Package", () => {
 
   describe("get .peerDependencies", () => {
     it("should return the peerDependencies", () => {
-      expect(pkg.peerDependencies).toEqual({ "my-peer-dependency": "^1.0.0" });
+      expect(pkg.peerDependencies).toEqual({ "my-peer-dependency": ">=1.0.0" });
     });
   });
 

--- a/test/PackageGraph.js
+++ b/test/PackageGraph.js
@@ -21,7 +21,6 @@ describe("PackageGraph", () => {
           scripts: { "my-script": "echo 'hello world'" },
           dependencies: { "my-dependency": "^1.0.0" },
           devDependencies: { "my-dev-dependency": "^1.0.0" },
-          peerDependencies: { "my-peer-dependency": "^1.0.0" }
         },
         "/path/to/package1"
       ),
@@ -33,7 +32,7 @@ describe("PackageGraph", () => {
           scripts: { "my-script": "echo 'hello world'" },
           dependencies: { "my-dependency": "^1.0.0" },
           devDependencies: { "my-package-1": dependencyVersion },
-          peerDependencies: { "my-peer-dependency": "^1.0.0" }
+          peerDependencies: { "my-package-1": ">=1.0.0" }
         },
         "/path/to/package2"
       )

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -142,6 +142,10 @@ describe("PublishCommand", () => {
         expect(updatedPackageJSON("package-3").devDependencies).toMatchObject({
           "package-2": "^1.0.1",
         });
+        // peerDependencies are _never_ modified automatically
+        expect(updatedPackageJSON("package-3").peerDependencies).toMatchObject({
+          "package-2": "^1.0.0",
+        });
         expect(updatedPackageJSON("package-4").dependencies).toMatchObject({
           "package-1": "^0.0.0",
         });

--- a/test/VersionSerializer.js
+++ b/test/VersionSerializer.js
@@ -7,7 +7,6 @@ import VersionSerializer from "../src/VersionSerializer";
 log.level = "silent";
 
 describe("VersionSerializer", () => {
-
   let serializer;
 
   beforeEach(() => {
@@ -29,7 +28,6 @@ describe("VersionSerializer", () => {
   });
 
   describe("deserialize", () => {
-
     it("should use version parser for inter-package dependencies only", () => {
       const mockParser = {
         parseVersion: jest.fn().mockReturnValue({
@@ -48,11 +46,16 @@ describe("VersionSerializer", () => {
       const pkg = {
         name: "my-package-1",
         version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "^1.0.0" },
-        devDependencies: { "my-package-2": "^1.0.0" },
-        peerDependencies: { "my-package-3": "^1.0.0" }
+        dependencies: {
+          "my-dependency": "^1.0.0",
+        },
+        devDependencies: {
+          "my-package-2": "^1.0.0",
+          "my-package-3": "^1.0.0",
+        },
+        peerDependencies: {
+          "my-package-3": ">=1.0.0",
+        }
       };
 
       serializer.deserialize(pkg);
@@ -62,12 +65,16 @@ describe("VersionSerializer", () => {
     it("should not touch versions parser does not recognize", () => {
       const pkg = {
         name: "my-package-1",
-        version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "^1.0.0" },
-        devDependencies: { "my-package-2": "^1.0.0" },
-        peerDependencies: { "my-package-3": "^1.0.0" }
+        dependencies: {
+          "my-dependency": "^1.0.0",
+        },
+        devDependencies: {
+          "my-package-2": "^1.0.0",
+          "my-package-3": "^1.0.0",
+        },
+        peerDependencies: {
+          "my-package-3": ">=1.0.0",
+        }
       };
 
       expect(serializer.deserialize(pkg)).toEqual(pkg);
@@ -77,69 +84,97 @@ describe("VersionSerializer", () => {
       expect(serializer.deserialize({
         name: "my-package-1",
         version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
-        devDependencies: { "my-package-2": "bbb#1.0.0" },
-        peerDependencies: { "my-package-3": "ccc#1.0.0" }
+        dependencies: {
+          "my-dependency": "dont-touch-this#1.0.0",
+        },
+        devDependencies: {
+          "my-package-2": "bbb#1.0.0",
+          "my-package-3": "ccc#1.0.0",
+        },
+        peerDependencies: {
+          "my-package-3": ">=1.0.0",
+        }
       })).toEqual({
         name: "my-package-1",
         version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
-        devDependencies: { "my-package-2": "1.0.0" },
-        peerDependencies: { "my-package-3": "1.0.0" }
+        dependencies: {
+          "my-dependency": "dont-touch-this#1.0.0",
+        },
+        devDependencies: {
+          "my-package-2": "1.0.0",
+          "my-package-3": "1.0.0",
+        },
+        peerDependencies: {
+          "my-package-3": ">=1.0.0",
+        }
       });
     });
   });
 
   describe("serialize", () => {
-
     it("should not touch versions parser does not recognize", () => {
       const pkg = {
         name: "my-package-1",
         version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "^1.0.0" },
-        devDependencies: { "my-package-2": "^1.0.0" },
-        peerDependencies: { "my-package-3": "^1.0.0" }
+        dependencies: {
+          "my-dependency": "^1.0.0",
+        },
+        devDependencies: {
+          "my-package-2": "^1.0.0",
+          "my-package-3": "^1.0.0",
+        },
+        peerDependencies: {
+          "my-package-3": ">=1.0.0",
+        }
       };
 
       expect(serializer.serialize(pkg)).toEqual(pkg);
     });
 
     it("should write back version strings transformed by deserialize", () => {
-
       // since serializer is stateful, version prefixes will be stored in its state
       serializer.deserialize({
         name: "my-package-1",
         version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
-        devDependencies: { "my-package-2": "bbb#1.0.0" },
-        peerDependencies: { "my-package-3": "ccc#1.0.0" }
+        dependencies: {
+          "my-dependency": "dont-touch-this#1.0.0",
+        },
+        devDependencies: {
+          "my-package-2": "bbb#1.0.0",
+          "my-package-3": "ccc#1.0.0",
+        },
+        peerDependencies: {
+          "my-package-3": ">=1.0.0",
+        }
       })
 
       // the preserved prefixes should be written back
       expect(serializer.serialize({
         name: "my-package-1",
         version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
-        devDependencies: { "my-package-2": "1.0.0" },
-        peerDependencies: { "my-package-3": "1.0.0" }
+        dependencies: {
+          "my-dependency": "dont-touch-this#1.0.0",
+        },
+        devDependencies: {
+          "my-package-2": "1.0.0",
+          "my-package-3": "1.0.0",
+        },
+        peerDependencies: {
+          "my-package-3": ">=1.0.0",
+        }
       })).toEqual({
         name: "my-package-1",
         version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "dont-touch-this#1.0.0" },
-        devDependencies: { "my-package-2": "bbb#1.0.0" },
-        peerDependencies: { "my-package-3": "ccc#1.0.0" }
+        dependencies: {
+          "my-dependency": "dont-touch-this#1.0.0",
+        },
+        devDependencies: {
+          "my-package-2": "bbb#1.0.0",
+          "my-package-3": "ccc#1.0.0",
+        },
+        peerDependencies: {
+          "my-package-3": ">=1.0.0",
+        }
       });
     });
   });

--- a/test/fixtures/BootstrapCommand/peer/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/peer/packages/package-1/package.json
@@ -2,7 +2,7 @@
   "name": "package-1",
   "version": "1.0.0",
   "peerDependencies": {
-    "external": "^1.0.0",
-    "package-2": "^1.0.0"
+    "external": "^1.0.0 || ^2.0.0",
+    "package-2": ">=1.0.0"
   }
 }

--- a/test/fixtures/PublishCommand/normal/packages/package-3/package.json
+++ b/test/fixtures/PublishCommand/normal/packages/package-3/package.json
@@ -1,6 +1,9 @@
 {
   "name": "package-3",
   "version": "1.0.0",
+  "peerDependencies": {
+    "package-2": "^1.0.0"
+  },
   "devDependencies": {
     "package-2": "^1.0.0"
   }

--- a/test/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/test/integration/__snapshots__/lerna-publish.test.js.snap
@@ -148,6 +148,9 @@ Array [
       "package-2": "^1.0.1",
     },
     "name": "package-3",
+    "peerDependencies": Object {
+      "package-2": "^1.0.0",
+    },
     "version": "1.0.1",
   },
   Object {


### PR DESCRIPTION
## Description
Changes to a peer version range are always semver major, and should be as broad as possible.

Until we can get fancier, we should never automatically modify them to match the new version being published (which is the current incorrect behavior).

## Motivation and Context
see #1018

## How Has This Been Tested?
new test assertions

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
