### PR TITLE
Remove --no-gpg-sign from `git commit`

### DIFF
--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -51,7 +51,7 @@ function addFile(file, opts) {
 
 function commit(message, opts) {
   log.silly("commit", message);
-  const args = ["commit", "--no-gpg-sign"];
+  const args = ["commit"];
 
   if (message.indexOf(EOL) > -1) {
     // Use tempfile to allow multi\nline strings.

--- a/test/Command.js
+++ b/test/Command.js
@@ -266,7 +266,7 @@ describe("Command", () => {
       await git("tag", "1.0.0");
       await touch(path.join(cwd, "packages/package-2/random-file"));
       await git("add", ".");
-      await git("commit", "--no-gpg-sign", "-m", "test");
+      await git("commit", "-m", "test");
 
       const { filteredPackages } = testFactory({ cwd, since: "" });
       expect(filteredPackages).toHaveLength(2);
@@ -283,13 +283,13 @@ describe("Command", () => {
       await git("tag", "1.0.0");
       await touch(path.join(cwd, "packages/package-1/random-file"));
       await git("add", ".");
-      await git("commit", "--no-gpg-sign", "-m", "test");
+      await git("commit", "-m", "test");
 
       // Then we can checkout a new branch, update and commit.
       await git("checkout", "-b", "test");
       await touch(path.join(cwd, "packages/package-2/random-file"));
       await git("add", ".");
-      await git("commit", "--no-gpg-sign", "-m", "test");
+      await git("commit", "-m", "test");
 
       const { filteredPackages } = testFactory({ cwd, since: "master" });
       expect(filteredPackages).toHaveLength(2);
@@ -304,7 +304,7 @@ describe("Command", () => {
       await git("checkout", "-b", "test");
       await touch(path.join(cwd, "packages/package-4/random-file"));
       await git("add", ".");
-      await git("commit", "--no-gpg-sign", "-m", "test");
+      await git("commit", "-m", "test");
 
       const { filteredPackages } = testFactory({
         cwd,

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -90,11 +90,7 @@ describe("GitUtilities", () => {
       const opts = { cwd: "oneline" };
       GitUtilities.commit("foo", opts);
 
-      expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "git",
-        ["commit", "--no-gpg-sign", "-m", "foo"],
-        opts
-      );
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git", ["commit", "-m", "foo"], opts);
       expect(tempWrite.sync).not.toBeCalled();
     });
 
@@ -104,11 +100,7 @@ describe("GitUtilities", () => {
       const opts = { cwd: "multiline" };
       GitUtilities.commit(`foo${EOL}bar`, opts);
 
-      expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "git",
-        ["commit", "--no-gpg-sign", "-F", "TEMPFILE"],
-        opts
-      );
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git", ["commit", "-F", "TEMPFILE"], opts);
       expect(tempWrite.sync).lastCalledWith(`foo${EOL}bar`, "lerna-commit.txt");
     });
   });

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -66,15 +66,15 @@ describe("ImportCommand", () => {
 
       await fs.writeFile(conflictedFile, "initial content");
       await execa("git", ["add", conflictedFileName], cwdExternalDir);
-      await execa("git", ["commit", "--no-gpg-sign", "-m", "Initial content written"], cwdExternalDir);
+      await execa("git", ["commit", "-m", "Initial content written"], cwdExternalDir);
       await execa("git", ["checkout", "-b", branchName], cwdExternalDir);
 
       await fs.writeFile(conflictedFile, "branch content");
-      await execa("git", ["commit", "--no-gpg-sign", "-am", "branch content written"], cwdExternalDir);
+      await execa("git", ["commit", "-am", "branch content written"], cwdExternalDir);
       await execa("git", ["checkout", "master"], cwdExternalDir);
 
       await fs.writeFile(conflictedFile, "master content");
-      await execa("git", ["commit", "--no-gpg-sign", "-am", "master content written"], cwdExternalDir);
+      await execa("git", ["commit", "-am", "master content written"], cwdExternalDir);
       try {
         await execa("git", ["merge", branchName], cwdExternalDir);
       } catch (e) {
@@ -83,7 +83,7 @@ describe("ImportCommand", () => {
 
       await fs.writeFile(conflictedFile, "merged content");
       await execa("git", ["add", conflictedFileName], cwdExternalDir);
-      await execa("git", ["commit", "--no-gpg-sign", "-m", "Branch merged"], cwdExternalDir);
+      await execa("git", ["commit", "-m", "Branch merged"], cwdExternalDir);
       expect(await lastCommitInDir(externalDir)).toBe("Branch merged");
 
       await lernaImport(externalDir, "--flatten");
@@ -102,7 +102,7 @@ describe("ImportCommand", () => {
       const newFilePath = path.join(testDir, "packages", path.basename(externalDir), "new-file");
 
       await execa("git", ["mv", "old-file", "new-file"], { cwd: externalDir });
-      await execa("git", ["commit", "--no-gpg-sign", "-m", "Moved old-file to new-file"], {
+      await execa("git", ["commit", "-m", "Moved old-file to new-file"], {
         cwd: externalDir,
       });
 
@@ -237,7 +237,7 @@ describe("ImportCommand", () => {
       const newFilePath = path.join(testDir, "packages", path.basename(externalDir), "new-file");
 
       await execa("git", ["mv", "old-file", "new-file"], { cwd: externalDir });
-      await execa("git", ["commit", "--no-gpg-sign", "-m", "[ISSUE-10] Moved old-file to new-file"], {
+      await execa("git", ["commit", "-m", "[ISSUE-10] Moved old-file to new-file"], {
         cwd: externalDir,
       });
 

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -32,7 +32,7 @@ const consoleOutput = () => output.mock.calls.map(args => normalizeNewline(args[
 
 const gitTag = cwd => execa("git", ["tag", "v1.0.0"], { cwd });
 const gitAdd = cwd => execa("git", ["add", "-A"], { cwd });
-const gitCommit = cwd => execa("git", ["commit", "--no-gpg-sign", "-m", "Commit"], { cwd });
+const gitCommit = cwd => execa("git", ["commit", "-m", "Commit"], { cwd });
 const touchFile = cwd => filePath => touch(path.join(cwd, filePath));
 
 const setupGitChanges = async (cwd, filePaths) => {

--- a/test/helpers/gitInit.js
+++ b/test/helpers/gitInit.js
@@ -8,6 +8,7 @@ async function gitInit(cwd, message) {
   const opts = { cwd };
 
   await execa("git", ["init", "."], opts);
+  await execa("git", ["config", "commit.gpgSign", "false"], opts);
   await execa("git", ["add", "-A"], opts);
-  await execa("git", ["commit", "--no-gpg-sign", "-m", message], opts);
+  await execa("git", ["commit", "-m", message], opts);
 }

--- a/test/integration/lerna-publish.test.js
+++ b/test/integration/lerna-publish.test.js
@@ -27,7 +27,7 @@ async function commitChangeToPackage(cwd, packageName, commitMsg, data) {
   const pkg = await loadJsonFile(packageJSONPath);
   await writeJsonFile(packageJSONPath, Object.assign(pkg, data));
   await execa("git", ["add", "."], { cwd });
-  return execa("git", ["commit", "--no-gpg-sign", "-m", commitMsg], { cwd });
+  return execa("git", ["commit", "-m", commitMsg], { cwd });
 }
 
 describe("lerna publish", () => {


### PR DESCRIPTION
## Description

#1059 included an incorrect fix for avoiding testing issues for those that sign their commits by default (without an agent, apparently). It should have been a local config override, not a universal change.

## Motivation and Context

Fixes #1175 

## How Has This Been Tested?

Tests updated and pass.

I started signing my commits locally, and the test suite still passes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
