### PR TITLE
feat: Upgrade to yargs 11

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -8,17 +8,6 @@ if (importLocal(__filename)) {
   // eslint-disable-next-line import/no-dynamic-require, global-require
   require("npmlog").verbose("cli", "using local version of lerna");
 } else {
-  const argv = process.argv.slice(2);
-  const context = {
-    // Avoid UnhandledPromiseRejectionWarning when run() errors in a non-test context
-    // (the errors actually _are_ logged, but this avoids yargs re-logging the error)
-    onRejected: err => {
-      if (err && err.name !== "ValidationError") {
-        console.error(err); // eslint-disable-line no-console
-      }
-    },
-  };
-
   // eslint-disable-next-line import/no-dynamic-require, global-require
-  require("../src/cli")().parse(argv, context);
+  require("../src/cli")(process.argv.slice(2)).parse();
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "write-file-atomic": "^2.3.0",
     "write-json-file": "^2.2.0",
     "write-pkg": "^3.1.0",
-    "yargs": "^8.0.2"
+    "yargs": "^11.0.0"
   },
   "bin": {
     "lerna": "./bin/lerna.js"

--- a/package.json
+++ b/package.json
@@ -92,6 +92,9 @@
     "tempy": "^0.2.1",
     "touch": "^3.1.0"
   },
+  "yargs": {
+    "populate--": true
+  },
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.js"

--- a/src/Command.js
+++ b/src/Command.js
@@ -95,7 +95,7 @@ class Command {
     log.info("version", this.lernaVersion);
 
     // launch the command
-    const runner = new Promise((resolve, reject) => {
+    let runner = new Promise((resolve, reject) => {
       const onComplete = (err, exitCode) => {
         if (err) {
           if (typeof err === "string") {
@@ -120,8 +120,8 @@ class Command {
       this.runCommand(onComplete);
     });
 
-    // passed via yargs context, never actual CLI
-    runner.then(argv.onResolved, argv.onRejected);
+    // passed via yargs context in tests, never actual CLI
+    runner = runner.then(argv.onResolved, argv.onRejected);
 
     // proxy "Promise" methods to "private" instance
     this.then = (onResolved, onRejected) => runner.then(onResolved, onRejected);

--- a/src/Command.js
+++ b/src/Command.js
@@ -47,7 +47,6 @@ const builder = {
       (Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands)
     `,
     type: "string",
-    requiresArg: false,
   },
   ignore: {
     describe: dedent`
@@ -70,7 +69,7 @@ const builder = {
   "reject-cycles": {
     describe: "Fail if a cycle is detected among dependencies",
     type: "boolean",
-    default: false,
+    default: undefined,
   },
   sort: {
     describe: "Sort packages topologically (all dependencies before dependents)",

--- a/src/cli.js
+++ b/src/cli.js
@@ -36,7 +36,7 @@ function CLI(argv, cwd) {
     .options(globalOptions)
     .group(globalKeys, "Global Options:")
     .commandDir("./commands")
-    .command("*", "", {}, parsed => {
+    .command("*", false, {}, parsed => {
       // a default command with no description catches typos or missing subcommands
       log.error("lerna", `${parsed._.length ? "Invalid" : "Missing"} command!`);
       log.error("lerna", "Pass --help to see all available commands and options.");
@@ -46,9 +46,7 @@ function CLI(argv, cwd) {
     })
     .demandCommand(1, "Pass --help to see all available commands and options.")
     .showHelpOnFail(false, "A command is required.")
-    .help("h")
     .alias("h", "help")
-    .version()
     .alias("v", "version")
     .wrap(cli.terminalWidth()).epilogue(dedent`
       When a command fails, all logs are written to lerna-debug.log in the current working directory.

--- a/src/commands/AddCommand.js
+++ b/src/commands/AddCommand.js
@@ -14,13 +14,19 @@ const ValidationError = require("../utils/ValidationError");
 
 exports.command = "add [pkgNames..]";
 
-exports.describe = "Add packages as dependency to matched packages";
+exports.describe = "Add dependencies to matched packages";
 
-exports.builder = {
-  dev: {
-    describe: "Save as to devDependencies",
-  },
-};
+exports.builder = yargs =>
+  yargs
+    .options({
+      dev: {
+        describe: "Save to devDependencies",
+      },
+    })
+    .positional("pkgNames", {
+      describe: "One or more package names to add as a dependency",
+      type: "string",
+    });
 
 exports.handler = function handler(argv) {
   // eslint-disable-next-line no-use-before-define

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -15,7 +15,10 @@ exports.command = "diff [pkgName]";
 
 exports.describe = "Diff all packages or a single package since the last release.";
 
-exports.builder = {};
+exports.builder = yargs =>
+  yargs.positional("pkgName", {
+    describe: "An optional package name to filter the diff output",
+  });
 
 function getLastCommit(execOpts) {
   if (GitUtilities.hasTags(execOpts)) {

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -5,6 +5,7 @@ const async = require("async");
 const ChildProcessUtilities = require("../ChildProcessUtilities");
 const Command = require("../Command");
 const PackageUtilities = require("../PackageUtilities");
+const ValidationError = require("../utils/ValidationError");
 
 exports.handler = function handler(argv) {
   // eslint-disable-next-line no-use-before-define
@@ -65,6 +66,10 @@ class ExecCommand extends Command {
     const { cmd, args } = this.options;
     this.command = cmd || dashedArgs.shift();
     this.args = (args || []).concat(dashedArgs);
+
+    if (!this.command) {
+      return callback(new ValidationError("exec", "A command to execute is required"));
+    }
 
     // don't interrupt spawned or streaming stdio
     this.logger.disableProgress();

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -15,22 +15,25 @@ exports.handler = function handler(argv) {
   return new ImportCommand(argv);
 };
 
-exports.command = "import <pathToRepo>";
+exports.command = "import <dir>";
 
 exports.describe = dedent`
-  Import the package in <pathToRepo> into packages/<directory-name> with commit history.
+  Import the package in <dir> into packages/<dir> with commit history.
 `;
 
-exports.builder = {
-  yes: {
-    group: "Command Options:",
-    describe: "Skip all confirmation prompts",
-  },
-  flatten: {
-    group: "Command Options:",
-    describe: "Import each merge commit as a single change the merge introduced",
-  },
-};
+exports.builder = yargs =>
+  yargs
+    .options({
+      yes: {
+        group: "Command Options:",
+        describe: "Skip all confirmation prompts",
+      },
+      flatten: {
+        group: "Command Options:",
+        describe: "Import each merge commit as a single change the merge introduced",
+      },
+    })
+    .positional("dir", { describe: "The path to an external git repository that contains an npm package" });
 
 class ImportCommand extends Command {
   gitParamsForTargetCommits() {

--- a/src/commands/ImportCommand.js
+++ b/src/commands/ImportCommand.js
@@ -45,7 +45,7 @@ class ImportCommand extends Command {
   }
 
   initialize(callback) {
-    const inputPath = this.options.pathToRepo;
+    const inputPath = this.options.dir;
 
     const externalRepoPath = path.resolve(inputPath);
     const externalRepoBase = path.basename(externalRepoPath);

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -12,30 +12,37 @@ exports.handler = function handler(argv) {
   return new RunCommand(argv);
 };
 
-exports.command = "run <script> [args..]";
+exports.command = "run <script>";
 
 exports.describe = "Run an npm script in each package that contains that script.";
 
-exports.builder = {
-  stream: {
-    group: "Command Options:",
-    describe: "Stream output with lines prefixed by package.",
-    type: "boolean",
-    default: undefined,
-  },
-  parallel: {
-    group: "Command Options:",
-    describe: "Run script in all packages with unlimited concurrency, streaming prefixed output",
-    type: "boolean",
-    default: undefined,
-  },
-  "npm-client": {
-    group: "Command Options:",
-    describe: "Executable used to run scripts (npm, yarn, pnpm, ...)",
-    type: "string",
-    requiresArg: true,
-  },
-};
+exports.builder = yargs =>
+  yargs
+    .example("$0 run build -- --silent", "# `npm run build --silent` in all packages with a build script")
+    .options({
+      stream: {
+        group: "Command Options:",
+        describe: "Stream output with lines prefixed by package.",
+        type: "boolean",
+        default: undefined,
+      },
+      parallel: {
+        group: "Command Options:",
+        describe: "Run script in all packages with unlimited concurrency, streaming prefixed output",
+        type: "boolean",
+        default: undefined,
+      },
+      "npm-client": {
+        group: "Command Options:",
+        describe: "Executable used to run scripts (npm, yarn, pnpm, ...)",
+        type: "string",
+        requiresArg: true,
+      },
+    })
+    .positional("script", {
+      describe: "The npm script to run. Pass flags to send to the npm client after --",
+      type: "string",
+    });
 
 class RunCommand extends Command {
   get requiresGit() {
@@ -50,9 +57,9 @@ class RunCommand extends Command {
   }
 
   initialize(callback) {
-    const { script, args } = this.options;
+    const { script } = this.options;
     this.script = script;
-    this.args = args;
+    this.args = this.options["--"] || [];
 
     if (!script) {
       callback(new Error("You must specify which npm script to run."));

--- a/src/utils/filterFlags.js
+++ b/src/utils/filterFlags.js
@@ -10,5 +10,5 @@ module.exports = filterFlags;
  * and yargs spam.
  */
 function filterFlags(argv) {
-  return _.omit(_.omitBy(argv, _.isNil), ["h", "help", "v", "version", "$0", "onRejected"]);
+  return _.omit(_.omitBy(argv, _.isNil), ["h", "help", "v", "version", "$0"]);
 }

--- a/test/Command.js
+++ b/test/Command.js
@@ -187,7 +187,7 @@ describe("Command", () => {
       }
 
       try {
-        await new PkgErrorCommand({ onRejected });
+        await new PkgErrorCommand({});
       } catch (err) {
         expect(console.error.mock.calls).toHaveLength(2);
         expect(console.error.mock.calls[0]).toEqual(["pkg-err-stdout"]);
@@ -497,7 +497,7 @@ describe("Command", () => {
       const cwd = tempy.directory();
 
       try {
-        await testFactory({ cwd, onRejected });
+        await testFactory({ cwd });
       } catch (err) {
         expect(err.exitCode).toBe(1);
         expect(err.prefix).toBe("ENOGIT");
@@ -511,7 +511,7 @@ describe("Command", () => {
       await fs.remove(path.join(cwd, "package.json"));
 
       try {
-        await testFactory({ cwd, onRejected });
+        await testFactory({ cwd });
       } catch (err) {
         expect(err.exitCode).toBe(1);
         expect(err.prefix).toBe("ENOPKG");
@@ -525,7 +525,7 @@ describe("Command", () => {
       await fs.remove(path.join(cwd, "lerna.json"));
 
       try {
-        await testFactory({ cwd, onRejected });
+        await testFactory({ cwd });
       } catch (err) {
         expect(err.exitCode).toBe(1);
         expect(err.prefix).toBe("ENOLERNA");

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -56,7 +56,7 @@ describe("ExecCommand", () => {
       try {
         await lernaExec("--parallel");
       } catch (err) {
-        expect(err.message).toBe("Not enough non-option arguments: got 0, need at least 1");
+        expect(err.message).toBe("A command to execute is required");
       }
     });
 

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -149,7 +149,7 @@ describe("ExecCommand", () => {
     });
 
     it("should run a command with parameters", async () => {
-      await lernaExec("--", "ls", "-la");
+      await lernaExec("ls", "--", "-la");
 
       expect(ChildProcessUtilities.spawn).toHaveBeenCalledTimes(2);
       expect(ChildProcessUtilities.spawn).lastCalledWith(

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -179,9 +179,7 @@ describe("PublishCommand", () => {
       });
 
       const testDir = await initFixture("PublishCommand/independent");
-      await run(testDir)(
-        "--independent" // not required due to lerna.json config, but here to assert it doesn't error
-      );
+      await run(testDir)(); // --independent is only valid in InitCommand
 
       expect(PromptUtilities.confirm).toBeCalled();
       expect(writeJsonFile.sync).not.toBeCalled();

--- a/test/integration/__snapshots__/lerna-exec.test.js.snap
+++ b/test/integration/__snapshots__/lerna-exec.test.js.snap
@@ -16,12 +16,3 @@ exports[`lerna exec exec-test --scope <pkg> 1`] = `
 file-1.js
 package.json
 `;
-
-exports[`lerna exec without -- 1`] = `
---> in "package-1" with extra args ""
-file-1.js
-package.json
---> in "package-2" with extra args ""
-file-2.js
-package.json
-`;

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -40,20 +40,6 @@ describe("lerna exec", () => {
     expect(stdout).toMatchSnapshot();
   });
 
-  test("without --", async () => {
-    const cwd = await initFixture("ExecCommand/basic");
-    const args = [
-      "--concurrency=1",
-      "exec",
-      EXEC_TEST_COMMAND,
-      // no --
-      "-C",
-    ];
-
-    const { stdout } = await execa(LERNA_BIN, args, { cwd, env });
-    expect(stdout).toMatchSnapshot();
-  });
-
   test("echo $LERNA_PACKAGE_NAME", async () => {
     const cwd = await initFixture("ExecCommand/basic");
     const args = [
@@ -135,7 +121,7 @@ describe("lerna exec", () => {
 
   test("--bail=false <cmd>", async () => {
     const cwd = await initFixture("ExecCommand/basic");
-    const args = ["exec", "--bail=false", "--concurrency=1", "--", "npm run fail-or-succeed"];
+    const args = ["exec", "--bail=false", "--concurrency=1", "--", "npm", "run", "fail-or-succeed"];
 
     const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
     expect(stderr).toMatch("Failed at the package-1@1.0.0 fail-or-succeed script");
@@ -145,7 +131,7 @@ describe("lerna exec", () => {
 
   test("--no-bail <cmd>", async () => {
     const cwd = await initFixture("ExecCommand/basic");
-    const args = ["exec", "--no-bail", "--concurrency=1", "--", "npm run fail-or-succeed"];
+    const args = ["exec", "--no-bail", "--concurrency=1", "--", "npm", "run", "fail-or-succeed"];
 
     const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
     expect(stderr).toMatch("Failed at the package-1@1.0.0 fail-or-succeed script");

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,14 +536,6 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
-cliui@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wrap-ansi "^2.0.0"
-
 cliui@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
@@ -3984,15 +3976,15 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs-parser@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
   dependencies:
     camelcase "^4.1.0"
 
@@ -4013,23 +4005,22 @@ yargs@^10.0.3:
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
 
-yargs@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
   dependencies:
-    camelcase "^4.1.0"
-    cliui "^3.2.0"
+    cliui "^4.0.0"
     decamelize "^1.1.1"
+    find-up "^2.1.0"
     get-caller-file "^1.0.1"
     os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
     string-width "^2.0.0"
     which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^7.0.0"
+    yargs-parser "^9.0.2"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
## Description

- Enable `strict()`, with typo recommendations
- Better logging of CLI errors
- Command's runner promise is now a complete chain, not weird
- Improved help output for various commands
- Add yargs-parser `populate--` config

BREAKING CHANGE: Extra flags to certain commands must now be passed behind `--`,
they cannot be implicitly passed with other lerna-specific flags.

## Motivation and Context

Foundation for future option refactoring, etc.

## How Has This Been Tested?

tests updated and pass

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
