### PR TITLE
Add "name" and "version" to temp "package.json"

### DIFF
--- a/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -20,6 +20,27 @@ package-3 cli1 OK
 package-3 cli2 package-2 OK
 `;
 
+exports[`lerna bootstrap bootstraps all packages: package1-lock.json 1`] = `
+Object {
+  name: @integration/package-1,
+  version: 1.0.0,
+}
+`;
+
+exports[`lerna bootstrap bootstraps all packages: package2-lock.json 1`] = `
+Object {
+  name: @integration/package-2,
+  version: 1.0.0,
+}
+`;
+
+exports[`lerna bootstrap bootstraps all packages: package3-lock.json 1`] = `
+Object {
+  name: @integration/package-3,
+  version: 1.0.0,
+}
+`;
+
 exports[`lerna bootstrap bootstraps all packages: stderr 1`] = `
 lerna info version __TEST_VERSION__
 lerna info Bootstrapping 4 packages

--- a/test/utils-npm-install.test.js
+++ b/test/utils-npm-install.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+jest.mock("read-pkg");
 jest.mock("write-pkg");
 jest.mock("../src/ChildProcessUtilities");
 jest.mock("../src/FileSystemUtilities");
@@ -7,6 +8,7 @@ jest.mock("../src/FileSystemUtilities");
 const path = require("path");
 
 // mocked modules
+const readPkg = require("read-pkg");
 const writePkg = require("write-pkg");
 const ChildProcessUtilities = require("../src/ChildProcessUtilities");
 const FileSystemUtilities = require("../src/FileSystemUtilities");
@@ -20,6 +22,7 @@ const npmInstall = require("../src/utils/npm-install");
 describe("npm-install", () => {
   ChildProcessUtilities.exec.mockResolvedValue();
   FileSystemUtilities.rename.mockImplementation(callsBack());
+  readPkg.mockResolvedValue({ name: "foo-bar", version: "1.2.3" });
   writePkg.mockResolvedValue();
 
   describe("npmInstall()", () => {
@@ -86,6 +89,8 @@ describe("npm-install", () => {
             path.join(directory, "package.json")
           );
           expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+            name: "foo-bar",
+            version: "1.2.3",
             dependencies: {
               "@scoped/caret": "^2.0.0",
               "@scoped/exact": "2.0.0",
@@ -119,6 +124,8 @@ describe("npm-install", () => {
 
         try {
           expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+            name: "foo-bar",
+            version: "1.2.3",
             dependencies: {
               "@scoped/tagged": "next",
               tagged: "next",
@@ -152,6 +159,8 @@ describe("npm-install", () => {
 
         try {
           expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+            name: "foo-bar",
+            version: "1.2.3",
             dependencies: {
               "@scoped/foo": "latest",
               foo: "latest",
@@ -183,6 +192,8 @@ describe("npm-install", () => {
 
         try {
           expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+            name: "foo-bar",
+            version: "1.2.3",
             dependencies: {
               "@scoped/something": "github:foo/bar",
               something: "github:foo/foo",
@@ -215,6 +226,8 @@ describe("npm-install", () => {
 
         try {
           expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+            name: "foo-bar",
+            version: "1.2.3",
             dependencies: {
               "@scoped/something": "github:foo/bar",
               something: "github:foo/foo",
@@ -249,6 +262,8 @@ describe("npm-install", () => {
 
         try {
           expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+            name: "foo-bar",
+            version: "1.2.3",
             dependencies: {
               "@scoped/something": "github:foo/bar",
               something: "github:foo/foo",
@@ -298,6 +313,8 @@ describe("npm-install", () => {
 
         try {
           expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+            name: "foo-bar",
+            version: "1.2.3",
             dependencies: {
               "@scoped/noversion": "*",
               noversion: "*",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When we generate temp `package.json`, in addition to `dependencies`, also add `name` and `version`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When lerna run `npm install`, npm will update `package-lock.json` based on the content of `package.json`. If `name` and `version` is missing from `package.json`, npm will remove `name` and `version` from existing `package-lock.json`.

This means after running `lerna bootstrap`, the `package-lock.json` will have `name` and `version` removed, and it might generate unnecessary changes.

The changes is depicted as the screenshot below:

![image](https://user-images.githubusercontent.com/1622400/36667073-8cc7c356-1aa1-11e8-8eb7-8000c2f03462.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run `lerna bootstrap`. It should no longer generate any changes for `package-lock.json`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Existing repos which have `name` and `version` stripped from their `package-lock.json`. Running `lerna bootstrap` will see their `package-lock.json` updated with `name` and `version` re-added.

This is expected behavior. On repos without lerna, running `npm install` will update `package-lock.json`, NPM will copy both `name` and `version` from `package.json` to `package-lock.json`.

Since lerna previously accidentally removed them in temp `package.json`, after the user run `lerna bootstrap` the first time after this PR, they will see changes in their `package-lock.json` with `name` and `version` added back again. This new behavior is expected and match what NPM does without lerna.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
