### PR TITLE
Avoid interactive prompt during yarn publish

### DIFF
--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -136,11 +136,21 @@ export default class NpmUtilities {
     ChildProcessUtilities.spawnStreaming(npmClient, ["run", script, ...args], opts, pkg.name, callback);
   }
 
-  static publishTaggedInDir(tag, directory, { client = "npm", registry }, callback) {
+  static publishTaggedInDir(tag, pkg, { npmClient, registry }, callback) {
+    const directory = pkg.location;
+
     log.silly("publishTaggedInDir", tag, path.basename(directory));
 
     const opts = NpmUtilities.getExecOpts(directory, registry);
-    ChildProcessUtilities.exec(client, ["publish", "--tag", tag.trim()], opts, callback);
+    const args = ["publish", "--tag", tag.trim()];
+
+    if (npmClient === "yarn") {
+      // skip prompt for new version, use existing instead
+      // https://yarnpkg.com/en/docs/cli/publish#toc-yarn-publish-new-version
+      args.push("--new-version", pkg.version);
+    }
+
+    ChildProcessUtilities.exec(npmClient, args, opts, callback);
   }
 
   static getExecOpts(directory, registry) {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -173,7 +173,7 @@ export default class PublishCommand extends Command {
     this.gitEnabled = !(this.options.canary || this.options.skipGit);
 
     this.npmConfig = {
-      client: this.options.npmClient || "npm",
+      npmClient: this.options.npmClient || "npm",
       registry: this.npmRegistry,
     };
 
@@ -730,7 +730,7 @@ export default class PublishCommand extends Command {
         const run = cb => {
           tracker.verbose("publishing", pkg.name);
 
-          NpmUtilities.publishTaggedInDir(tag, pkg.location, this.npmConfig, err => {
+          NpmUtilities.publishTaggedInDir(tag, pkg, this.npmConfig, err => {
             // FIXME: this err.stack conditional is too cute
             err = (err && err.stack) || err; // eslint-disable-line no-param-reassign
 

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -210,35 +210,47 @@ describe("NpmUtilities", () => {
 
   describe(".publishTaggedInDir()", () => {
     const directory = "/test/publishTaggedInDir";
+    const pkg = { name: "test", location: directory, version: "1.10.100" };
     const callback = () => {};
 
     beforeEach(stubExecOpts);
     afterEach(resetExecOpts);
 
     it("runs npm publish in a directory with --tag support", () => {
-      NpmUtilities.publishTaggedInDir("published-tag", directory, {}, callback);
+      const npmClient = "npm";
+      NpmUtilities.publishTaggedInDir("published-tag", pkg, { npmClient }, callback);
 
-      const cmd = "npm";
       const args = ["publish", "--tag", "published-tag"];
       const opts = { directory, registry: undefined };
-      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
+      expect(ChildProcessUtilities.exec).lastCalledWith(npmClient, args, opts, expect.any(Function));
     });
 
     it("trims trailing whitespace in tag parameter", () => {
-      NpmUtilities.publishTaggedInDir("trailing-tag ", directory, {}, callback);
+      NpmUtilities.publishTaggedInDir("trailing-tag ", pkg, { npmClient: "npm" }, callback);
 
       const actualtag = ChildProcessUtilities.exec.mock.calls[0][1][2];
       expect(actualtag).toBe("trailing-tag");
     });
 
     it("supports custom registry", () => {
+      const npmClient = "npm";
       const registry = "https://custom-registry/publishTaggedInDir";
-      NpmUtilities.publishTaggedInDir("published-tag", directory, { registry }, callback);
+      NpmUtilities.publishTaggedInDir("custom-registry", pkg, { npmClient, registry }, callback);
 
-      const cmd = "npm";
-      const args = ["publish", "--tag", "published-tag"];
+      const args = ["publish", "--tag", "custom-registry"];
       const opts = { directory, registry };
-      expect(ChildProcessUtilities.exec).lastCalledWith(cmd, args, opts, expect.any(Function));
+      expect(ChildProcessUtilities.exec).lastCalledWith(npmClient, args, opts, expect.any(Function));
+    });
+
+    describe("with npmClient yarn", () => {
+      it("appends --new-version to avoid interactive prompt", () => {
+        const npmClient = "yarn";
+        NpmUtilities.publishTaggedInDir("yarn-publish", pkg, { npmClient }, callback);
+
+        const args = ["publish", "--tag", "yarn-publish", "--new-version", "1.10.100"];
+        const opts = { directory, registry: undefined };
+        expect(ChildProcessUtilities.exec).lastCalledWith(npmClient, args, opts, expect.any(Function));
+      });
     });
   });
 

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -47,7 +47,7 @@ const consoleOutput = () => output.mock.calls.map(args => normalizeNewline(args[
 const publishedTagInDirectories = testDir =>
   NpmUtilities.publishTaggedInDir.mock.calls.reduce((arr, args) => {
     const tag = args[0];
-    const dir = normalizeRelativeDir(testDir, args[1]);
+    const dir = normalizeRelativeDir(testDir, args[1].location);
     arr.push({ dir, tag });
     return arr;
   }, []);


### PR DESCRIPTION
This avoids an unfortunate interactive prompt due to a questionable
conflation of the "version" and "publish" commands.

Fixes #1200
