### PR TITLE
PackageGraph is a Map, its nodes store relationship Sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "load-json-file": "^4.0.0",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.4",
+    "npm-package-arg": "^6.0.0",
     "npmlog": "^4.1.2",
     "p-finally": "^1.0.0",
     "package-json": "^4.0.1",

--- a/src/Command.js
+++ b/src/Command.js
@@ -275,14 +275,15 @@ class Command {
     }
 
     try {
-      const versionParser = useGitVersion && new GitVersionParser(gitVersionPrefix);
       const packages = PackageUtilities.getPackages({ rootPath, packageConfigs });
-      const packageGraph = PackageUtilities.getPackageGraph(packages, false, versionParser);
+      const packageGraph = PackageUtilities.getPackageGraph(packages);
 
       if (useGitVersion) {
+        const versionParser = new GitVersionParser(gitVersionPrefix);
+
         packages.forEach(pkg => {
           pkg.versionSerializer = new VersionSerializer({
-            graphDependencies: packageGraph.get(pkg.name).dependencies,
+            localDependencies: packageGraph.get(pkg.name).localDependencies,
             versionParser,
           });
         });

--- a/src/PackageGraph.js
+++ b/src/PackageGraph.js
@@ -1,66 +1,235 @@
 "use strict";
 
+const npa = require("npm-package-arg");
 const semver = require("semver");
 
 /**
  * Represents a node in a PackageGraph.
  * @constructor
  * @param {!<Package>} pkg - A Package object to build the node from.
+ * @param {!<String>} graphType - "allDependencies" or "dependencies"
  */
 class PackageGraphNode {
-  constructor(pkg) {
-    this.package = pkg;
-    this.dependencies = [];
+  constructor(pkg, graphType) {
+    Object.defineProperties(this, {
+      // immutable properties
+      name: {
+        enumerable: true,
+        value: pkg.name,
+      },
+      location: {
+        value: pkg.location,
+      },
+      // properties that might change over time
+      version: {
+        get() {
+          return pkg.version;
+        },
+      },
+      graphDependencies: {
+        get() {
+          return pkg[graphType] || {};
+        },
+      },
+      pkg: {
+        get() {
+          return pkg;
+        },
+      },
+      // graph-specific computed properties
+      indegree: {
+        get() {
+          // https://en.wikipedia.org/wiki/Directed_graph#Indegree_and_outdegree
+          return this.localDependencies.size;
+        },
+      },
+      outdegree: {
+        get() {
+          // https://en.wikipedia.org/wiki/Directed_graph#Indegree_and_outdegree
+          return this.localDependents.size;
+        },
+      },
+      degree: {
+        get() {
+          // https://en.wikipedia.org/wiki/Degree_(graph_theory)
+          return this.indegree + this.outdegree;
+        },
+      },
+    });
+
+    this.externalDependencies = new Map();
+    this.localDependencies = new Map();
+    this.localDependents = new Map();
   }
 
-  satisfies(versionRange) {
-    return semver.satisfies(this.package.version, versionRange);
+  is(degreeType) {
+    // The mind-bending thing (just one?!) about dependency graphs
+    // is that the arrows ("edges") point in the reverse direction
+    // of the traditional implication of "has a dependency on" and
+    // "is a dependent of" relationship descriptions.
+    switch (degreeType) {
+      case "source":
+        // only local dependents
+        return this.indegree === 0;
+
+      case "sink":
+        // only local dependencies
+        return this.outdegree === 0;
+
+      case "isolated":
+        // no local dependencies or dependents
+        return this.degree === 0;
+
+      case "leaf":
+        // exactly one local dependency OR dependent
+        return this.degree === 1;
+
+      case "internal":
+        // more than one local dependency OR dependents
+        return !(this.indegree === 0 || this.outdegree === 0);
+
+      default:
+        throw new Error(`unknown property "${degreeType}"`);
+    }
   }
 }
 
 /**
- * Represents a node in a PackageGraph.
+ * A PackageGraph.
  * @constructor
  * @param {!Array.<Package>} packages An array of Packages to build the graph out of.
- * @param {boolean} [depsOnly=false] True to create a graph of only dependencies, excluding the
- *    devDependencies that would normally be included.
+ * @param {!Object} config
+ * @param {!String} config.graphType ("allDependencies" or "dependencies")
+ *    Pass "dependencies" to create a graph of only dependencies,
+ *    excluding the devDependencies that would normally be included.
+ * @param {Boolean} config.forceLocal Force all local dependencies to be linked.
  */
-class PackageGraph {
-  constructor(packages, depsOnly = false, versionParser) {
-    this.nodes = [];
-    this.nodesByName = {};
+class PackageGraph extends Map {
+  constructor(packages, { graphType, forceLocal }) {
+    super(packages.map(pkg => [pkg.name, new PackageGraphNode(pkg, graphType)]));
 
-    for (let p = 0; p < packages.length; p += 1) {
-      const pkg = packages[p];
-      const node = new PackageGraphNode(pkg);
-      this.nodes.push(node);
-      this.nodesByName[pkg.name] = node;
-    }
+    const satisfies = forceLocal
+      ? () => true
+      : (version, resolved) => semver.satisfies(version, resolved.fetchSpec || resolved.gitCommittish);
 
-    for (let n = 0; n < this.nodes.length; n += 1) {
-      const node = this.nodes[n];
-      const dependencies = node.package[depsOnly ? "dependencies" : "allDependencies"] || {};
-      const depNames = Object.keys(dependencies);
+    this.forEach((currentNode, currentName) => {
+      const { graphDependencies } = currentNode;
 
-      for (let d = 0; d < depNames.length; d += 1) {
-        const depName = depNames[d];
-        const packageNode = this.nodesByName[depName];
+      Object.keys(graphDependencies).forEach(depName => {
+        const depNode = this.get(depName);
+        const resolved = npa.resolve(depName, graphDependencies[depName], currentNode.location);
 
-        if (packageNode) {
-          const depVersion = versionParser
-            ? versionParser.parseVersion(dependencies[depName]).version
-            : dependencies[depName];
-
-          if (packageNode.satisfies(depVersion)) {
-            node.dependencies.push(depName);
-          }
+        if (!depNode) {
+          // it's an external dependency, store the resolution and bail
+          return currentNode.externalDependencies.set(depName, resolved);
         }
-      }
-    }
+
+        if (satisfies(depNode.version, resolved)) {
+          currentNode.localDependencies.set(depName, resolved);
+          depNode.localDependents.set(currentName, currentNode);
+        }
+      });
+    });
   }
 
-  get(packageName) {
-    return this.nodesByName[packageName];
+  /**
+   * Return a tuple of cycle paths and nodes, which have been removed from the graph.
+   * @returns [Set<String[]>, Set<PackageGraphNode>]
+   */
+  partitionCycles() {
+    const cyclePaths = new Set();
+    const cycleNodes = new Set();
+
+    this.forEach((currentNode, currentName) => {
+      // console.error("START %s\n%O", currentName, currentNode);
+      const seen = new Set();
+
+      if (currentNode.localDependencies.has(currentName)) {
+        // utterly ridiculous self -> self
+        seen.add(currentNode);
+        cyclePaths.add([currentName, currentName]);
+      }
+
+      const visits = walk => (dependentNode, dependentName, siblingDependents) => {
+        const step = walk.concat(dependentName);
+        // console.warn("VISITS %O", step);
+
+        if (seen.has(dependentNode)) {
+          // console.info("SEEN:: %O", [currentName, dependentName]);
+          return;
+        }
+
+        seen.add(dependentNode);
+
+        if (dependentNode === currentNode) {
+          // a direct cycle
+          cycleNodes.add(currentNode);
+          cyclePaths.add(step);
+          // console.error("DIRECT", step);
+
+          return;
+        }
+
+        if (siblingDependents.has(currentName)) {
+          // a transitive cycle
+          const cycleDependentName = Array.from(dependentNode.localDependencies).find(([key]) =>
+            currentNode.localDependents.has(key)
+          );
+          const pathToCycle = step
+            .slice()
+            .reverse()
+            .concat(cycleDependentName);
+
+          // console.error("TRANSITIVE", pathToCycle);
+          cycleNodes.add(dependentNode);
+          cyclePaths.add(pathToCycle);
+        }
+
+        dependentNode.localDependents.forEach(visits(step));
+        // console.warn("EXITED %O", step);
+      };
+
+      // currentNode.localDependents.forEach((topLevelNode, topLevelName, sibs) => {
+      //   console.log("TOPLVL %O\n%O", [currentName, topLevelName], topLevelNode);
+      //   visits([currentName])(topLevelNode, topLevelName, sibs);
+      // });
+      currentNode.localDependents.forEach(visits([currentName]));
+    });
+
+    if (cycleNodes.size) {
+      this.prune(...cycleNodes);
+    }
+
+    return [cyclePaths, cycleNodes];
+  }
+
+  /**
+   * Remove all candidate nodes.
+   * @param {PackageGraphNode[]} candidates
+   */
+  prune(...candidates) {
+    if (candidates.length === this.size) {
+      return this.clear();
+    }
+
+    candidates.forEach(node => this.remove(node));
+  }
+
+  /**
+   * Delete by value (instead of key), as well as removing pointers
+   * to itself in the other node's internal collections.
+   * @param {PackageGraphNode} candidateNode instance to remove
+   */
+  remove(candidateNode) {
+    this.delete(candidateNode.name);
+
+    this.forEach(node => {
+      // remove incoming edges ("indegree")
+      node.localDependencies.delete(candidateNode.name);
+
+      // remove outgoing edges ("outdegree")
+      node.localDependents.delete(candidateNode.name);
+    });
   }
 }
 

--- a/src/VersionSerializer.js
+++ b/src/VersionSerializer.js
@@ -1,8 +1,8 @@
 "use strict";
 
 class VersionSerializer {
-  constructor({ graphDependencies, versionParser }) {
-    this._graphDependencies = graphDependencies;
+  constructor({ localDependencies, versionParser }) {
+    this._localDependencies = localDependencies;
     this._versionParser = versionParser;
     this._dependenciesKeys = ["dependencies", "devDependencies"];
     this._strippedPrefixes = new Map();
@@ -36,7 +36,7 @@ class VersionSerializer {
 
   _stripPrefix(dependencies) {
     Object.keys(dependencies).forEach(name => {
-      if (this._graphDependencies.includes(name)) {
+      if (this._localDependencies.has(name)) {
         const result = this._versionParser.parseVersion(dependencies[name]);
 
         if (result.prefix) {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -111,7 +111,7 @@ class BootstrapCommand extends Command {
 
     try {
       this.batchedPackages = this.toposort
-        ? PackageUtilities.topologicallyBatchPackages(this.filteredPackages, {
+        ? PackageUtilities.batchPackages(this.filteredPackages, {
             rejectCycles,
           })
         : [this.filteredPackages];
@@ -403,7 +403,7 @@ class BootstrapCommand extends Command {
         // binaries are linked to the packages that depend on them.
         root.push({
           name,
-          dependents: (dependents[rootVersion] || []).map(dep => this.packageGraph.get(dep).package),
+          dependents: (dependents[rootVersion] || []).map(dep => this.packageGraph.get(dep).pkg),
           dependency: `${name}@${rootVersion}`,
           isSatisfied: this.repository.hasDependencyInstalled(name, rootVersion),
         });
@@ -546,7 +546,7 @@ class BootstrapCommand extends Command {
 
     // Install anything that needs to go into the leaves.
     Object.keys(leaves)
-      .map(pkgName => ({ pkg: this.packageGraph.get(pkgName).package, deps: leaves[pkgName] }))
+      .map(pkgName => ({ pkg: this.packageGraph.get(pkgName).pkg, deps: leaves[pkgName] }))
       .forEach(({ pkg, deps }) => {
         // If we have any unsatisfied deps then we need to install everything.
         // This is important for consistent behavior across npm clients.
@@ -584,8 +584,6 @@ class BootstrapCommand extends Command {
    * @param {Function} callback
    */
   symlinkPackages(callback) {
-    const forceLocal = false;
-    const { filteredPackages, packageGraph, logger } = this;
-    PackageUtilities.symlinkPackages(filteredPackages, packageGraph, logger, forceLocal, callback);
+    PackageUtilities.symlinkPackages(this.filteredPackages, this.packageGraph, this.logger, callback);
   }
 }

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -78,7 +78,7 @@ class ExecCommand extends Command {
 
     try {
       this.batchedPackages = this.toposort
-        ? PackageUtilities.topologicallyBatchPackages(filteredPackages, {
+        ? PackageUtilities.batchPackages(filteredPackages, {
             rejectCycles: this.options.rejectCycles,
           })
         : [filteredPackages];

--- a/src/commands/LinkCommand.js
+++ b/src/commands/LinkCommand.js
@@ -37,7 +37,12 @@ class LinkCommand extends Command {
   }
 
   execute(callback) {
-    const { packages, packageGraph, logger, options: { forceLocal } } = this;
-    PackageUtilities.symlinkPackages(packages, packageGraph, logger, forceLocal, callback);
+    let graph = this.packageGraph;
+
+    if (this.options.forceLocal) {
+      graph = PackageUtilities.getPackageGraph(this.packages, { forceLocal: true });
+    }
+
+    PackageUtilities.symlinkPackages(this.packages, graph, this.logger, callback);
   }
 }

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -88,7 +88,7 @@ class RunCommand extends Command {
 
     try {
       this.batchedPackages = this.toposort
-        ? PackageUtilities.topologicallyBatchPackages(this.packagesWithScript, {
+        ? PackageUtilities.batchPackages(this.packagesWithScript, {
             rejectCycles: this.options.rejectCycles,
           })
         : [this.packagesWithScript];

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -30,8 +30,7 @@ exports.builder = yargs => yargs.options(updatedOptions);
 
 class UpdatedCommand extends Command {
   initialize(callback) {
-    const updatedPackagesCollector = new UpdatedPackagesCollector(this);
-    this.updates = updatedPackagesCollector.getUpdates();
+    this.updates = new UpdatedPackagesCollector(this).getUpdates();
 
     const proceedWithUpdates = this.updates.length > 0;
     if (!proceedWithUpdates) {

--- a/test/Command.js
+++ b/test/Command.js
@@ -232,10 +232,7 @@ describe("Command", () => {
   describe("get .packageGraph", () => {
     it("returns the graph of packages", () => {
       const { packageGraph } = testFactory();
-      expect(packageGraph).toEqual({
-        nodes: [],
-        nodesByName: {},
-      });
+      expect(packageGraph).toBeInstanceOf(Map);
     });
   });
 

--- a/test/LinkCommand.js
+++ b/test/LinkCommand.js
@@ -37,14 +37,10 @@ const symlinkedDirectories = testDir =>
   }));
 
 describe("LinkCommand", () => {
-  beforeEach(() => {});
-
-  afterEach(() => jest.resetAllMocks());
+  beforeEach(stubSymlink);
+  afterEach(resetSymlink);
 
   describe("with local package dependencies", () => {
-    beforeEach(stubSymlink);
-    afterEach(resetSymlink);
-
     it("should symlink all packages", async () => {
       const testDir = await initFixture("LinkCommand/basic");
       const lernaLink = run(testDir);
@@ -55,9 +51,6 @@ describe("LinkCommand", () => {
   });
 
   describe("with --force-local", () => {
-    beforeEach(stubSymlink);
-    afterEach(resetSymlink);
-
     it("should force symlink of all packages", async () => {
       const testDir = await initFixture("LinkCommand/force-local");
       const lernaLink = run(testDir);

--- a/test/Package.js
+++ b/test/Package.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const log = require("npmlog");
+const os = require("os");
 const path = require("path");
 
 // mocked modules
@@ -41,10 +42,10 @@ describe("Package", () => {
       const pkg = factory({ name: "get-resolved" });
       expect(pkg.resolved).toMatchObject({
         type: "directory",
-        where: "/root",
         name: "get-resolved",
-        // windows is ridiculous
-        fetchSpec: expect.stringContaining(path.normalize(pkg.location)),
+        where: path.normalize("/root"),
+        // windows is so fucking ridiculous
+        fetchSpec: path.resolve(os.homedir(), pkg.location),
       });
     });
   });

--- a/test/Package.js
+++ b/test/Package.js
@@ -18,74 +18,109 @@ jest.mock("../src/NpmUtilities");
 log.level = "silent";
 
 describe("Package", () => {
-  let pkg;
-
-  beforeEach(() => {
-    pkg = new Package(
-      {
-        name: "my-package",
-        version: "1.0.0",
-        bin: "bin.js",
-        scripts: { "my-script": "echo 'hello world'" },
-        dependencies: { "my-dependency": "^1.0.0" },
-        devDependencies: { "my-dev-dependency": "^1.0.0" },
-        peerDependencies: { "my-peer-dependency": ">=1.0.0" },
-      },
-      "/path/to/package"
-    );
-  });
+  const factory = json => new Package(json, `/root/path/to/${json.name || "package"}`, "/root");
 
   describe("get .name", () => {
     it("should return the name", () => {
-      expect(pkg.name).toBe("my-package");
+      const pkg = factory({ name: "get-name" });
+      expect(pkg.name).toBe("get-name");
     });
   });
 
   describe("get .location", () => {
     it("should return the location", () => {
-      expect(pkg.location).toBe("/path/to/package");
+      const pkg = factory({ name: "get-location" });
+      expect(pkg.location).toBe("/root/path/to/get-location");
+    });
+  });
+
+  describe("get .resolved", () => {
+    it("returns npa.Result relative to rootPath", () => {
+      const pkg = factory({ name: "get-resolved" });
+      expect(pkg.resolved).toMatchObject({
+        type: "directory",
+        where: "/root",
+        name: "get-resolved",
+        fetchSpec: pkg.location,
+      });
     });
   });
 
   describe("get .version", () => {
     it("should return the version", () => {
+      const pkg = factory({ version: "1.0.0" });
       expect(pkg.version).toBe("1.0.0");
     });
   });
 
   describe("set .version", () => {
     it("should set the version", () => {
+      const pkg = factory({ version: "1.0.0" });
       pkg.version = "2.0.0";
       expect(pkg.version).toBe("2.0.0");
     });
   });
 
   describe("get .bin", () => {
-    it("should return the bin", () => {
-      expect(pkg.bin).toBe("bin.js");
+    it("should return the bin object", () => {
+      const pkg = factory({
+        name: "obj-bin",
+        bin: { "custom-bin": "bin.js" },
+      });
+      expect(pkg.bin).toEqual({ "custom-bin": "bin.js" });
+    });
+
+    it("returns a normalized object when pkg.bin is a string", () => {
+      const pkg = factory({
+        name: "string-bin",
+        bin: "bin.js",
+      });
+      expect(pkg.bin).toEqual({ "string-bin": "bin.js" });
+    });
+
+    it("strips scope from normalized bin name", () => {
+      const pkg = factory({
+        name: "@scoped/string-bin",
+        bin: "bin.js",
+      });
+      expect(pkg.bin).toEqual({ "string-bin": "bin.js" });
     });
   });
 
   describe("get .dependencies", () => {
     it("should return the dependencies", () => {
+      const pkg = factory({
+        dependencies: { "my-dependency": "^1.0.0" },
+      });
       expect(pkg.dependencies).toEqual({ "my-dependency": "^1.0.0" });
     });
   });
 
   describe("get .devDependencies", () => {
     it("should return the devDependencies", () => {
+      const pkg = factory({
+        devDependencies: { "my-dev-dependency": "^1.0.0" },
+      });
       expect(pkg.devDependencies).toEqual({ "my-dev-dependency": "^1.0.0" });
     });
   });
 
   describe("get .peerDependencies", () => {
     it("should return the peerDependencies", () => {
+      const pkg = factory({
+        peerDependencies: { "my-peer-dependency": ">=1.0.0" },
+      });
       expect(pkg.peerDependencies).toEqual({ "my-peer-dependency": ">=1.0.0" });
     });
   });
 
   describe("get .allDependencies", () => {
     it("should return the combined dependencies", () => {
+      const pkg = factory({
+        dependencies: { "my-dependency": "^1.0.0" },
+        devDependencies: { "my-dev-dependency": "^1.0.0" },
+        peerDependencies: { "my-peer-dependency": ">=1.0.0" },
+      });
       expect(pkg.allDependencies).toEqual({
         "my-dependency": "^1.0.0",
         "my-dev-dependency": "^1.0.0",
@@ -95,20 +130,37 @@ describe("Package", () => {
 
   describe("get .scripts", () => {
     it("should return the scripts", () => {
+      const pkg = factory({
+        scripts: { "my-script": "echo 'hello world'" },
+      });
       expect(pkg.scripts).toEqual({
         "my-script": "echo 'hello world'",
       });
+    });
+
+    it("preserves immutability of the input", () => {
+      const json = {
+        scripts: { "my-script": "keep" },
+      };
+      const pkg = factory(json);
+
+      pkg.scripts["my-script"] = "tweaked";
+
+      expect(pkg.scripts).toHaveProperty("my-script", "tweaked");
+      expect(json.scripts).toHaveProperty("my-script", "keep");
     });
   });
 
   describe("get .private", () => {
     it("should indicate if the package is private", () => {
+      const pkg = factory({ name: "not-private" });
       expect(pkg.private).toBe(false);
     });
   });
 
   describe(".set versionSerializer", () => {
     it("should call 'deserialize' method of serializer'", () => {
+      const pkg = factory({ name: "serialized-version" });
       const mockSerializer = {
         serialize: jest.fn(obj => obj),
         deserialize: jest.fn(obj => obj),
@@ -124,6 +176,10 @@ describe("Package", () => {
 
   describe(".toJSON()", () => {
     it("should return clone of internal package for serialization", () => {
+      const pkg = factory({
+        name: "is-cloned",
+      });
+
       expect(pkg.toJSON()).not.toBe(pkg.json);
       expect(pkg.toJSON()).toEqual(pkg.json);
 
@@ -134,8 +190,9 @@ describe("Package", () => {
     });
 
     it("should not change internal package with versionSerializer", () => {
-      pkg.json.state = "serialized";
-
+      const pkg = factory({
+        name: "is-idempotent",
+      });
       const mockSerializer = {
         serialize: jest.fn(obj => {
           obj.state = "serialized";
@@ -146,6 +203,8 @@ describe("Package", () => {
           return obj;
         }),
       };
+
+      pkg.json.state = "serialized";
 
       const serializedPkg = Object.assign({}, pkg.json, { state: "serialized" });
       const deserializedPkg = Object.assign({}, pkg.json, { state: "deserialized" });
@@ -162,6 +221,9 @@ describe("Package", () => {
     });
 
     it("should use versionSerializer.serialize on internal package before return", () => {
+      const pkg = factory({
+        name: "is-serialized",
+      });
       const mockSerializer = {
         serialize: jest.fn(obj => obj),
         deserialize: jest.fn(obj => obj),
@@ -180,6 +242,10 @@ describe("Package", () => {
   describe(".runScript()", () => {
     it("should run the script", done => {
       NpmUtilities.runScriptInDir = jest.fn(callsBack());
+
+      const pkg = factory({
+        scripts: { "my-script": "echo 'hello world'" },
+      });
 
       pkg.runScript("my-script", () => {
         try {
@@ -205,6 +271,10 @@ describe("Package", () => {
     it("should run the script", () => {
       NpmUtilities.runScriptInDirSync = jest.fn(callsBack());
 
+      const pkg = factory({
+        scripts: { "my-script": "echo 'hello world'" },
+      });
+
       pkg.runScriptSync("my-script", () => {});
 
       expect(NpmUtilities.runScriptInDirSync).lastCalledWith(
@@ -220,6 +290,13 @@ describe("Package", () => {
   });
 
   describe(".hasMatchingDependency()", () => {
+    const pkg = factory({
+      name: "has-matching",
+      dependencies: { "my-dependency": "^1.0.0" },
+      devDependencies: { "my-dev-dependency": "^1.0.0" },
+      peerDependencies: { "my-peer-dependency": ">=1.0.0" },
+    });
+
     it("should match included dependency", () => {
       expect(
         pkg.hasMatchingDependency({

--- a/test/Package.js
+++ b/test/Package.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const log = require("npmlog");
+const path = require("path");
 
 // mocked modules
 const NpmUtilities = require("../src/NpmUtilities");
@@ -18,7 +19,8 @@ jest.mock("../src/NpmUtilities");
 log.level = "silent";
 
 describe("Package", () => {
-  const factory = json => new Package(json, `/root/path/to/${json.name || "package"}`, "/root");
+  const factory = json =>
+    new Package(json, path.normalize(`/root/path/to/${json.name || "package"}`), path.normalize("/root"));
 
   describe("get .name", () => {
     it("should return the name", () => {
@@ -30,18 +32,19 @@ describe("Package", () => {
   describe("get .location", () => {
     it("should return the location", () => {
       const pkg = factory({ name: "get-location" });
-      expect(pkg.location).toBe("/root/path/to/get-location");
+      expect(pkg.location).toBe(path.normalize("/root/path/to/get-location"));
     });
   });
 
   describe("get .resolved", () => {
-    it("returns npa.Result relative to rootPath", () => {
+    it("returns npa.Result relative to rootPath, always posix", () => {
       const pkg = factory({ name: "get-resolved" });
       expect(pkg.resolved).toMatchObject({
         type: "directory",
         where: "/root",
         name: "get-resolved",
-        fetchSpec: pkg.location,
+        // windows is ridiculous
+        fetchSpec: expect.stringContaining(path.normalize(pkg.location)),
       });
     });
   });

--- a/test/UpdatedPackagesCollector.js
+++ b/test/UpdatedPackagesCollector.js
@@ -19,6 +19,8 @@ const filteredPackages = [
   },
 ];
 
+const packageGraph = new Map(filteredPackages.map(pkg => [pkg.name, pkg]));
+
 const logger = {
   silly: () => {},
   info: () => {},
@@ -36,7 +38,7 @@ describe("UpdatedPackagesCollector", () => {
 
   describe(".collectUpdatedPackages()", () => {
     beforeEach(() => {
-      GitUtilities.getCurrentSHA = jest.fn(() => "deadbeefcafe");
+      GitUtilities.getShortSHA = jest.fn(() => "deadbeef");
       GitUtilities.hasTags = jest.fn(() => true);
       GitUtilities.diffSinceIn = jest.fn(() => "");
       GitUtilities.getLastTag = jest.fn(() => "lastTag");
@@ -52,6 +54,7 @@ describe("UpdatedPackagesCollector", () => {
         repository,
         logger,
         filteredPackages,
+        packageGraph,
       }).getUpdates();
 
       expect(GitUtilities.diffSinceIn).toBeCalledWith("deadbeef^..deadbeef", "location-1", undefined);
@@ -66,6 +69,7 @@ describe("UpdatedPackagesCollector", () => {
         repository,
         logger,
         filteredPackages,
+        packageGraph,
       }).getUpdates();
 
       expect(GitUtilities.diffSinceIn).toBeCalledWith("deadbeef^..deadbeef", "location-1", undefined);
@@ -78,6 +82,7 @@ describe("UpdatedPackagesCollector", () => {
         repository,
         logger,
         filteredPackages,
+        packageGraph,
       }).getUpdates();
 
       expect(GitUtilities.diffSinceIn).toBeCalledWith("lastTag", "location-1", undefined);

--- a/test/VersionSerializer.js
+++ b/test/VersionSerializer.js
@@ -22,7 +22,7 @@ describe("VersionSerializer", () => {
       },
     };
     serializer = new VersionSerializer({
-      graphDependencies: ["my-package-1", "my-package-2", "my-package-3"],
+      localDependencies: new Set(["my-package-1", "my-package-2", "my-package-3"]),
       versionParser: parser,
     });
   });
@@ -37,7 +37,7 @@ describe("VersionSerializer", () => {
       };
 
       serializer = new VersionSerializer({
-        graphDependencies: ["my-package-1", "my-package-2", "my-package-3"],
+        localDependencies: new Set(["my-package-1", "my-package-2", "my-package-3"]),
         versionParser: mockParser,
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,6 +436,10 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -2747,6 +2751,15 @@ normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-package-arg@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.0.0.tgz#8cce04b49d3f9faec3f56b0fe5f4391aeb9d2fac"
+  dependencies:
+    hosted-git-info "^2.5.0"
+    osenv "^0.1.4"
+    semver "^5.4.1"
+    validate-npm-package-name "^3.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -3825,6 +3838,12 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  dependencies:
+    builtins "^1.0.3"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
## sorry this is so big

A lot of existing code was re-calculating stuff that should live inside the PackageGraph; namely, the relationships between packages (localDependencies and localDependents). I made PackageGraph a subclass of Map, mostly because it already had a `.get()` method, and now it can be iterated and such. It's a lot more elegant, overall.

A big piece of the new relationship logic is based on [`npm-package-arg`](https://github.com/npm/npm-package-arg#result-object) parsing, which resolves a lot of previously half-baked logic. It's no longer necessary to pass the git version parser to the graph constructor, for example. `npm-package-arg` will also facilitate future graph manipulations, such as recognizing relative `file:` specifiers correctly.

### `Package`

* The package `bin` field now properly resolves an object when the original value is a string shorthand.
* Many `Package` properties are immutable now, and very few are actually enumerable.

### `PackageGraph`

* `--force-local` evaluation has been moved into `PackageGraph`'s constructor, simplifying the existing evaluation of local dependencies during symlink creation in `LinkCommand`.
* Cycle detection and removal has been moved into a `PackageGraph` instance method, making the topological batching algogrithm much easier to read.
* `PackageGraphNode`s no longer have a confusingly-named "dependencies" list, but distinct `Map` instances `.localDependencies` and `.localDependents`.
* `PackageGraphNode`s themselves now forward most of the interesting `Package` properties, so the potential is there to use them directly, instead of the myriad places we pluck a (renamed) `pkg` property from various containers.

### `UpdatedPackagesCollector`

* Now reuses all of the new graph calculation in `PackageGraph` instead of blithely duplicating it.
* There's a lot of room for other improvements in this utility.

### `PackageUtilities`

* I renamed `topologicallyBatchPackages()` to `batchPackages()`, because ain't nobody got time for that many syllables.
