### PR TITLE
Set `matchBase` to `false`

### DIFF
--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -215,7 +215,7 @@ export default class UpdatedPackagesCollector {
 
     if (this.options.ignore) {
       changedFiles = changedFiles.filter(
-        file => !_.find(this.options.ignore, pattern => minimatch(file, pattern, { matchBase: true })),
+        file => !_.find(this.options.ignore, pattern => minimatch(file, pattern, { matchBase: false })),
       );
     }
 


### PR DESCRIPTION
## Description
At the moment ignored files are being matched with `matchBase: true`, but it's more flexible when you match the base of a file by prefixing it with `**/`.

See the following cases:

```
1. minimatch('src/index.js', 'index.js', { matchBase: false })
false
2. minimatch('src/index.js', 'index.js', { matchBase: true })
true
3. minimatch('index.js', 'index.js', { matchBase: false })
true
4. minimatch('src/index.js', '**/index.js', { matchBase: false })
true
5. minimatch('index.js', '**/index.js', { matchBase: false })
true
```

For my use case I need `1` to be `false` and `3` to be `true`. This is not possible at the moment, due to the `matchBase: true` option. If you would want to accomplish that both `1` and `3` are true, you could prefix the pattern with the `**/` wildcard like I showed in `4` and `5`.

## Motivation and Context
I want to match a file in the root folder of the package, but it at the moment it matches all files that are named like in all subfolders of that package.

## How Has This Been Tested?
I tested this in my own project and it worked.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
