### PR TITLE
Treat 'lerna run test' like any other command

### DIFF
--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -63,7 +63,7 @@ export default class RunCommand extends Command {
 
     const { filteredPackages } = this;
 
-    if (script === "test" || script === "env") {
+    if (script === "env") {
       this.packagesWithScript = filteredPackages;
     } else {
       this.packagesWithScript = filteredPackages.filter(pkg => pkg.scripts && pkg.scripts[script]);

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -69,12 +69,6 @@ describe("RunCommand", () => {
       expect(ranInPackagesStreaming(testDir)).toMatchSnapshot("run <script> --stream");
     });
 
-    it("always runs test script", async () => {
-      await lernaRun("test");
-
-      expect(ranInPackages(testDir)).toMatchSnapshot("run test");
-    });
-
     it("always runs env script", async () => {
       await lernaRun("env");
 

--- a/test/__snapshots__/RunCommand.js.snap
+++ b/test/__snapshots__/RunCommand.js.snap
@@ -56,12 +56,3 @@ Array [
   "packages/package-3 env",
 ]
 `;
-
-exports[`run test 1`] = `
-Array [
-  "packages/package-1 test",
-  "packages/package-4 test",
-  "packages/package-2 test",
-  "packages/package-3 test",
-]
-`;


### PR DESCRIPTION
Fix for #1142 

Don't know why `lerna run test` was treated differently from other commands.
This PR makes it behave "normally" and thus fixes #1142, read comment https://github.com/lerna/lerna/issues/1142#issuecomment-357299896

Fix has been tested against my code base (https://github.com/tkrotoff/react-form-with-constraints) with 2.6 (npm) and 2.7 (`"npmClient": "yarn"`)