### PR TITLE
Throw friendly error when workspaces are not configured correctly

### DIFF
--- a/src/Repository.js
+++ b/src/Repository.js
@@ -61,6 +61,14 @@ class Repository {
 
   get packageConfigs() {
     if (this.lernaJson.useWorkspaces) {
+      if (!this.packageJson.workspaces) {
+        throw new ValidationError(
+          "Invalid workspaces",
+          "workspaces need to be defined in the root package.json." +
+            "See: https://github.com/lerna/lerna#--use-workspaces"
+        );
+      }
+
       return this.packageJson.workspaces;
     }
     return this.lernaJson.packages || [DEFAULT_PACKAGE_GLOB];

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const dedent = require("dedent");
 const findUp = require("find-up");
 const globParent = require("glob-parent");
 const loadJsonFile = require("load-json-file");
@@ -63,9 +64,11 @@ class Repository {
     if (this.lernaJson.useWorkspaces) {
       if (!this.packageJson.workspaces) {
         throw new ValidationError(
-          "Invalid workspaces",
-          "workspaces need to be defined in the root package.json." +
-            "See: https://github.com/lerna/lerna#--use-workspaces"
+          "EWORKSPACES",
+          dedent`
+            Yarn workspaces need to be defined in the root package.json.
+            See: https://github.com/lerna/lerna#--use-workspaces
+          `
         );
       }
 

--- a/test/Repository.js
+++ b/test/Repository.js
@@ -19,11 +19,9 @@ log.level = "silent";
 
 describe("Repository", () => {
   let testDir;
-  let testDirWithWorkspaces;
 
   beforeAll(async () => {
     testDir = await initFixture("Repository/basic");
-    testDirWithWorkspaces = await initFixture("Repository/yarn-workspaces");
   });
 
   describe(".rootPath", () => {
@@ -140,7 +138,8 @@ describe("Repository", () => {
       expect(repo.packageConfigs).toBe(customPackages);
     });
 
-    it("returns workspace packageConfigs", () => {
+    it("returns workspace packageConfigs", async () => {
+      const testDirWithWorkspaces = await initFixture("Repository/yarn-workspaces");
       const repo = new Repository(testDirWithWorkspaces);
       expect(repo.packageConfigs).toEqual(["packages/*"]);
     });
@@ -148,7 +147,7 @@ describe("Repository", () => {
     it("throws with friendly error if workspaces are not configured", () => {
       const repo = new Repository(testDir);
       repo.lernaJson.useWorkspaces = true;
-      expect(() => repo.packageConfigs).toThrowErrorMatchingSnapshot();
+      expect(() => repo.packageConfigs).toThrow(/workspaces need to be defined/);
     });
   });
 

--- a/test/Repository.js
+++ b/test/Repository.js
@@ -144,6 +144,12 @@ describe("Repository", () => {
       const repo = new Repository(testDirWithWorkspaces);
       expect(repo.packageConfigs).toEqual(["packages/*"]);
     });
+
+    it("throws with friendly error if workspaces are not configured", () => {
+      const repo = new Repository(testDir);
+      repo.lernaJson.useWorkspaces = true;
+      expect(() => repo.packageConfigs).toThrowErrorMatchingSnapshot();
+    });
   });
 
   describe("get .packageParentDirs", () => {

--- a/test/Repository.js
+++ b/test/Repository.js
@@ -19,9 +19,11 @@ log.level = "silent";
 
 describe("Repository", () => {
   let testDir;
+  let testDirWithWorkspaces;
 
   beforeAll(async () => {
     testDir = await initFixture("Repository/basic");
+    testDirWithWorkspaces = await initFixture("Repository/yarn-workspaces");
   });
 
   describe(".rootPath", () => {
@@ -136,6 +138,11 @@ describe("Repository", () => {
       const customPackages = [".", "my-packages/*"];
       repo.lernaJson.packages = customPackages;
       expect(repo.packageConfigs).toBe(customPackages);
+    });
+
+    it("returns workspace packageConfigs", () => {
+      const repo = new Repository(testDirWithWorkspaces);
+      expect(repo.packageConfigs).toEqual(["packages/*"]);
     });
   });
 

--- a/test/__snapshots__/Repository.js.snap
+++ b/test/__snapshots__/Repository.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Repository get .packageConfigs throws with friendly error if workspaces are not configured 1`] = `"workspaces need to be defined in the root package.json.See: https://github.com/lerna/lerna#--use-workspaces"`;

--- a/test/__snapshots__/Repository.js.snap
+++ b/test/__snapshots__/Repository.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Repository get .packageConfigs throws with friendly error if workspaces are not configured 1`] = `"workspaces need to be defined in the root package.json.See: https://github.com/lerna/lerna#--use-workspaces"`;

--- a/test/fixtures/Repository/yarn-workspaces/lerna.json
+++ b/test/fixtures/Repository/yarn-workspaces/lerna.json
@@ -1,0 +1,6 @@
+{
+  "lerna": "500.0.0",
+  "version": "1.0.0",
+  "npmClient": "yarn",
+  "useWorkspaces": true
+}

--- a/test/fixtures/Repository/yarn-workspaces/package.json
+++ b/test/fixtures/Repository/yarn-workspaces/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test",
+  "devDependencies": {
+    "external": "^1.0.0",
+    "lerna": "500.0.0"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If you add `useWorkspaces` to your lerna config but don't make the necessary changes in your `package.json`, `lerna bootstrap` will fail [here](https://github.com/lerna/lerna/blob/d0e8d9c5af654f52634119d2c2bd2a888b9488f0/src/PackageUtilities.js#L58).

## Motivation and Context
This PR adds a validation error to make it clearer where the problem is, rather than pointing at the call to `some` on an `undefined` value for example.

Potentially it should throw if not an `Array<string>` too?

## How Has This Been Tested?
There didn't appear to be any repo workspace tests so added an example for future use using the naming convention that seemed to exist. Added one test to confirm workspaces were correctly returned as a default and another for when `useWorkspaces` is configured only.

As an aside all tests run and pass for me if I use `yarn test` but `yarn test:watch` fails on several of them. I can look at this separately if needed?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
