### PR TITLE
Avoid duplicate root changelog entries

### DIFF
--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -958,6 +958,14 @@ describe("PublishCommand", () => {
           }),
         );
       });
+
+      it("avoids double-updating root changelog that is also a package", async () => {
+        const testDir = await initFixture("PublishCommand/fixed-root-conventional");
+        await run(testDir)(); // { conventionalCommits: true } in lerna.json
+
+        expect(ConventionalCommitUtilities.updateFixedRootChangelog).not.toBeCalled();
+        expect(ConventionalCommitUtilities.updateFixedChangelog).toHaveBeenCalledTimes(3);
+      });
     });
   });
 

--- a/test/fixtures/PublishCommand/fixed-root-conventional/lerna.json
+++ b/test/fixtures/PublishCommand/fixed-root-conventional/lerna.json
@@ -1,0 +1,9 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "packages": [
+    ".",
+    "packages/*"
+  ],
+  "conventionalCommits": true,
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/fixed-root-conventional/package.json
+++ b/test/fixtures/PublishCommand/fixed-root-conventional/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixed-root-conventional",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/fixed-root-conventional/packages/package-1/package.json
+++ b/test/fixtures/PublishCommand/fixed-root-conventional/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/fixed-root-conventional/packages/package-2/package.json
+++ b/test/fixtures/PublishCommand/fixed-root-conventional/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}


### PR DESCRIPTION
This covers an edge case when the root package is also published.
The ability to publish the root package.json will be removed in v3.0.

Fixes #1215