### PR TITLE
Add %v as placeholder for raw version in `--message`

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,9 @@ Useful for bypassing the user input prompt if you already know which version to 
 $ lerna publish -m "chore(release): publish %s"
 # commit message = "chore(release): publish v1.0.0"
 
+$ lerna publish -m "chore(release): publish %v"
+# commit message = "chore(release): publish 1.0.0"
+
 $ lerna publish -m "chore(release): publish" --independent
 # commit message = "chore(release): publish
 #
@@ -474,6 +477,7 @@ for publication. Useful for integrating lerna into projects that expect commit m
 to certain guidelines, such as projects which use [commitizen](https://github.com/commitizen/cz-cli) and/or [semantic-release](https://github.com/semantic-release/semantic-release).
 
 If the message contains `%s`, it will be replaced with the new global version version number prefixed with a "v".
+If the message contains `%v`, it will be replaced with the new global version version number without the leading "v".
 Note that this only applies when using the default "fixed" versioning mode, as there is no "global" version when using `--independent`.
 
 This can be configured in lerna.json, as well:

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -690,7 +690,9 @@ export default class PublishCommand extends Command {
 
   gitCommitAndTagVersion(version) {
     const tag = `v${version}`;
-    const message = (this.options.message && this.options.message.replace(/%s/g, tag)) || tag;
+    const message = this.options.message
+      ? this.options.message.replace(/%s/g, tag).replace(/%v/g, version)
+      : tag;
 
     GitUtilities.commit(message, this.execOpts);
     GitUtilities.addTag(tag, this.execOpts);

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -772,9 +772,14 @@ describe("PublishCommand", () => {
       }),
     );
 
-    it("commits changes with a custom message", () =>
+    it("commits changes with a custom message using %s", () =>
       run(testDir)("--message", "chore: Release %s :rocket:").then(() => {
         expect(GitUtilities.commit).lastCalledWith("chore: Release v1.0.1 :rocket:", execOpts(testDir));
+      }));
+
+    it("commits changes with a custom message using %v", () =>
+      run(testDir)("--message", "chore: Release %v :rocket:").then(() => {
+        expect(GitUtilities.commit).lastCalledWith("chore: Release 1.0.1 :rocket:", execOpts(testDir));
       }));
   });
 


### PR DESCRIPTION
## Description

Added %v as an placeholder for the version in the commit message.

## Motivation and Context

See #1196.

## How Has This Been Tested?

Added a test similar to the test for %s.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
