### PR TITLE
Add package location env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,10 +653,10 @@ To spawn long-running processes, pass the `--parallel` flag:
 $ lerna exec --parallel -- babel src -d lib -w
 ```
 
-You may also get the name of the current package through the environment variable `LERNA_PACKAGE_NAME`:
+You may also get the name and path of the current package through the environment variables `LERNA_PACKAGE_NAME` and `LERNA_PACKAGE_PATH`:
 
 ```sh
-$ lerna exec -- npm view \$LERNA_PACKAGE_NAME
+$ lerna exec -- echo \$LERNA_PACKAGE_PATH - \$LERNA_PACKAGE_NAME
 ```
 
 You may also run a script located in the root dir, in a complicated dir structure through the environment variable `LERNA_ROOT_PATH`:

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -91,6 +91,7 @@ export default class ExecCommand extends Command {
       shell: true,
       env: Object.assign({}, process.env, {
         LERNA_PACKAGE_NAME: pkg.name,
+        LERNA_PACKAGE_PATH: pkg.location,
         LERNA_ROOT_PATH: this.repository.rootPath,
       }),
       reject: this.options.bail,


### PR DESCRIPTION
## Description
This PR adds a new environment variable to the `exec` command - `LERNA_PACKAGE_PATH`. This variable can be used to get the exact path of the package. This is useful for cases where the name of the package differs from the name of the parent folder.

## Motivation and Context
The reason I made this PR is because in order for my shared webpack config to work, I need access to the full path of the packages. The names of the packages are namespaced, and thus have a different folder name.

## How Has This Been Tested?
In order to test this change, I first modified the test cases which involve the `LERNA_PACKAGE_NAME` variable. I later reverted the change, because the test cases weren't used to test the variables. After that, I made a new build to test against my use case, and everything seemed to work fine.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
