### PR TITLE
Add ability to run top level prepublish script with flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,14 @@ $ lerna publish --repo-version 1.0.1
 When run with this flag, `publish` will skip the version selection prompt and use the specified version.
 Useful for bypassing the user input prompt if you already know which version to publish.
 
+#### --run-prepublish
+
+```sh
+$ lerna publish --run-prepublish
+```
+
+Will run the prepublish script in the main package.json. This is run once lerna updates the versions but before it does a git commit or publishes the packages.
+
 #### --message, -m [msg]
 
 ```sh

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -142,6 +142,12 @@ exports.builder = {
     describe: "Specify which branches to allow publishing from.",
     type: "array",
   },
+  "run-prepublish": {
+    group: "Command Options:",
+    describe: "Run prepublish script before committing and publishing.",
+    type: "boolean",
+    default: undefined,
+  },
 };
 
 class PublishCommand extends Command {
@@ -266,6 +272,12 @@ class PublishCommand extends Command {
     }
 
     this.updateUpdatedPackages();
+
+    if (this.options.runPrepublish) {
+      this.repository.package.runScriptSync("prepublish", err => {
+        this.logger.error("failed prepublish", err);
+      });
+    }
 
     if (this.gitEnabled) {
       this.commitAndTagUpdates();

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -956,4 +956,17 @@ describe("PublishCommand", () => {
       expect(NpmUtilities.runScriptInDirSync.mock.calls.map(args => args[0])).toEqual(scripts);
     });
   });
+
+  /** =========================================================================
+   * RUN PREPUBLISH
+   * ======================================================================= */
+
+  describe("prepublish script", () => {
+    it("should be called if run prepublish flag is set", async () => {
+      const testDir = await initFixture("PublishCommand/prepublish");
+      await run(testDir)("--run-prepublish");
+
+      expect(NpmUtilities.runScriptInDirSync.mock.calls[0][0]).toEqual("prepublish");
+    });
+  });
 });

--- a/test/fixtures/PublishCommand/prepublish/lerna.json
+++ b/test/fixtures/PublishCommand/prepublish/lerna.json
@@ -1,0 +1,6 @@
+{
+  "packages": [
+    "package-*"
+  ],
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/prepublish/package-1/package.json
+++ b/test/fixtures/PublishCommand/prepublish/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@prepublish/package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/prepublish/package-2/package.json
+++ b/test/fixtures/PublishCommand/prepublish/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@prepublish/package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "@prepublish/package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/prepublish/package.json
+++ b/test/fixtures/PublishCommand/prepublish/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "prepublish",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "prepublish": "exit 0"
+  },
+  "devDependencies": {
+    "lerna": "__TEST_PKG_URL__"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a flag to run the the main packages prepublish script. This will run once the changed packages are updated but before git phase and publish phase.

## Motivation and Context

Motivation for this is to run some automated doc updates (with newest versions that will be published) and to allow it to be automatically committed with the publish.

For example, I would like to run `yarn run doc:update && git add README.md` and have it committed by lerna as part of the current lifecycle.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Added test to test if npm script is run.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
