### PR TITLE
Fix import command so it works if Lerna root is a subdir of git root

### DIFF
--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -150,6 +150,14 @@ export default class GitUtilities {
     return diff;
   }
 
+  static getWorkspaceRoot(opts) {
+    log.silly("getWorkspaceRoot");
+    const root = ChildProcessUtilities.execSync("git", ["rev-parse", "--show-toplevel"], opts);
+    log.verbose("getWorkspaceRoot", root);
+
+    return root;
+  }
+
   static getCurrentBranch(opts) {
     log.silly("getCurrentBranch");
 

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -236,6 +236,15 @@ describe("GitUtilities", () => {
     });
   });
 
+  describe(".getWorkspaceRoot()", () => {
+    it("calls `git rev-parse --show-toplevel`", () => {
+      ChildProcessUtilities.execSync.mockImplementation(() => "master");
+      const opts = { cwd: "test" };
+      expect(GitUtilities.getWorkspaceRoot(opts)).toBe("master");
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git", ["rev-parse", "--show-toplevel"], opts);
+    });
+  });
+
   describe(".getCurrentBranch()", () => {
     it("calls `git rev-parse --abbrev-ref HEAD`", () => {
       ChildProcessUtilities.execSync.mockImplementation(() => "master");

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -245,4 +245,33 @@ describe("ImportCommand", () => {
       expect(await pathExists(newFilePath)).toBe(true);
     });
   });
+
+  describe("with non-root Lerna dir", () => {
+    let testDir;
+    let lernaRootDir;
+    let externalDir;
+    let lernaImport;
+
+    beforeEach(async () => {
+      const [extDir, fixtureDir] = await Promise.all([
+        initFixture("ImportCommand/external", "Init external commit"),
+        initFixture("ImportCommand/lerna-not-in-root"),
+      ]);
+
+      externalDir = extDir;
+      testDir = fixtureDir;
+      lernaRootDir = path.join(testDir, "subdir");
+      lernaImport = run(lernaRootDir);
+    });
+
+    // Issue 1197
+    it("creates a module in packages location with imported commit history", async () => {
+      const packageJson = path.join(lernaRootDir, "packages", path.basename(externalDir), "package.json");
+
+      await lernaImport(externalDir);
+
+      expect(await lastCommitInDir(testDir)).toBe("Init external commit");
+      expect(await pathExists(packageJson)).toBe(true);
+    });
+  });
 });

--- a/test/fixtures/ImportCommand/lerna-not-in-root/subdir/lerna.json
+++ b/test/fixtures/ImportCommand/lerna-not-in-root/subdir/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/ImportCommand/lerna-not-in-root/subdir/package.json
+++ b/test/fixtures/ImportCommand/lerna-not-in-root/subdir/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}


### PR DESCRIPTION
Fix for #1197 

## Description

The code in the import command was computing a `targetDir` relative to the Lerna root directory, and using that in the Git patches. If the Lerna root directory wasn't in the Git root directory, that produced incorrect import locations.

## Motivation and Context

This fix is needed in order to enable Lerna to import correctly if Lerna is not based in the root of the Git workspace.

Fixes issue #1197 

## How Has This Been Tested?

1. New unit test added to import command tests.  The test creates a Lerna environment where Lerna is in a subdirectory of the Git workspace, and checks that the import works correctly.  It failed before I fixed the code, and now passes.  I've added a sibling 'describe' that configures an environment where Lerna isn't in the root, in order to avoid touching all the existing tests.
1. I've manually run the resulting Lerna build on a real-world workspace example I had that previously produced the wrong output. It's now correct.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
