### PR TITLE
Add support for new yarn workspaces config format

### DIFF
--- a/src/Repository.js
+++ b/src/Repository.js
@@ -67,7 +67,7 @@ class Repository {
         );
       }
 
-      return this.packageJson.workspaces;
+      return this.packageJson.workspaces.packages || this.packageJson.workspaces;
     }
     return this.lernaJson.packages || [DEFAULT_PACKAGE_GLOB];
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use the new `workspaces.packages` key in `package.json` when available. Otherwise fall back to current behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows use of yarn's new [`nohoist` feature](https://github.com/yarnpkg/yarn/pull/4979)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My current project has the following relevant versions:
* `node@9.5.0`
* `yarn@1.4.1-20180208.2355` (nightly)
* `lerna@2.8.0` (with my patch)

I've only had time to test this manually in my current project. Here's what happened.

1) I enabled and used the `nohoist` feature. For more detail on how I did this see [my PR to create-react-app](https://github.com/facebook/create-react-app/pull/4001)

2) At this point, `lerna run start` failed with:
```sh
EPACKAGES Errored while collecting packages and package graph
TypeError: packageConfigs.some is not a function
```
3) I applied this patch. The error went away and everything worked as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
