### PR TITLE
Use `globby`, remove `glob`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "find-up": "^2.1.0",
     "fs-extra": "^5.0.0",
     "get-port": "^3.2.0",
-    "glob": "^7.1.2",
     "glob-parent": "^3.1.0",
     "globby": "^7.1.1",
     "graceful-fs": "^4.1.11",

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const async = require("async");
-const glob = require("glob");
+const globby = require("globby");
 const log = require("npmlog");
 const minimatch = require("minimatch");
 const { entries } = require("lodash");
@@ -73,7 +73,7 @@ function getPackages({ packageConfigs, rootPath }) {
   }
 
   packageConfigs.forEach(globPath => {
-    glob.sync(path.join(globPath, "package.json"), globOpts).forEach(globResult => {
+    globby.sync(path.join(globPath, "package.json"), globOpts).forEach(globResult => {
       // https://github.com/isaacs/node-glob/blob/master/common.js#L104
       // glob always returns "\\" as "/" in windows, so everyone
       // gets normalized because we can't have nice things.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove use of `glob.sync`, use `globby.sync`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`lerna` requires both `glob` and `globby`, which do the same thing, just with callbacks or promises, respectively.  So, this just makes things consistent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I Ctrl+F'd for double quotes this time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
