### PR TITLE
Bump major versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "read-pkg": "^3.0.0",
     "rimraf": "^2.6.1",
     "safe-buffer": "^5.1.1",
-    "semver": "^5.4.1",
+    "semver": "^5.5.0",
     "signal-exit": "^3.0.2",
     "slash": "^1.0.0",
     "strong-log-transformer": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://lernajs.io/",
   "dependencies": {
-    "async": "^1.5.0",
+    "async": "^2.6.0",
     "chalk": "^2.1.0",
     "cmd-shim": "^2.0.2",
     "columnify": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "get-port": "^3.2.0",
     "glob": "^7.1.2",
     "glob-parent": "^3.1.0",
-    "globby": "^6.1.0",
+    "globby": "^7.1.1",
     "graceful-fs": "^4.1.11",
     "hosted-git-info": "^2.5.0",
     "inquirer": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "conventional-changelog-cli": "^1.3.2",
     "conventional-recommended-bump": "^1.0.1",
     "dedent": "^0.7.0",
-    "execa": "^0.8.0",
+    "execa": "^0.9.0",
     "find-up": "^2.1.0",
     "fs-extra": "^4.0.1",
     "get-port": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dedent": "^0.7.0",
     "execa": "^0.9.0",
     "find-up": "^2.1.0",
-    "fs-extra": "^4.0.1",
+    "fs-extra": "^5.0.0",
     "get-port": "^3.2.0",
     "glob": "^7.1.2",
     "glob-parent": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "globby": "^7.1.1",
     "graceful-fs": "^4.1.11",
     "hosted-git-info": "^2.5.0",
-    "inquirer": "^3.2.2",
+    "inquirer": "^5.0.0",
     "is-ci": "^1.0.10",
     "load-json-file": "^4.0.0",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "normalize-path": "^2.1.1",
     "path-key": "^2.0.1",
     "prettier": "^1.9.2",
-    "replacestream": "^4.0.2",
     "tempy": "^0.2.1",
     "touch": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "path-key": "^2.0.1",
     "prettier": "^1.9.2",
     "replacestream": "^4.0.2",
-    "tempy": "^0.1.0",
+    "tempy": "^0.2.1",
     "touch": "^3.1.0"
   },
   "jest": {

--- a/test/InitCommand.js
+++ b/test/InitCommand.js
@@ -37,8 +37,6 @@ jest.mock("../src/GitUtilities");
 // silence logs
 log.level = "silent";
 
-const initEmptyDir = () => tempy.directoryAsync();
-
 describe("InitCommand", () => {
   beforeEach(() => {
     // defaults for most of these tests
@@ -61,7 +59,7 @@ describe("InitCommand", () => {
     let lernaInit;
 
     beforeEach(async () => {
-      testDir = await initEmptyDir();
+      testDir = tempy.directory();
       lernaInit = run(testDir);
 
       GitUtilities.isInitialized = jest.fn(() => false);
@@ -151,7 +149,7 @@ describe("InitCommand", () => {
     let lernaInit;
 
     beforeEach(async () => {
-      const dir = await initEmptyDir();
+      const dir = tempy.directory();
       testDir = path.join(dir, "subdir");
       lernaInit = run(testDir);
 

--- a/test/helpers/copyFixture.js
+++ b/test/helpers/copyFixture.js
@@ -23,10 +23,12 @@ async function copyFixture(targetDir, fixturePath) {
  * @param {String} fileName source path of file being copied
  */
 async function transform(fileName) {
-  let data = await fs.readFile(fileName, "utf8");
+  const original = await fs.readFile(fileName, "utf8");
+  const filtered = original
+    .replace(constants.__TEST_VERSION__, constants.LERNA_VERSION)
+    .replace(constants.__TEST_PKG_URL__, constants.LERNA_PKG_URL);
 
-  data = data.replace(constants.__TEST_VERSION__, constants.LERNA_VERSION);
-  data = data.replace(constants.__TEST_PKG_URL__, constants.LERNA_PKG_URL);
-
-  return fs.writeFile(fileName, data, "utf8");
+  if (original !== filtered) {
+    await fs.writeFile(fileName, filtered, "utf8");
+  }
 }

--- a/test/helpers/copyFixture.js
+++ b/test/helpers/copyFixture.js
@@ -2,36 +2,31 @@
 
 const fs = require("fs-extra");
 const path = require("path");
-const replaceStream = require("replacestream");
+const globby = require("globby");
 const constants = require("./constants");
 
 module.exports = copyFixture;
 
 async function copyFixture(targetDir, fixturePath) {
   const fixtureDir = path.resolve(__dirname, `../fixtures/${fixturePath}`);
-  await fs.copy(fixtureDir, targetDir, { transform });
+  await fs.copy(fixtureDir, targetDir);
+
+  const jsonFiles = await globby(["./package.json", "**/lerna.json"], { cwd: targetDir, absolute: true });
+  await Promise.all(jsonFiles.map(fileName => transform(fileName)));
 }
 
 /**
- * During fixture copy, replace "__TEST_VERSION__" with the current version.
+ * During fixture copy, replace "__TEST_VERSION__" with the current version
+ * and "__TEST_PKG_URL__" with the generated file-url.
  * This is primarily for integration tests, but doesn't hurt unit tests.
  *
- * @param {stream.Readable} readStream
- * @param {stream.Writable} writeStream
- * @param {Object} file metadata
- * @property {String} file.name source path of file being copied
- *
- * @see https://github.com/jprichardson/node-fs-extra/blob/master/lib/copy/ncp.js#L105
+ * @param {String} fileName source path of file being copied
  */
-function transform(readStream, writeStream, file) {
-  let stream = readStream;
+async function transform(fileName) {
+  let data = await fs.readFile(fileName, "utf8");
 
-  if (path.extname(file.name) === ".json") {
-    stream = stream.pipe(replaceStream(constants.__TEST_VERSION__, constants.LERNA_VERSION));
-    stream = stream.pipe(replaceStream(constants.__TEST_PKG_URL__, constants.LERNA_PKG_URL));
-  }
+  data = data.replace(constants.__TEST_VERSION__, constants.LERNA_VERSION);
+  data = data.replace(constants.__TEST_PKG_URL__, constants.LERNA_PKG_URL);
 
-  writeStream.on("open", () => {
-    stream.pipe(writeStream);
-  });
+  return fs.writeFile(fileName, data, "utf8");
 }

--- a/test/helpers/initFixture.js
+++ b/test/helpers/initFixture.js
@@ -7,7 +7,7 @@ const gitInit = require("./gitInit");
 module.exports = initFixture;
 
 async function initFixture(fixturePath, commitMessage = "Init commit") {
-  const testDir = await tempy.directoryAsync();
+  const testDir = tempy.directory();
   await copyFixture(testDir, fixturePath);
   await gitInit(testDir, commitMessage);
   return testDir;

--- a/test/integration/lerna-bootstrap.test.js
+++ b/test/integration/lerna-bootstrap.test.js
@@ -48,7 +48,7 @@ describe("lerna bootstrap", () => {
     });
 
     test("git repo check is ignored by default", async () => {
-      const cwd = await tempy.directoryAsync();
+      const cwd = tempy.directory();
       await copyFixture(cwd, "BootstrapCommand/integration");
       const args = ["bootstrap"];
 

--- a/test/integration/lerna-init.test.js
+++ b/test/integration/lerna-init.test.js
@@ -9,8 +9,6 @@ const tempy = require("tempy");
 const { LERNA_BIN } = require("../helpers/constants");
 const initFixture = require("../helpers/initFixture");
 
-const initEmptyDir = () => tempy.directoryAsync();
-
 const parsePackageJson = cwd => readPkg(path.join(cwd, "package.json"), { normalize: false });
 
 const parseLernaJson = cwd => loadJsonFile(path.join(cwd, "lerna.json"));
@@ -19,7 +17,7 @@ const loadMetaData = cwd => Promise.all([parsePackageJson(cwd), parseLernaJson(c
 
 describe("lerna init", () => {
   test("initializes empty directory", async () => {
-    const cwd = await initEmptyDir();
+    const cwd = tempy.directory();
 
     const { stderr } = await execa(LERNA_BIN, ["init"], { cwd });
     expect(stderr).toMatchSnapshot("stderr");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,8 +1076,8 @@ eslint-plugin-import@^2.8.0:
     read-pkg-up "^2.0.0"
 
 eslint-plugin-jest@^21.6.1:
-  version "21.6.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.6.1.tgz#adca015bbdb8d23b210438ff9e1cee1dd9ec35df"
+  version "21.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.6.2.tgz#aaa7b37c621e49aa0b13f4dc5f7038f73c64b438"
 
 eslint-plugin-node@^5.1.1:
   version "5.2.1"
@@ -1089,8 +1089,8 @@ eslint-plugin-node@^5.1.1:
     semver "5.3.0"
 
 eslint-plugin-prettier@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz#85cab0775c6d5e3344ef01e78d960f166fb93aae"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.5.0.tgz#39a91dd7528eaf19cd42c0ee3f2c1f684606a05f"
   dependencies:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,9 +1394,9 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-fs-extra@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,7 +1249,7 @@ extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-external-editor@^2.0.4:
+external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
   dependencies:
@@ -1757,7 +1757,7 @@ ini@^1.3.2, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-inquirer@^3.0.6, inquirer@^3.2.2:
+inquirer@^3.0.6:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
@@ -1772,6 +1772,24 @@ inquirer@^3.0.6, inquirer@^3.2.2:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.0.0.tgz#261b77cdb535495509f1b90197108ffb96c02db5"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -3327,6 +3345,12 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
+rxjs@^5.5.2:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -3578,6 +3602,10 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 symbol-tree@^3.2.1:
   version "3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,7 +1015,7 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -3129,7 +3129,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -3194,14 +3194,6 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
-
-replacestream@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/replacestream/-/replacestream-4.0.3.tgz#3ee5798092be364b1cdb1484308492cb3dff2f36"
-  dependencies:
-    escape-string-regexp "^1.0.3"
-    object-assign "^4.0.1"
-    readable-stream "^2.0.2"
 
 request-promise-core@1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,11 +197,11 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
 
-async@^1.4.0, async@^1.5.0:
+async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4:
+async@^2.1.4, async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,6 +947,13 @@ diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -1560,15 +1567,16 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-globby@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
   dependencies:
     array-union "^1.0.1"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 got@^6.7.1:
   version "6.7.1"
@@ -1713,7 +1721,7 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ignore@^3.3.3, ignore@^3.3.6:
+ignore@^3.3.3, ignore@^3.3.5, ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3349,17 +3349,13 @@ sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
-semver@^5.0.1, semver@^5.1.0, semver@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,9 +1199,9 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3633,11 +3633,10 @@ tempfile@^1.1.1:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
 
-tempy@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.1.0.tgz#8527413cd07100834fcc9cbb8242be95ba0e1fee"
+tempy@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.2.1.tgz#9038e4dbd1c201b74472214179bc2c6f7776e54c"
   dependencies:
-    pify "^2.3.0"
     temp-dir "^1.0.0"
     unique-string "^1.0.0"
 


### PR DESCRIPTION
## Description

Except for yargs 10, which needs a patch release before my local stash can go forward.

## Motivation and Context

Many of these deps have dropped node v4 support, thus being gated behind lerna v3.0.

Builds off of #1210, #1209, #1208, and #1207. Rebasing is fun times.

## How Has This Been Tested?

Existing tests pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
