### PR TITLE
Add --ignore-scripts flag to bootstrap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ When run, this command will:
 3. `npm run prepublish` in all bootstrapped packages.
 4. `npm run prepare` in all bootstrapped packages.
 
-`lerna bootstrap` respects the `--ignore`, `--scope` and `--include-filtered-dependencies` flags (see [Flags](#flags)).
+`lerna bootstrap` respects the `--ignore`, `--ignore-scripts`, `--scope` and `--include-filtered-dependencies` flags (see [Flags](#flags)).
 
 Pass extra arguments to npm client by placing them after `--`:
 
@@ -878,6 +878,14 @@ The `ignore` flag, when used with the `bootstrap` command, can also be set in `l
 
 > Hint: The glob is matched against the package name defined in `package.json`,
 > not the directory name the package lives in.
+
+#### --ignore-scripts
+
+When used with the `bootstrap` command it won't run any lifecycle scripts in bootstrapped packages.
+
+```sh
+$ lerna bootstrap --ignore-scripts
+```
 
 #### --include-filtered-dependencies
 

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -139,21 +139,22 @@ class BootstrapCommand extends Command {
     if (this.options.useWorkspaces) {
       this.installRootPackageOnly(callback);
     } else {
+      const { ignoreScripts } = this.options;
       async.series(
         [
           // preinstall bootstrapped packages
-          cb => this.preinstallPackages(cb),
+          !ignoreScripts && (cb => this.preinstallPackages(cb)),
           // install external dependencies
           cb => this.installExternalDependencies(cb),
           // symlink packages and their binaries
           cb => this.symlinkPackages(cb),
           // postinstall bootstrapped packages
-          cb => this.postinstallPackages(cb),
+          !ignoreScripts && (cb => this.postinstallPackages(cb)),
           // prepublish bootstrapped packages
-          cb => this.prepublishPackages(cb),
+          !ignoreScripts && (cb => this.prepublishPackages(cb)),
           // prepare bootstrapped packages
-          cb => this.preparePackages(cb),
-        ],
+          !ignoreScripts && (cb => this.preparePackages(cb)),
+        ].filter(Boolean),
         callback
       );
     }
@@ -228,7 +229,7 @@ class BootstrapCommand extends Command {
   }
 
   /**
-   * Run the "prepublish" NPM script in all bootstrapped packages
+   * Run the "prepare" NPM script in all bootstrapped packages
    * @param callback
    */
   preparePackages(callback) {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -36,6 +36,12 @@ exports.builder = {
     describe: "Don't hoist external dependencies matching [glob] to the repo root",
     type: "string",
   },
+  "ignore-scripts": {
+    group: "Command Options:",
+    describe: "Don't run lifecycle scripts in bootstrapped packages",
+    type: "boolean",
+    default: undefined,
+  },
   "npm-client": {
     group: "Command Options:",
     describe: "Executable used to install dependencies (npm, yarn, pnpm, ...)",

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -95,6 +95,14 @@ describe("BootstrapCommand", () => {
       expect(NpmUtilities.installInDir).not.toBeCalled();
       expect(ranScriptsInDirectories(testDir)).toMatchSnapshot();
     });
+
+    it("shouldn't run lifecycle scripts with --ignore-scripts", async () => {
+      const testDir = await initFixture("BootstrapCommand/ignored-scripts");
+      const lernaBootstrap = run(testDir);
+      await lernaBootstrap("--ignore-scripts");
+
+      expect(ranScriptsInDirectories(testDir)).toMatchSnapshot();
+    });
   });
 
   describe("with hoisting", () => {

--- a/test/__snapshots__/BootstrapCommand.js.snap
+++ b/test/__snapshots__/BootstrapCommand.js.snap
@@ -14,6 +14,8 @@ Object {
 }
 `;
 
+exports[`BootstrapCommand lifecycle scripts shouldn't run lifecycle scripts with --ignore-scripts 1`] = `Object {}`;
+
 exports[`BootstrapCommand with at least one external dependency to install should install all dependencies 1`] = `
 Object {
   "packages/package-1": Array [

--- a/test/fixtures/BootstrapCommand/ignored-scripts/lerna.json
+++ b/test/fixtures/BootstrapCommand/ignored-scripts/lerna.json
@@ -1,0 +1,4 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/ignored-scripts/package.json
+++ b/test/fixtures/BootstrapCommand/ignored-scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ignored-scripts"
+}

--- a/test/fixtures/BootstrapCommand/ignored-scripts/packages/package-postinstall/package.json
+++ b/test/fixtures/BootstrapCommand/ignored-scripts/packages/package-postinstall/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-postinstall",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "touch did-postinstall"
+  }
+}

--- a/test/fixtures/BootstrapCommand/ignored-scripts/packages/package-preinstall/package.json
+++ b/test/fixtures/BootstrapCommand/ignored-scripts/packages/package-preinstall/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-preinstall",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "touch did-preinstall"
+  }
+}

--- a/test/fixtures/BootstrapCommand/ignored-scripts/packages/package-prepare/package.json
+++ b/test/fixtures/BootstrapCommand/ignored-scripts/packages/package-prepare/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-prepare",
+  "version": "1.0.0",
+  "scripts": {
+    "prepare": "touch did-prepare"
+  }
+}

--- a/test/fixtures/BootstrapCommand/ignored-scripts/packages/package-prepublish/package.json
+++ b/test/fixtures/BootstrapCommand/ignored-scripts/packages/package-prepublish/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-prepublish",
+  "version": "1.0.0",
+  "scripts": {
+    "prepublish": "touch did-prepublish"
+  }
+}


### PR DESCRIPTION
## Description
This is quite a simple change - as in the title of the PR.

## Motivation and Context
Fixes #1178 . Our packages have configured lifecycle scripts, but having them ran during bootstrap in monorepo only takes time for us. We later use source files between packages within webpack, jest etc (by aliasing packages).

## How Has This Been Tested?
Snapshot test was added.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
