### PR TITLE
Issue #962: publish --canary should have some way of limiting publish

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -44,7 +44,7 @@ const builder = {
     describe: dedent`
       Restricts the scope to the packages that have been updated since
       the specified [ref], or if not specified, the latest tag.
-      (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)
+      (Only for 'run', 'exec', 'clean', 'ls', 'bootstrap' and 'publish' commands)
     `,
     type: "string",
     requiresArg: false,

--- a/src/UpdatedPackagesCollector.js
+++ b/src/UpdatedPackagesCollector.js
@@ -61,7 +61,7 @@ class UpdatedPackagesCollector {
     let { since } = options;
 
     if (GitUtilities.hasTags(execOpts)) {
-      if (canary) {
+      if (since === undefined && canary) {
         const currentSHA = GitUtilities.getCurrentSHA(execOpts);
 
         since = this.getAssociatedCommits(currentSHA);
@@ -182,7 +182,7 @@ class UpdatedPackagesCollector {
           this.updatedPackages[pkg.name] ||
           this.prereleasedPackages[pkg.name] ||
           this.dependents[pkg.name] ||
-          this.options.canary
+          (this.options.since === undefined && this.options.canary)
       )
       .map(pkg => {
         this.logger.verbose("has filtered update", pkg.name);

--- a/test/UpdatedPackagesCollector.js
+++ b/test/UpdatedPackagesCollector.js
@@ -72,6 +72,36 @@ describe("UpdatedPackagesCollector", () => {
       expect(GitUtilities.diffSinceIn).toBeCalledWith("deadbeef^..deadbeef", "location-2", undefined);
     });
 
+    it("should use the last tag for commit ranges when the canary flag is set and since is set", () => {
+      new UpdatedPackagesCollector({
+        options: {
+          canary: true,
+          since: "",
+        },
+        repository,
+        logger,
+        filteredPackages,
+      }).getUpdates();
+
+      expect(GitUtilities.diffSinceIn).toBeCalledWith("lastTag", "location-1", undefined);
+      expect(GitUtilities.diffSinceIn).toBeCalledWith("lastTag", "location-2", undefined);
+    });
+
+    it("should use the tag for commit ranges when the canary flag is set and since is set to tag", () => {
+      new UpdatedPackagesCollector({
+        options: {
+          canary: true,
+          since: "olderTag",
+        },
+        repository,
+        logger,
+        filteredPackages,
+      }).getUpdates();
+
+      expect(GitUtilities.diffSinceIn).toBeCalledWith("olderTag", "location-1", undefined);
+      expect(GitUtilities.diffSinceIn).toBeCalledWith("olderTag", "location-2", undefined);
+    });
+
     it("should use the last tag in non-canary mode for commit ranges when a repo has tags", () => {
       new UpdatedPackagesCollector({
         options: {},
@@ -82,6 +112,20 @@ describe("UpdatedPackagesCollector", () => {
 
       expect(GitUtilities.diffSinceIn).toBeCalledWith("lastTag", "location-1", undefined);
       expect(GitUtilities.diffSinceIn).toBeCalledWith("lastTag", "location-2", undefined);
+    });
+
+    it("should use the tag in non-canary mode for commit ranges when since is set to tag", () => {
+      new UpdatedPackagesCollector({
+        options: {
+          since: "olderTag",
+        },
+        repository,
+        logger,
+        filteredPackages,
+      }).getUpdates();
+
+      expect(GitUtilities.diffSinceIn).toBeCalledWith("olderTag", "location-1", undefined);
+      expect(GitUtilities.diffSinceIn).toBeCalledWith("olderTag", "location-2", undefined);
     });
   });
 });


### PR DESCRIPTION
## Description
The current behavior for publish --canary is that it publishes all packages whether they've been updated or not. This PR is to support the --since flag on publish --canary to limit publishing to changed
modules only.  

## Motivation and Context
Avoid publishing unchanged modules when doing canary builds. See #962

The referenced issue discusses this in terms of performance, for us the issue isn't performance but rather storage and a clearer view of what the modules the feature branch is affect. In our CI system we have feature branches that we want to QA prior to merging. These branches are built and published using the --canary flag to our internal repository. However publishing every package in the monorepo even if it has no deltas is a waste of resources. 

## How Has This Been Tested?
The unit tests are updated with additional test cases to ensure it behaves as expected.
It's also been sanity checked in our gitlab CI environment.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
