### PR TITLE
Avoid triggering pre-commit and commitmsg hooks during publish

### DIFF
--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -51,7 +51,7 @@ function addFile(file, opts) {
 
 function commit(message, opts) {
   log.silly("commit", message);
-  const args = ["commit", "--no-gpg-sign"];
+  const args = ["commit", "--no-gpg-sign", "--no-verify"];
 
   if (message.indexOf(EOL) > -1) {
     // Use tempfile to allow multi\nline strings.

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -92,7 +92,7 @@ describe("GitUtilities", () => {
 
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git",
-        ["commit", "--no-gpg-sign", "-m", "foo"],
+        ["commit", "--no-gpg-sign", "--no-verify", "-m", "foo"],
         opts
       );
       expect(tempWrite.sync).not.toBeCalled();
@@ -106,7 +106,7 @@ describe("GitUtilities", () => {
 
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git",
-        ["commit", "--no-gpg-sign", "-F", "TEMPFILE"],
+        ["commit", "--no-gpg-sign", "--no-verify","-F", "TEMPFILE"],
         opts
       );
       expect(tempWrite.sync).lastCalledWith(`foo${EOL}bar`, "lerna-commit.txt");

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -106,7 +106,7 @@ describe("GitUtilities", () => {
 
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git",
-        ["commit", "--no-verify","-F", "TEMPFILE"],
+        ["commit", "--no-verify", "-F", "TEMPFILE"],
         opts
       );
       expect(tempWrite.sync).lastCalledWith(`foo${EOL}bar`, "lerna-commit.txt");


### PR DESCRIPTION
At the moment lerna is publish is trigger a precommit hook and a commitmsg hook

## Motivation and context.
At the moment lerna triggers precommit hooks which for publishing shouldn’t be triggered I think.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
