### PR TITLE
Avoid dropping early logs below default level

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -195,8 +195,6 @@ export default class Command {
   }
 
   run() {
-    // no logging is emitted until run() is called
-    log.resume();
     log.info("version", this.lernaVersion);
 
     return new Promise((resolve, reject) => {
@@ -213,6 +211,7 @@ export default class Command {
       };
 
       try {
+        this.configureLogging();
         this.runValidations();
         this.runPreparations();
       } catch (err) {
@@ -223,13 +222,20 @@ export default class Command {
     });
   }
 
-  runValidations() {
+  configureLogging() {
     // this.options getter might throw (invalid JSON in lerna.json)
-    const { loglevel, independent, onlyExplicitUpdates } = this.options;
+    const { loglevel } = this.options;
 
     if (loglevel) {
       log.level = loglevel;
     }
+
+    // emit all buffered logs at configured level and higher
+    log.resume();
+  }
+
+  runValidations() {
+    const { independent, onlyExplicitUpdates } = this.options;
 
     if (this.requiresGit && !GitUtilities.isInitialized(this.execOpts)) {
       throw new ValidationError(

--- a/src/utils/ValidationError.js
+++ b/src/utils/ValidationError.js
@@ -5,6 +5,7 @@ export default class ValidationError extends Error {
     super(message);
     this.name = "ValidationError";
     this.prefix = prefix;
+    log.resume(); // might be paused, noop otherwise
     log.error(prefix, message);
   }
 }

--- a/src/utils/filterFlags.js
+++ b/src/utils/filterFlags.js
@@ -6,5 +6,5 @@ import _ from "lodash";
  * and yargs spam.
  */
 export default function filterFlags(argv) {
-  return _.omit(_.omitBy(argv, _.isNil), ["h", "help", "v", "version", "$0"]);
+  return _.omit(_.omitBy(argv, _.isNil), ["h", "help", "v", "version", "$0", "_onRejected"]);
 }


### PR DESCRIPTION
Due to changes in #1193, any verbose or silly logs called before any custom loglevel was configured were silently dropped. They were still included in lerna-debug.log, but omitted entirely from the CLI.

- Ensures error logs in ValidationError are emitted
- Filters out context callback from yargs argv
