### PR TITLE
Use realpath when creating relative symlinks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,21 +50,10 @@ $ yarn lint
 If you want to test out Lerna on local repos:
 
 ```sh
-$ yarn build
 $ yarn link
 ```
 
 This will set your global `lerna` command to the local version.
-
-Note that Lerna needs to be built after changes are made. So you can either run
-`yarn build` to run it once, or you can run:
-
-```sh
-$ yarn dev
-```
-
-Which will start a watch task that will continuously re-build Lerna while you
-are working on it.
 
 If you would like to check test coverage, run the coverage script, then open
 `coverage/lcov-report/index.html` in your favorite browser.

--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -142,8 +142,13 @@ function createSymbolicLink(src, dest, type, callback) {
 
 function createPosixSymlink(origin, dest, _type, callback) {
   const type = _type === "exec" ? "file" : _type;
-  const src = path.relative(path.dirname(dest), origin);
-  createSymbolicLink(src, dest, type, callback);
+  const destDir = path.dirname(dest);
+  Promise.all([fs.realpath(origin), fs.realpath(destDir)])
+    .then(([realOrigin, realDestDir]) => {
+      const src = path.relative(realDestDir, realOrigin);
+      createSymbolicLink(src, dest, type, callback);
+    })
+    .catch(callback);
 }
 
 function createWindowsSymlink(src, dest, type, callback) {

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -195,7 +195,7 @@ describe("FileSystemUtilities", () => {
         fs.lstatSync.mockImplementation(() => ({
           isSymbolicLink: () => true,
         }));
-        fs.readlinkSync.mockImplementation(() => linkRelative(original, filePath));
+        fs.realpathSync.mockImplementation(() => original);
         expect(FileSystemUtilities.isSymlink(filePath)).toBe(original);
       });
     } else {

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -251,54 +251,84 @@ describe("FileSystemUtilities", () => {
     });
 
     if (process.platform !== "win32") {
-      it("creates relative symlink to a directory", done => {
-        const src = path.resolve("./packages/package-2");
-        const dst = path.resolve("./packages/package-1/node_modules/package-2");
-        const type = "junction"; // even in posix environments :P
+      describe("without any parent directories being symlinks", () => {
+        beforeEach(() => {
+          fs.realpath.mockImplementation(filePath => Promise.resolve(filePath));
+        });
 
-        FileSystemUtilities.symlink(src, dst, type, () => {
-          try {
-            expect(fs.unlink).not.toBeCalled();
-            expect(fs.symlink).lastCalledWith(linkRelative(src, dst), dst, type, expect.any(Function));
-            done();
-          } catch (ex) {
-            done.fail(ex);
-          }
+        it("creates relative symlink to a directory", done => {
+          const src = path.resolve("./packages/package-2");
+          const dst = path.resolve("./packages/package-1/node_modules/package-2");
+          const type = "junction"; // even in posix environments :P
+
+          FileSystemUtilities.symlink(src, dst, type, () => {
+            try {
+              expect(fs.unlink).not.toBeCalled();
+              expect(fs.symlink).lastCalledWith(linkRelative(src, dst), dst, type, expect.any(Function));
+              done();
+            } catch (ex) {
+              done.fail(ex);
+            }
+          });
+        });
+
+        it("creates relative symlink to an executable file", done => {
+          const src = path.resolve("./packages/package-2/cli.js");
+          const dst = path.resolve("./packages/package-1/node_modules/.bin/package-2");
+          const type = "exec";
+
+          FileSystemUtilities.symlink(src, dst, type, () => {
+            try {
+              expect(fs.unlink).not.toBeCalled();
+              expect(fs.symlink).lastCalledWith(linkRelative(src, dst), dst, "file", expect.any(Function));
+              done();
+            } catch (ex) {
+              done.fail(ex);
+            }
+          });
+        });
+
+        it("overwrites an existing symlink", done => {
+          const src = path.resolve("./packages/package-2");
+          const dst = path.resolve("./packages/package-1/node_modules/package-2");
+          const type = "junction"; // even in posix environments :P
+
+          fs.lstat.mockImplementation(callsBack()); // something _does_ exist at destination
+          fs.unlink.mockImplementation(callsBack());
+
+          FileSystemUtilities.symlink(src, dst, type, () => {
+            try {
+              expect(fs.unlink).lastCalledWith(dst, expect.any(Function));
+              expect(fs.symlink).lastCalledWith(linkRelative(src, dst), dst, type, expect.any(Function));
+              done();
+            } catch (ex) {
+              done.fail(ex);
+            }
+          });
         });
       });
 
-      it("creates relative symlink to an executable file", done => {
-        const src = path.resolve("./packages/package-2/cli.js");
-        const dst = path.resolve("./packages/package-1/node_modules/.bin/package-2");
-        const type = "exec";
-
-        FileSystemUtilities.symlink(src, dst, type, () => {
-          try {
-            expect(fs.unlink).not.toBeCalled();
-            expect(fs.symlink).lastCalledWith(linkRelative(src, dst), dst, "file", expect.any(Function));
-            done();
-          } catch (ex) {
-            done.fail(ex);
-          }
+      describe("with some parent directories being symlinks", () => {
+        beforeEach(() => {
+          fs.realpath.mockImplementation(filePath =>
+            path.resolve(filePath.replace(/package-1\/node_modules$/, "../all_node_modules/package-1"))
+          );
         });
-      });
 
-      it("overwrites an existing symlink", done => {
-        const src = path.resolve("./packages/package-2");
-        const dst = path.resolve("./packages/package-1/node_modules/package-2");
-        const type = "junction"; // even in posix environments :P
+        it("creates a resolvable relative symlink to a directory", done => {
+          const src = path.resolve("./packages/package-2");
+          const dst = path.resolve("./packages/package-1/node_modules/package-2");
+          const type = "junction"; // even in posix environments :P
 
-        fs.lstat.mockImplementation(callsBack()); // something _does_ exist at destination
-        fs.unlink.mockImplementation(callsBack());
-
-        FileSystemUtilities.symlink(src, dst, type, () => {
-          try {
-            expect(fs.unlink).lastCalledWith(dst, expect.any(Function));
-            expect(fs.symlink).lastCalledWith(linkRelative(src, dst), dst, type, expect.any(Function));
-            done();
-          } catch (ex) {
-            done.fail(ex);
-          }
+          FileSystemUtilities.symlink(src, dst, type, () => {
+            try {
+              expect(fs.unlink).not.toBeCalled();
+              expect(fs.symlink).lastCalledWith("../../packages/package-2", dst, type, expect.any(Function));
+              done();
+            } catch (ex) {
+              done.fail(ex);
+            }
+          });
         });
       });
     } else {


### PR DESCRIPTION
## Description

If any parent directories are symlinks, then lerna can create invalid relative symlinks. This pull request fixes that by using `realpath` to resolve symlinks before computing relative paths.

## Motivation and Context

If a monorepo contains two packages `foo` and `bar`, and `foo` depends on `bar`, then `lerna bootstrap` always creates the symlink `packages/foo/node_modules/bar` pointing at `../../bar`. This target value comes from using node’s `path.relative` function, which only looks at strings and not the filesystem.

But if `node_modules` is a symlink off to somewhere else, then `../../bar` might not even exist from inside `foo/node_modules`.

To address the context here:

First, I gather from some googling that there have been some arguments in the JS community around Node’s handling of symlinks. Some people argue that Node handles symlinks ‘wrong’, and that instead of populating large `node_modules` directories with copies of code, `node_modules` should contain only symlinks to centrally-installed packages.

I’m not trying to argue for that at all.

What I have found to be helpful is to make `node_modules` a symlink off to a different part of the disk, e.g., `/not-backed-up/$project`. `npm install` and `require` both work happily with `node_modules` being a symlink. Then large `node_modules` directories from forgotten throwaway projects do not clog backups, and go into a central location where it’s easy to see large, potentially unused and easily recreatable directories, and free up that disk space. Lerna currently chokes on that, and this change would help support that use case.

And I think that, even without that specific use case, this is a fix for a valid bug: when there are other symlinks around, lerna can create symlinks which do not resolve.

## How Has This Been Tested?

Existing test suite passes. Added tests for new code.

Ran locally to verify that valid symlinks are now created where invalid ones were created before.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
