### PR TITLE
Convert command lifecycle from callbacks to Promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "dev": true,
       "requires": {
         "lodash": "4.17.5"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "homepage": "https://lernajs.io/",
   "dependencies": {
-    "async": "^2.6.0",
     "chalk": "^2.3.1",
     "cmd-shim": "^2.0.2",
     "columnify": "^1.5.4",

--- a/src/Command.js
+++ b/src/Command.js
@@ -105,13 +105,9 @@ class Command {
         () => {
           warnIfHanging();
 
-          // redundant, but makes tests easier
-          resolve({ exitCode: process.exitCode });
+          resolve();
         },
         err => {
-          // non-zero is bash for "error"
-          process.exitCode = 1;
-
           if (err.pkg) {
             // Cleanly log specific package error details
             logPackageError(err);
@@ -123,14 +119,12 @@ class Command {
 
           // ValidationError does not trigger a log dump
           if (err.name !== "ValidationError") {
-            console.log("err.name", err.name);
             writeLogFile(this.repository.rootPath);
           }
 
           warnIfHanging();
 
-          // redundant, but makes tests easier
-          err.exitCode = process.exitCode;
+          // error code is handled by cli.fail()
           reject(err);
         }
       );

--- a/src/Command.js
+++ b/src/Command.js
@@ -90,28 +90,50 @@ class Command {
 
     // launch the command
     let runner = new Promise((resolve, reject) => {
-      const onComplete = (err, exitCode) => {
-        if (err) {
-          if (typeof err === "string") {
-            err = { stack: err }; // eslint-disable-line no-param-reassign
-          }
-          err.exitCode = exitCode;
-          reject(err);
-        } else {
-          resolve({ exitCode });
-        }
-      };
+      // run everything inside a Promise chain
+      let chain = Promise.resolve();
 
-      try {
+      chain = chain.then(() => {
         this.repository = new Repository(argv.cwd);
-        this.configureLogging();
-        this.runValidations();
-        this.runPreparations();
-      } catch (err) {
-        return this._complete(err, 1, onComplete);
-      }
+      });
+      chain = chain.then(() => this.configureLogging());
+      chain = chain.then(() => this.runValidations());
+      chain = chain.then(() => this.runPreparations());
+      chain = chain.then(() => this.runCommand());
 
-      this.runCommand(onComplete);
+      chain.then(
+        () => {
+          warnIfHanging();
+
+          // redundant, but makes tests easier
+          resolve({ exitCode: process.exitCode });
+        },
+        err => {
+          // non-zero is bash for "error"
+          process.exitCode = 1;
+
+          if (err.pkg) {
+            // Cleanly log specific package error details
+            logPackageError(err);
+          } else if (err.name !== "ValidationError") {
+            // npmlog does some funny stuff to the stack by default,
+            // so pass it directly to avoid duplication.
+            log.error("", cleanStack(err, this.className));
+          }
+
+          // ValidationError does not trigger a log dump
+          if (err.name !== "ValidationError") {
+            console.log("err.name", err.name);
+            writeLogFile(this.repository.rootPath);
+          }
+
+          warnIfHanging();
+
+          // redundant, but makes tests easier
+          err.exitCode = process.exitCode;
+          reject(err);
+        }
+      );
     });
 
     // passed via yargs context in tests, never actual CLI
@@ -268,101 +290,32 @@ class Command {
       this.npmRegistry = registry;
     }
 
-    try {
-      this.packages = collectPackages({ rootPath, packageConfigs });
-      this.packageGraph = new PackageGraph(this.packages);
-      this.filteredPackages = filterPackages(this.packages, { scope, ignore });
+    this.packages = collectPackages({ rootPath, packageConfigs });
+    this.packageGraph = new PackageGraph(this.packages);
+    this.filteredPackages = filterPackages(this.packages, { scope, ignore });
 
-      // collectUpdates requires that filteredPackages be present prior to checking for
-      // updates. That's okay because it further filters based on what's already been filtered.
-      if (typeof since === "string") {
-        const updated = collectUpdates(this).map(({ pkg }) => pkg.name);
-        this.filteredPackages = this.filteredPackages.filter(pkg => updated.indexOf(pkg.name) > -1);
-      }
+    // collectUpdates requires that filteredPackages be present prior to checking for
+    // updates. That's okay because it further filters based on what's already been filtered.
+    if (typeof since === "string") {
+      const updated = collectUpdates(this).map(({ pkg }) => pkg.name);
 
-      if (this.options.includeFilteredDependencies) {
-        this.filteredPackages = this.packageGraph.addDependencies(this.filteredPackages);
-      }
-    } catch (err) {
-      this._logError("EPACKAGES", "Errored while collecting packages and package graph", err);
-      throw err;
+      this.filteredPackages = this.filteredPackages.filter(pkg => updated.indexOf(pkg.name) > -1);
+    }
+
+    if (this.options.includeFilteredDependencies) {
+      this.filteredPackages = this.packageGraph.addDependencies(this.filteredPackages);
     }
   }
 
-  runCommand(callback) {
-    this._attempt(
-      "initialize",
-      () => {
-        this._attempt(
-          "execute",
-          () => {
-            this._complete(null, 0, callback);
-          },
-          callback
-        );
-      },
-      callback
-    );
-  }
-
-  _attempt(method, next, callback) {
-    try {
-      log.silly(method, "attempt");
-
-      this[method]((err, completed, code = 0) => {
-        if (err) {
-          // If we have package details we can direct the developers attention
-          // to that specific package.
-          if (err.pkg) {
-            this._logPackageError(method, err);
-          } else {
-            this._logError(method, "callback with error", err);
-          }
-          this._complete(err, 1, callback);
-        } else if (!completed) {
-          // an early exit is rarely an error
-          log.verbose(method, "exited early");
-          this._complete(null, code, callback);
-        } else {
-          log.silly(method, "success");
-          next();
+  runCommand() {
+    return Promise.resolve()
+      .then(() => this.initialize())
+      .then(proceed => {
+        if (proceed !== false) {
+          return this.execute();
         }
+        // early exits set their own exitCode (if non-zero)
       });
-    } catch (err) {
-      // ValidationError already logged appropriately
-      if (err.name !== "ValidationError") {
-        this._logError(method, "caught error", err);
-      }
-      this._complete(err, 1, callback);
-    }
-  }
-
-  _complete(err, code, callback) {
-    if (err && err.name !== "ValidationError") {
-      writeLogFile(this.repository.rootPath);
-    }
-
-    // process.exit() is an anti-pattern
-    process.exitCode = code;
-
-    const finish = () => {
-      if (callback) {
-        callback(err, code);
-      }
-    };
-
-    const childProcessCount = ChildProcessUtilities.getChildProcessCount();
-    if (childProcessCount > 0) {
-      log.warn(
-        "complete",
-        `Waiting for ${childProcessCount} child ` +
-          `process${childProcessCount === 1 ? "" : "es"} to exit. ` +
-          "CTRL-C to exit immediately."
-      );
-      ChildProcessUtilities.onAllExited(finish);
-    } else {
-      finish();
-    }
   }
 
   _legacyOptions() {
@@ -386,33 +339,6 @@ class Command {
   execute() {
     throw new Error("command.execute() needs to be implemented.");
   }
-
-  _logError(method, description, err) {
-    log.error(method, description);
-
-    // npmlog does some funny stuff to the stack by default,
-    // so pass it directly to avoid duplication.
-    log.error("", cleanStack(err, this.className));
-  }
-
-  _logPackageError(method, err) {
-    log.error(method, `Error occured with '${err.pkg.name}' while running '${err.cmd}'`);
-
-    const pkgPrefix = `${err.cmd} [${err.pkg.name}]`;
-    log.error(pkgPrefix, `Output from stdout:`);
-    log.pause();
-    console.error(err.stdout); // eslint-disable-line no-console
-
-    log.resume();
-    log.error(pkgPrefix, `Output from stderr:`);
-    log.pause();
-    console.error(err.stderr); // eslint-disable-line no-console
-
-    // Below is just to ensure something sensible is printed after the long
-    // stream of logs
-    log.resume();
-    log.error(method, `Error occured with '${err.pkg.name}' while running '${err.cmd}'`);
-  }
 }
 
 function commandNameFromClassName(className) {
@@ -421,9 +347,41 @@ function commandNameFromClassName(className) {
 
 function cleanStack(err, className) {
   const lines = err.stack ? err.stack.split("\n") : err.split("\n");
-  const cutoff = new RegExp(`^    at ${className}._attempt .*$`);
+  const cutoff = new RegExp(`^    at ${className}.runCommand .*$`);
   const relevantIndex = lines.findIndex(line => cutoff.test(line));
   return lines.slice(0, relevantIndex).join("\n");
+}
+
+function logPackageError(err) {
+  log.error(`Error occured in '${err.pkg.name}' while running '${err.cmd}'`);
+
+  const pkgPrefix = `${err.cmd} [${err.pkg.name}]`;
+  log.error(pkgPrefix, `Output from stdout:`);
+  log.pause();
+  console.error(err.stdout); // eslint-disable-line no-console
+
+  log.resume();
+  log.error(pkgPrefix, `Output from stderr:`);
+  log.pause();
+  console.error(err.stderr); // eslint-disable-line no-console
+
+  // Below is just to ensure something sensible is printed after the long
+  // stream of logs
+  log.resume();
+  log.error(`Error occured in '${err.pkg.name}' while running '${err.cmd}'`);
+}
+
+function warnIfHanging() {
+  const childProcessCount = ChildProcessUtilities.getChildProcessCount();
+
+  if (childProcessCount > 0) {
+    log.warn(
+      "complete",
+      `Waiting for ${childProcessCount} child ` +
+        `process${childProcessCount === 1 ? "" : "es"} to exit. ` +
+        "CTRL-C to exit immediately."
+    );
+  }
 }
 
 module.exports = Command;

--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -87,7 +87,11 @@ function rimraf(dirPath, callback) {
 
   return pathExists(dirPath).then(exists => {
     if (!exists) {
-      return callback();
+      if (callback) {
+        callback();
+      }
+
+      return;
     }
 
     // globs only return directories with a trailing slash

--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -14,9 +14,10 @@ function ensureEndsWithNewLine(string) {
   return /\n$/.test(string) ? string : `${string}\n`;
 }
 
-function chmod(filePath, mode, cb) {
+function chmod(filePath, mode) {
   log.silly("chmod", filePath, mode);
-  fs.chmod(filePath, mode, cb);
+
+  return fs.chmod(filePath, mode);
 }
 
 function chmodSync(filePath, mode) {
@@ -29,9 +30,10 @@ function existsSync(filePath) {
   return pathExists.sync(filePath);
 }
 
-function mkdirp(filePath, callback) {
+function mkdirp(filePath) {
   log.silly("mkdirp", filePath);
-  fs.ensureDir(filePath, callback);
+
+  return fs.ensureDir(filePath);
 }
 
 function mkdirpSync(filePath) {
@@ -44,9 +46,10 @@ function readdirSync(filePath) {
   return fs.readdirSync(filePath);
 }
 
-function rename(from, to, callback) {
-  log.silly("rename", [from, to]);
-  fs.rename(from, to, callback);
+function rename(fromPath, toPath) {
+  log.silly("rename", [fromPath, toPath]);
+
+  return fs.rename(fromPath, toPath);
 }
 
 function renameSync(from, to) {
@@ -54,9 +57,10 @@ function renameSync(from, to) {
   fs.renameSync(from, to);
 }
 
-function writeFile(filePath, fileContents, callback) {
+function writeFile(filePath, fileContents) {
   log.silly("writeFile", [filePath, fileContents]);
-  return fs.writeFile(filePath, ensureEndsWithNewLine(fileContents), callback);
+
+  return fs.writeFile(filePath, ensureEndsWithNewLine(fileContents));
 }
 
 function writeFileSync(filePath, fileContents) {
@@ -79,7 +83,7 @@ function statSync(filePath) {
   return fs.statSync(filePath);
 }
 
-function rimraf(dirPath, callback) {
+function rimraf(dirPath) {
   log.silly("rimraf", dirPath);
   // Shelling out to a child process for a noop is expensive.
   // Checking if `dirPath` exists to be removed is cheap.
@@ -87,10 +91,6 @@ function rimraf(dirPath, callback) {
 
   return pathExists(dirPath).then(exists => {
     if (!exists) {
-      if (callback) {
-        callback();
-      }
-
       return;
     }
 
@@ -100,9 +100,8 @@ function rimraf(dirPath, callback) {
 
     // We call this resolved CLI path in the "path/to/node path/to/cli <..args>"
     // pattern to avoid Windows hangups with shebangs (e.g., WSH can't handle it)
-    return ChildProcessUtilities.spawn(process.execPath, args, {}, err => {
+    return ChildProcessUtilities.spawn(process.execPath, args).then(() => {
       log.verbose("rimraf", "removed", dirPath);
-      callback(err);
     });
   });
 }

--- a/src/PromptUtilities.js
+++ b/src/PromptUtilities.js
@@ -7,7 +7,7 @@ exports.confirm = confirm;
 exports.select = select;
 exports.input = input;
 
-function confirm(message, callback) {
+function confirm(message) {
   log.pause();
 
   return inquirer
@@ -23,15 +23,11 @@ function confirm(message, callback) {
     .then(answers => {
       log.resume();
 
-      if (callback) {
-        callback(answers.confirm);
-      }
-
       return answers.confirm;
     });
 }
 
-function select(message, { choices, filter, validate } = {}, callback) {
+function select(message, { choices, filter, validate } = {}) {
   log.pause();
 
   return inquirer
@@ -49,15 +45,11 @@ function select(message, { choices, filter, validate } = {}, callback) {
     .then(answers => {
       log.resume();
 
-      if (callback) {
-        callback(answers.prompt);
-      }
-
       return answers.prompt;
     });
 }
 
-function input(message, { filter, validate } = {}, callback) {
+function input(message, { filter, validate } = {}) {
   log.pause();
 
   return inquirer
@@ -72,10 +64,6 @@ function input(message, { filter, validate } = {}, callback) {
     ])
     .then(answers => {
       log.resume();
-
-      if (callback) {
-        callback(answers.input);
-      }
 
       return answers.input;
     });

--- a/src/commands/AddCommand.js
+++ b/src/commands/AddCommand.js
@@ -38,87 +38,124 @@ class AddCommand extends Command {
     return false;
   }
 
-  initialize(callback) {
-    const pkgs = this.options.pkgNames.map(input => {
+  initialize() {
+    this.dependencyType = this.options.dev ? "devDependencies" : "dependencies";
+    this.targetPackages = this.options.pkgNames.map(input => {
       const { name, fetchSpec: versionRange } = npa(input);
+
       return { name, versionRange };
     });
 
-    if (pkgs.length === 0) {
-      const err = new ValidationError("EINPUT", "Missing list of packages to add to your project.");
-      return callback(err);
+    if (this.targetPackages.length === 0) {
+      throw new ValidationError("EINPUT", "Missing list of packages to add to your project.");
     }
 
-    const unsatisfied = pkgs
-      .filter(pkg => this.packageExists(pkg.name))
+    const unsatisfied = this.targetPackages
+      .filter(pkg => this.packageGraph.has(pkg.name))
       .filter(a => !this.packageSatisfied(a.name, a.versionRange))
       .map(u => ({
         name: u.name,
         versionRange: u.versionRange,
-        version: this.getPackage(u.name).version,
+        version: this.packageGraph.get(u.name).version,
       }));
 
     if (unsatisfied.length > 0) {
-      const err = new ValidationError("ENOTSATISFIED", notSatisfiedMessage(unsatisfied));
-      return callback(err);
+      throw new ValidationError("ENOTSATISFIED", notSatisfiedMessage(unsatisfied));
     }
 
-    this.dependencyType = this.options.dev ? "devDependencies" : "dependencies";
+    let chain = Promise.resolve();
 
-    Promise.all(
-      pkgs.map(({ name, versionRange }) =>
-        this.getPackageVersion(name, versionRange).then(version => ({ name, version, versionRange }))
-      )
-    )
-      .then(packagesToInstall => {
-        this.packagesToInstall = packagesToInstall;
+    chain = chain.then(() => this.collectPackagesToInstall());
+    chain = chain.then(packagesToInstall => {
+      this.packagesToInstall = packagesToInstall;
+    });
 
-        this.packagesToChange = this.filteredPackages
-          // Skip packages that only would install themselves
-          .filter(filteredPackage => {
-            const notSamePackage = pkgToInstall => pkgToInstall.name !== filteredPackage.name;
-            const addable = this.packagesToInstall.some(notSamePackage);
-            if (!addable) {
-              this.logger.warn(`Will not add ${filteredPackage.name} to itself.`);
-            }
-            return addable;
-          })
-          // Skip packages without actual changes to manifest
-          .filter(filteredPackage => {
-            const deps = filteredPackage[this.dependencyType] || {};
+    chain = chain.then(() => this.collectPackagesToChange());
+    chain = chain.then(packagesToChange => {
+      this.packagesToChange = packagesToChange;
+    });
 
-            // Check if one of the packages to install necessiates a change to filteredPackage's manifest
-            return this.packagesToInstall
-              .filter(pkgToInstall => pkgToInstall.name !== filteredPackage.name)
-              .some(pkgToInstall => {
-                if (!(pkgToInstall.name in deps)) {
-                  return true;
-                }
-                const current = deps[pkgToInstall.name];
-                const range = getRangeToReference(current, pkgToInstall.version, pkgToInstall.versionRange);
-                return range !== current;
-              });
-          });
+    return chain.then(() => {
+      const proceed = this.packagesToChange.length > 0;
 
-        if (this.packagesToChange.length === 0) {
-          const packagesToInstallList = this.packagesToInstall.map(pkg => pkg.name).join(", ");
-          this.logger.warn(`No packages found in scope where ${packagesToInstallList} can be added.`);
-        }
-      })
-      .then(() => callback(null, this.packagesToChange.length > 0))
-      .catch(callback);
+      if (!proceed) {
+        const packagesToInstallList = this.packagesToInstall.map(pkg => pkg.name).join(", ");
+
+        this.logger.warn(`No packages found in scope where ${packagesToInstallList} can be added.`);
+      }
+
+      return proceed;
+    });
   }
 
-  execute(callback) {
+  execute() {
     this.logger.info(`Add ${this.dependencyType} in ${this.packagesToChange.length} packages`);
 
-    Promise.all(
-      this.packagesToChange.map(pkgToChange => {
-        const manifestPath = path.join(pkgToChange.location, "package.json");
+    return this.makeChanges().then(pkgs => {
+      const changedPkgs = pkgs.filter(p => p.changed);
 
-        const notSamePackage = pkgToInstall => pkgToChange.name !== pkgToInstall.name;
+      this.logger.info(`Changes require bootstrap in ${changedPkgs.length} packages`);
 
-        const applicable = this.packagesToInstall.filter(notSamePackage).reduce((obj, pkgToInstall) => {
+      const options = Object.assign({}, this.options, {
+        args: [],
+        cwd: this.repository.rootPath,
+        scope: changedPkgs.map(p => p.name),
+      });
+
+      return BootstrapCommand.handler(options);
+    });
+  }
+
+  collectPackagesToInstall() {
+    const mapper = ({ name, versionRange }) =>
+      this.getPackageVersion(name, versionRange).then(version => ({ name, version, versionRange }));
+
+    return Promise.all(this.targetPackages.map(mapper));
+  }
+
+  collectPackagesToChange() {
+    let result = this.filteredPackages;
+
+    // Skip packages that only would install themselves
+    result = result.filter(filteredPackage => {
+      const addable = this.packagesToInstall.some(pkgToInstall => pkgToInstall.name !== filteredPackage.name);
+
+      if (!addable) {
+        this.logger.warn(`Will not add ${filteredPackage.name} to itself.`);
+      }
+
+      return addable;
+    });
+
+    // Skip packages without actual changes to manifest
+    result = result.filter(filteredPackage => {
+      const deps = filteredPackage[this.dependencyType] || {};
+
+      // Check if one of the packages to install necessiates a change to filteredPackage's manifest
+      return this.packagesToInstall
+        .filter(pkgToInstall => pkgToInstall.name !== filteredPackage.name)
+        .some(pkgToInstall => {
+          if (!(pkgToInstall.name in deps)) {
+            return true;
+          }
+
+          const current = deps[pkgToInstall.name];
+          const range = getRangeToReference(current, pkgToInstall.version, pkgToInstall.versionRange);
+
+          return range !== current;
+        });
+    });
+
+    return result;
+  }
+
+  makeChanges() {
+    const mapper = pkgToChange => {
+      const manifestPath = path.join(pkgToChange.location, "package.json");
+
+      const applicable = this.packagesToInstall
+        .filter(pkgToInstall => pkgToChange.name !== pkgToInstall.name)
+        .reduce((obj, pkgToInstall) => {
           const deps = pkgToChange[this.dependencyType] || {};
           const current = deps[pkgToInstall.name];
           const range = getRangeToReference(current, pkgToInstall.version, pkgToInstall.versionRange);
@@ -126,72 +163,54 @@ class AddCommand extends Command {
           this.logger.verbose(
             `Add ${pkgToInstall.name}@${range} as ${this.dependencyType} in ${pkgToChange.name}`
           );
+
           obj[pkgToInstall.name] = range;
 
           return obj;
         }, {});
 
-        return readPkg(manifestPath, { normalize: false })
-          .then(a => {
-            const previous = a[this.dependencyType] || {};
-            const payload = Object.assign({}, previous, applicable);
-            const ammendment = { [this.dependencyType]: payload };
+      return readPkg(manifestPath, { normalize: false })
+        .then(a => {
+          const previous = a[this.dependencyType] || {};
+          const payload = Object.assign({}, previous, applicable);
+          const ammendment = { [this.dependencyType]: payload };
 
-            const b = Object.assign({}, a, ammendment);
-            return { a, b };
-          })
-          .then(({ a, b }) => {
-            const changed = JSON.stringify(a) !== JSON.stringify(b);
-            const exec = changed ? () => writePkg(manifestPath, b) : () => Promise.resolve();
+          const b = Object.assign({}, a, ammendment);
+          return { a, b };
+        })
+        .then(({ a, b }) => {
+          const changed = JSON.stringify(a) !== JSON.stringify(b);
+          const exec = changed ? () => writePkg(manifestPath, b) : () => Promise.resolve();
 
-            return exec().then(() => ({
-              name: pkgToChange.name,
-              changed,
-            }));
-          });
-      })
-    )
-      .then(pkgs => {
-        const changedPkgs = pkgs.filter(p => p.changed);
-
-        this.logger.info(`Changes require bootstrap in ${changedPkgs.length} packages`);
-
-        const options = Object.assign({}, this.options, {
-          args: [],
-          cwd: this.repository.rootPath,
-          scope: changedPkgs.map(p => p.name),
+          return exec().then(() => ({
+            name: pkgToChange.name,
+            changed,
+          }));
         });
+    };
 
-        return BootstrapCommand.handler(options);
-      })
-      .then(() => callback())
-      .catch(callback);
-  }
-
-  getPackage(name) {
-    return this.packages.find(pkg => pkg.name === name);
+    return Promise.all(this.packagesToChange.map(mapper));
   }
 
   getPackageVersion(name, versionRange) {
     if (this.packageSatisfied(name, versionRange)) {
-      return Promise.resolve(this.getPackage(name).version);
+      return Promise.resolve(this.packageGraph.get(name).version);
     }
+
     return packageJson(name, { version: versionRange }).then(pkg => pkg.version);
   }
 
-  packageExists(name) {
-    return this.packages.some(pkg => pkg.name === name);
-  }
-
   packageSatisfied(name, versionRange) {
-    const pkg = this.getPackage(name);
+    const pkg = this.packageGraph.get(name);
 
     if (!pkg) {
       return false;
     }
+
     if (versionRange === "latest") {
       return true;
     }
+
     return semver.intersects(pkg.version, versionRange);
   }
 }

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -13,6 +13,7 @@ const FileSystemUtilities = require("../FileSystemUtilities");
 const npmInstall = require("../utils/npm-install");
 const npmRunScript = require("../utils/npm-run-script");
 const batchPackages = require("../utils/batch-packages");
+const runParallelBatches = require("../utils/run-parallel-batches");
 const matchPackageName = require("../utils/match-package-name");
 const hasDependencyInstalled = require("../utils/has-dependency-installed");
 const symlinkBinary = require("../utils/symlink-binary");
@@ -197,11 +198,8 @@ class BootstrapCommand extends Command {
 
     tracker.addWork(packagesWithScript.size);
 
-    return pFinally(
-      pMapSeries(this.batchedPackages, batch =>
-        pMap(batch, mapPackageWithScript, { concurrency: this.concurrency })
-      ),
-      () => tracker.finish()
+    return pFinally(runParallelBatches(this.batchedPackages, this.concurrency, mapPackageWithScript), () =>
+      tracker.finish()
     );
   }
 

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -28,7 +28,7 @@ function getLastCommit(execOpts) {
 }
 
 class DiffCommand extends Command {
-  initialize(callback) {
+  initialize() {
     const packageName = this.options.pkgName;
 
     // don't interrupt spawned or streaming stdio
@@ -57,16 +57,13 @@ class DiffCommand extends Command {
     }
 
     this.args = args;
-
-    callback(null, true);
   }
 
-  execute(callback) {
-    ChildProcessUtilities.spawn("git", this.args, this.execOpts, err => {
-      if (err && err.code) {
-        callback(err);
-      } else {
-        callback(null, true);
+  execute() {
+    return ChildProcessUtilities.spawn("git", this.args, this.execOpts).catch(err => {
+      if (err.code) {
+        // quitting the diff viewer is not an error
+        throw err;
       }
     });
   }

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -93,9 +93,11 @@ class ExecCommand extends Command {
         batch,
         pkg =>
           this.runCommandInPackage(pkg).catch(err => {
-            if (err && err.code) {
+            if (err.code) {
               this.logger.error("exec", `Errored while executing '${err.cmd}' in '${pkg.name}'`);
             }
+
+            throw err;
           }),
         { concurrency: this.concurrency }
       )

--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -42,23 +42,21 @@ class InitCommand extends Command {
   runValidations() {}
   runPreparations() {}
 
-  initialize(callback) {
-    if (!GitUtilities.isInitialized(this.execOpts)) {
-      this.logger.info("", "Initializing Git repository");
-      GitUtilities.init(this.execOpts);
-    }
-
+  initialize() {
     this.exact = this.options.exact;
 
-    callback(null, true);
+    if (!GitUtilities.isInitialized(this.execOpts)) {
+      this.logger.info("", "Initializing Git repository");
+
+      GitUtilities.init(this.execOpts);
+    }
   }
 
-  execute(callback) {
+  execute() {
     this.ensurePackageJSON();
     this.ensureLernaJson();
     this.ensurePackagesDir();
     this.logger.success("", "Initialized Lerna files");
-    callback(null, true);
   }
 
   ensurePackageJSON() {

--- a/src/commands/LinkCommand.js
+++ b/src/commands/LinkCommand.js
@@ -33,17 +33,17 @@ class LinkCommand extends Command {
     });
   }
 
-  initialize(callback) {
-    callback(null, true);
-  }
-
-  execute(callback) {
+  initialize() {
     let graph = this.packageGraph;
 
     if (this.options.forceLocal) {
       graph = new PackageGraph(this.packages, "allDependencies", "forceLocal");
     }
 
-    symlinkDependencies(this.packages, graph, this.logger, callback);
+    this.targetGraph = graph;
+  }
+
+  execute() {
+    return symlinkDependencies(this.packages, this.targetGraph, this.logger);
   }
 }

--- a/src/commands/LsCommand.js
+++ b/src/commands/LsCommand.js
@@ -37,17 +37,15 @@ class LsCommand extends Command {
     });
   }
 
-  initialize(callback) {
+  initialize() {
     this.resultList = this.filteredPackages.map(pkg => ({
       name: pkg.name,
       version: pkg.version,
       private: pkg.private,
     }));
-
-    callback(null, true);
   }
 
-  execute(callback) {
+  execute() {
     let result;
 
     if (this.options.json) {
@@ -57,8 +55,6 @@ class LsCommand extends Command {
     }
 
     output(result);
-
-    callback(null, true);
   }
 
   formatJSON() {

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -7,7 +7,6 @@ const minimatch = require("minimatch");
 const path = require("path");
 const pFinally = require("p-finally");
 const pMap = require("p-map");
-const pMapSeries = require("p-map-series");
 const pReduce = require("p-reduce");
 const pWaterfall = require("p-waterfall");
 const semver = require("semver");
@@ -24,6 +23,7 @@ const npmDistTag = require("../utils/npm-dist-tag");
 const npmPublish = require("../utils/npm-publish");
 const npmRunScript = require("../utils/npm-run-script");
 const batchPackages = require("../utils/batch-packages");
+const runParallelBatches = require("../utils/run-parallel-batches");
 const ValidationError = require("../utils/validation-error");
 
 exports.handler = function handler(argv) {
@@ -224,7 +224,7 @@ class PublishCommand extends Command {
 
     this.packagesToPublish = this.updates.map(({ pkg }) => pkg).filter(pkg => !pkg.private);
 
-    this.batchedPackagesToPublish = this.toposort
+    this.batchedPackages = this.toposort
       ? batchPackages(
           this.packagesToPublish,
           this.options.rejectCycles,
@@ -694,11 +694,8 @@ class PublishCommand extends Command {
       });
     };
 
-    return pFinally(
-      pMapSeries(this.batchedPackagesToPublish, batch =>
-        pMap(batch, mapPackage, { concurrency: this.concurrency })
-      ),
-      () => tracker.finish()
+    return pFinally(runParallelBatches(this.batchedPackages, this.concurrency, mapPackage), () =>
+      tracker.finish()
     );
   }
 
@@ -713,11 +710,8 @@ class PublishCommand extends Command {
         tracker.completeWork(1);
       });
 
-    return pFinally(
-      pMapSeries(this.batchedPackagesToPublish, batch =>
-        pMap(batch, mapPackage, { concurrency: this.concurrency })
-      ),
-      () => tracker.finish()
+    return pFinally(runParallelBatches(this.batchedPackages, this.concurrency, mapPackage), () =>
+      tracker.finish()
     );
   }
 

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -168,7 +168,7 @@ class PublishCommand extends Command {
     });
   }
 
-  initialize(callback) {
+  initialize() {
     this.gitRemote = this.options.gitRemote || "origin";
     this.gitEnabled = !(this.options.canary || this.options.skipGit);
 
@@ -216,8 +216,10 @@ class PublishCommand extends Command {
     this.updates = collectUpdates(this);
 
     if (!this.updates.length) {
-      this.logger.info("No updated packages to publish.");
-      return callback(null, false);
+      this.logger.success("No updated packages to publish");
+
+      // still exits zero, aka "ok"
+      return false;
     }
 
     this.packagesToPublish = this.updates.map(({ pkg }) => pkg).filter(pkg => !pkg.private);
@@ -240,12 +242,10 @@ class PublishCommand extends Command {
       () => this.confirmVersions(),
     ];
 
-    return pWaterfall(tasks)
-      .then(proceed => callback(null, proceed))
-      .catch(callback);
+    return pWaterfall(tasks);
   }
 
-  execute(callback) {
+  execute() {
     const tasks = [];
 
     if (!this.repository.isIndependent() && !this.options.canary) {
@@ -264,9 +264,7 @@ class PublishCommand extends Command {
       tasks.push(() => this.publishPackagesToNpm());
     }
 
-    pWaterfall(tasks)
-      .then(() => callback(null, true))
-      .catch(callback);
+    return pWaterfall(tasks);
   }
 
   resolveLocalDependencyLinks() {

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -1,11 +1,11 @@
 "use strict";
 
 const pMap = require("p-map");
-const pMapSeries = require("p-map-series");
 
 const Command = require("../Command");
 const npmRunScript = require("../utils/npm-run-script");
 const batchPackages = require("../utils/batch-packages");
+const runParallelBatches = require("../utils/run-parallel-batches");
 const output = require("../utils/output");
 
 exports.handler = function handler(argv) {
@@ -113,11 +113,7 @@ class RunCommand extends Command {
       ? pkg => this.runScriptInPackageStreaming(pkg)
       : pkg => this.runScriptInPackageCapturing(pkg);
 
-    return pMapSeries(this.batchedPackages, batch =>
-      pMap(batch, pkg => runner(pkg), {
-        concurrency: this.concurrency,
-      })
-    );
+    return runParallelBatches(this.batchedPackages, this.concurrency, pkg => runner(pkg));
   }
 
   runScriptInPackagesParallel() {

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -110,10 +110,10 @@ class RunCommand extends Command {
 
   runScriptInPackagesBatched() {
     const runner = this.options.stream
-      ? this.runScriptInPackageStreaming.bind(this)
-      : this.runScriptInPackageCapturing.bind(this);
+      ? pkg => this.runScriptInPackageStreaming(pkg)
+      : pkg => this.runScriptInPackageCapturing(pkg);
 
-    pMapSeries(this.batchedPackages, batch =>
+    return pMapSeries(this.batchedPackages, batch =>
       pMap(batch, pkg => runner(pkg), {
         concurrency: this.concurrency,
       })

--- a/src/commands/UpdatedCommand.js
+++ b/src/commands/UpdatedCommand.js
@@ -39,19 +39,21 @@ class UpdatedCommand extends Command {
     });
   }
 
-  initialize(callback) {
+  initialize() {
     this.updates = collectUpdates(this);
 
     const proceedWithUpdates = this.updates.length > 0;
 
     if (!proceedWithUpdates) {
       this.logger.info("No packages need updating");
+
+      process.exitCode = 1;
     }
 
-    callback(null, proceedWithUpdates, 1);
+    return proceedWithUpdates;
   }
 
-  execute(callback) {
+  execute() {
     const updatedPackages = this.updates.map(({ pkg }) => ({
       name: pkg.name,
       version: pkg.version,
@@ -65,7 +67,5 @@ class UpdatedCommand extends Command {
           .join("\n");
 
     output(formattedUpdates);
-
-    callback(null, true);
   }
 }

--- a/src/utils/npm-publish.js
+++ b/src/utils/npm-publish.js
@@ -8,7 +8,7 @@ const getExecOpts = require("./get-npm-exec-opts");
 
 module.exports = npmPublish;
 
-function npmPublish(tag, pkg, { npmClient, registry }, callback) {
+function npmPublish(tag, pkg, { npmClient, registry }) {
   const directory = pkg.location;
 
   log.silly("npmPublish", tag, path.basename(directory));
@@ -22,5 +22,5 @@ function npmPublish(tag, pkg, { npmClient, registry }, callback) {
     args.push("--new-version", pkg.version);
   }
 
-  return ChildProcessUtilities.exec(npmClient, args, opts, callback);
+  return ChildProcessUtilities.exec(npmClient, args, opts);
 }

--- a/src/utils/npm-run-script.js
+++ b/src/utils/npm-run-script.js
@@ -9,20 +9,19 @@ const getOpts = require("./get-npm-exec-opts");
 module.exports = runScript;
 module.exports.stream = stream;
 
-function runScript(script, { args, npmClient, pkg }, callback) {
+function runScript(script, { args, npmClient, pkg }) {
   log.silly("npmRunScript", script, args, path.basename(pkg.location));
 
-  return ChildProcessUtilities.exec(npmClient, ["run", script, ...args], getOpts(pkg.location), callback);
+  return ChildProcessUtilities.exec(npmClient, ["run", script, ...args], getOpts(pkg.location));
 }
 
-function stream(script, { args, npmClient, pkg }, callback) {
+function stream(script, { args, npmClient, pkg }) {
   log.silly("npmRunScript.stream", [script, args, pkg.name]);
 
   return ChildProcessUtilities.spawnStreaming(
     npmClient,
     ["run", script, ...args],
     getOpts(pkg.location),
-    pkg.name,
-    callback
+    pkg.name
   );
 }

--- a/src/utils/output.js
+++ b/src/utils/output.js
@@ -5,6 +5,7 @@ const log = require("npmlog");
 
 module.exports = output;
 
+// istanbul ignore next
 function output(...args) {
   log.clearProgress();
   console.log(...args);

--- a/src/utils/run-parallel-batches.js
+++ b/src/utils/run-parallel-batches.js
@@ -1,14 +1,10 @@
 "use strict";
 
-const async = require("async");
+const pMap = require("p-map");
+const pMapSeries = require("p-map-series");
 
 module.exports = runParallelBatches;
 
-function runParallelBatches(batches, makeTask, concurrency, callback) {
-  async.series(
-    batches.map(batch => cb => {
-      async.parallelLimit(batch.map(makeTask), concurrency, cb);
-    }),
-    callback
-  );
+function runParallelBatches(batches, concurrency, mapper) {
+  return pMapSeries(batches, batch => pMap(batch, mapper, { concurrency }));
 }

--- a/src/utils/symlink-dependencies.js
+++ b/src/utils/symlink-dependencies.js
@@ -19,7 +19,7 @@ module.exports = symlinkDependencies;
  * @param {Array.<Package>} packages
  * @param {Object} packageGraph
  * @param {Object} logger
- * @param {Function} callback
+ * @returns {Promise}
  */
 function symlinkDependencies(packages, packageGraph, logger) {
   const tracker = logger.newItem("symlink packages");
@@ -37,14 +37,14 @@ function symlinkDependencies(packages, packageGraph, logger) {
       const currentName = currentNode.name;
       const currentNodeModules = currentNode.pkg.nodeModulesLocation;
 
-      return pMap(currentNode.localDependencies, resolved => {
+      return pMap(currentNode.localDependencies, ([dependencyName, resolved]) => {
         if (resolved.type === "directory") {
           // a local file: specifier is already a symlink
           return;
         }
 
         // get PackageGraphNode of dependency
-        const dependencyName = resolved.name;
+        // const dependencyName = resolved.name;
         const dependencyNode = packageGraph.get(dependencyName);
         const targetDirectory = path.join(currentNodeModules, dependencyName);
 

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -42,11 +42,15 @@ const ranScriptsInDirectories = testDir =>
   }, {});
 
 const symlinkedDirectories = testDir =>
-  createSymlink.mock.calls.map(([src, dest, type]) => ({
-    _src: normalizeRelativeDir(testDir, src),
-    dest: normalizeRelativeDir(testDir, dest),
-    type,
-  }));
+  createSymlink.mock.calls
+    .slice()
+    // ensure sort is always consistent, despite promise variability
+    .sort((a, b) => (b[0] === a[0] ? b[1] < a[1] : b[0] < a[0]))
+    .map(([src, dest, type]) => ({
+      _src: normalizeRelativeDir(testDir, src),
+      dest: normalizeRelativeDir(testDir, dest),
+      type,
+    }));
 
 describe("BootstrapCommand", () => {
   // we stub npmInstall in most tests because

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -14,7 +14,6 @@ const npmRunScript = require("../src/utils/npm-run-script");
 const createSymlink = require("../src/utils/create-symlink");
 
 // helpers
-const callsBack = require("./helpers/callsBack");
 const initFixture = require("./helpers/initFixture");
 const normalizeRelativeDir = require("./helpers/normalizeRelativeDir");
 
@@ -53,14 +52,14 @@ describe("BootstrapCommand", () => {
   // we stub npmInstall in most tests because
   // we already have enough tests of npmInstall
   npmInstall.mockResolvedValue();
-  npmInstall.dependencies.mockImplementation(callsBack());
+  npmInstall.dependencies.mockResolvedValue();
 
   // stub runScriptInDir() because it is a huge source
   // of slowness when running tests for no good reason
-  npmRunScript.mockImplementation(callsBack());
+  npmRunScript.mockResolvedValue();
 
   // the underlying implementation of symlinkBinary and symlinkDependencies
-  createSymlink.mockImplementation(callsBack());
+  createSymlink.mockResolvedValue();
 
   describe("lifecycle scripts", () => {
     it("should run preinstall, postinstall and prepublish scripts", async () => {
@@ -86,7 +85,7 @@ describe("BootstrapCommand", () => {
     const fsRimraf = FileSystemUtilities.rimraf;
 
     beforeEach(() => {
-      FileSystemUtilities.rimraf = jest.fn(callsBack());
+      FileSystemUtilities.rimraf = jest.fn(() => Promise.resolve());
     });
 
     afterEach(() => {
@@ -114,8 +113,7 @@ describe("BootstrapCommand", () => {
           npmClientArgs: undefined,
           mutex: undefined,
           // npmGlobalStyle is not included at all
-        },
-        expect.any(Function)
+        }
       );
 
       // foo@0.1.2 differs from the more common foo@^1.0.0
@@ -124,8 +122,7 @@ describe("BootstrapCommand", () => {
         ["foo@0.1.12"],
         expect.objectContaining({
           npmGlobalStyle: true,
-        }),
-        expect.any(Function)
+        })
       );
     });
 
@@ -192,8 +189,7 @@ describe("BootstrapCommand", () => {
         expect.arrayContaining(["foo@^1.0.0"]),
         expect.objectContaining({
           npmGlobalStyle: false,
-        }),
-        expect.any(Function)
+        })
       );
     });
   });
@@ -352,8 +348,7 @@ describe("BootstrapCommand", () => {
           registry: "https://my-secure-registry/npm",
           npmClient: "npm",
           npmGlobalStyle: false,
-        }),
-        expect.any(Function)
+        })
       );
     });
   });
@@ -446,9 +441,10 @@ describe("BootstrapCommand", () => {
   it("succeeds in repositories with zero packages", async () => {
     const testDir = await initFixture("BootstrapCommand/zero-pkgs");
 
-    const { exitCode } = await lernaBootstrap(testDir)();
+    const result = await lernaBootstrap(testDir)();
 
-    expect(exitCode).toBe(0);
+    // cheesy workaround for jest's expectation of assertions
+    expect(result).toBeDefined();
   });
 
   it("does not require an initialized git repo", async () => {
@@ -456,8 +452,9 @@ describe("BootstrapCommand", () => {
 
     fs.remove(path.join(testDir, ".git"));
 
-    const { exitCode } = await lernaBootstrap(testDir)();
+    const result = await lernaBootstrap(testDir)();
 
-    expect(exitCode).toBe(0);
+    // cheesy workaround for jest's expectation of assertions
+    expect(result).toBeDefined();
   });
 });

--- a/test/ChildProcessUtilities.js
+++ b/test/ChildProcessUtilities.js
@@ -15,61 +15,19 @@ describe("ChildProcessUtilities", () => {
   });
 
   describe(".exec()", () => {
-    afterEach(done => {
-      if (ChildProcessUtilities.getChildProcessCount()) {
-        ChildProcessUtilities.onAllExited(done);
-      } else {
-        done();
-      }
+    it("returns an execa Promise", async () => {
+      const { stderr, stdout } = await ChildProcessUtilities.exec("echo", ["foo"]);
+
+      expect(stderr).toBe("");
+      expect(stdout).toBe("foo");
     });
 
-    it("should execute a command in a child process and call the callback with the result", done => {
-      ChildProcessUtilities.exec("echo", ["foo"], null, (stderr, stdout) => {
-        try {
-          expect(stderr).toBe(null);
-          expect(stdout).toBe("foo");
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      });
-    });
-
-    it("passes an error object to callback when stdout maxBuffer exceeded", done => {
-      ChildProcessUtilities.exec("echo", ["wat"], { maxBuffer: 1 }, (stderr, stdout) => {
-        try {
-          expect(String(stderr)).toBe("Error: stdout maxBuffer exceeded");
-          expect(stdout).toBeUndefined();
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      });
-    });
-
-    it("does not require a callback, instead returning a Promise", async () => {
-      const { stdout } = await ChildProcessUtilities.exec("echo", ["Promise"]);
-      expect(stdout).toBe("Promise");
-    });
-
-    it("passes error object to callback", done => {
-      ChildProcessUtilities.exec("nowImTheModelOfAModernMajorGeneral", [], {}, err => {
-        try {
-          expect(err.message).toMatch(/\bnowImTheModelOfAModernMajorGeneral\b/);
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      });
-    });
-
-    it("passes Promise rejection through", async () => {
-      expect.assertions(1);
-
+    it("rejects on undefined command", async () => {
       try {
-        await ChildProcessUtilities.exec("theVeneratedVirginianVeteranWhoseMenAreAll", []);
+        await ChildProcessUtilities.exec("nowImTheModelOfAModernMajorGeneral");
       } catch (err) {
-        expect(err.message).toMatch(/\btheVeneratedVirginianVeteranWhoseMenAreAll\b/);
+        expect(err.message).toMatch(/\bnowImTheModelOfAModernMajorGeneral\b/);
+        expect(ChildProcessUtilities.getChildProcessCount()).toBe(0);
       }
     });
 

--- a/test/Command.js
+++ b/test/Command.js
@@ -11,7 +11,6 @@ const touch = require("touch");
 const ChildProcessUtilities = require("../src/ChildProcessUtilities");
 
 // helpers
-const callsBack = require("./helpers/callsBack");
 const initFixture = require("./helpers/initFixture");
 const loggingOutput = require("./helpers/loggingOutput");
 const updateLernaConfig = require("./helpers/updateLernaConfig");
@@ -27,7 +26,6 @@ describe("Command", () => {
     testDir = await initFixture("Command/basic");
   });
 
-  ChildProcessUtilities.onAllExited = jest.fn(callsBack());
   ChildProcessUtilities.getChildProcessCount = jest.fn(() => 0);
 
   // swallow errors when passed in argv

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -10,14 +10,13 @@ const ChildProcessUtilities = require("../src/ChildProcessUtilities");
 const GitUtilities = require("../src/GitUtilities");
 
 // helpers
-const callsBack = require("./helpers/callsBack");
 const initFixture = require("./helpers/initFixture");
 
 // file under test
 const lernaDiff = require("./helpers/command-runner")(require("../src/commands/DiffCommand"));
 
 describe("DiffCommand", () => {
-  ChildProcessUtilities.spawn.mockImplementation(callsBack(null, true));
+  ChildProcessUtilities.spawn.mockResolvedValue();
   GitUtilities.isInitialized.mockReturnValue(true);
   GitUtilities.hasCommit.mockReturnValue(true);
 
@@ -31,8 +30,7 @@ describe("DiffCommand", () => {
     expect(ChildProcessUtilities.spawn).lastCalledWith(
       "git",
       ["diff", "beefcafe", "--color=auto", "--", path.join(testDir, "packages")],
-      expect.objectContaining({ cwd: testDir }),
-      expect.any(Function)
+      expect.objectContaining({ cwd: testDir })
     );
   });
 
@@ -47,8 +45,7 @@ describe("DiffCommand", () => {
     expect(ChildProcessUtilities.spawn).lastCalledWith(
       "git",
       ["diff", "cafedead", "--color=auto", "--", path.join(testDir, "packages")],
-      expect.objectContaining({ cwd: testDir }),
-      expect.any(Function)
+      expect.objectContaining({ cwd: testDir })
     );
   });
 
@@ -62,8 +59,7 @@ describe("DiffCommand", () => {
     expect(ChildProcessUtilities.spawn).lastCalledWith(
       "git",
       ["diff", "deadbeef", "--color=auto", "--", path.join(testDir, "packages/package-1")],
-      expect.objectContaining({ cwd: testDir }),
-      expect.any(Function)
+      expect.objectContaining({ cwd: testDir })
     );
   });
 
@@ -73,7 +69,6 @@ describe("DiffCommand", () => {
     try {
       await lernaDiff(testDir)("missing");
     } catch (err) {
-      expect(err.exitCode).toBe(1);
       expect(err.message).toBe("Cannot diff, the package 'missing' does not exist.");
     }
   });
@@ -86,7 +81,6 @@ describe("DiffCommand", () => {
     try {
       await lernaDiff(testDir)("package-1");
     } catch (err) {
-      expect(err.exitCode).toBe(1);
       expect(err.message).toBe("Cannot diff, there are no commits in this repository yet.");
     }
   });
@@ -97,12 +91,11 @@ describe("DiffCommand", () => {
     const nonZero = new Error("An actual non-zero, not git diff pager SIGPIPE");
     nonZero.code = 1;
 
-    ChildProcessUtilities.spawn.mockImplementationOnce(callsBack(nonZero));
+    ChildProcessUtilities.spawn.mockRejectedValueOnce(nonZero);
 
     try {
       await lernaDiff(testDir)("package-1");
     } catch (err) {
-      expect(err.exitCode).toBe(1);
       expect(err.message).toBe("An actual non-zero, not git diff pager SIGPIPE");
     }
   });

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -45,7 +45,7 @@ describe("ExecCommand", () => {
       }
     });
 
-    it("passes execution error to callback", async () => {
+    it("rejects with execution error", async () => {
       expect.assertions(1);
 
       const testDir = await initFixture("ExecCommand/basic");

--- a/test/ExecCommand.js
+++ b/test/ExecCommand.js
@@ -10,7 +10,6 @@ const ChildProcessUtilities = require("../src/ChildProcessUtilities");
 const collectUpdates = require("../src/utils/collect-updates");
 
 // helpers
-const callsBack = require("./helpers/callsBack");
 const initFixture = require("./helpers/initFixture");
 const loggingOutput = require("./helpers/loggingOutput");
 const normalizeRelativeDir = require("./helpers/normalizeRelativeDir");
@@ -30,8 +29,8 @@ const execInPackagesStreaming = testDir =>
   }, []);
 
 describe("ExecCommand", () => {
-  ChildProcessUtilities.spawn.mockImplementation(callsBack());
-  ChildProcessUtilities.spawnStreaming.mockImplementation(callsBack());
+  ChildProcessUtilities.spawn.mockResolvedValue();
+  ChildProcessUtilities.spawnStreaming.mockResolvedValue();
 
   describe("in a basic repo", () => {
     it("should complain if invoked without command", async () => {
@@ -55,7 +54,7 @@ describe("ExecCommand", () => {
       boom.code = 1;
       boom.cmd = "boom";
 
-      ChildProcessUtilities.spawn.mockImplementationOnce(callsBack(boom));
+      ChildProcessUtilities.spawn.mockRejectedValueOnce(boom);
 
       try {
         await lernaExec(testDir)("boom");
@@ -67,17 +66,15 @@ describe("ExecCommand", () => {
     it("should ignore execution errors with --bail=false", async () => {
       const testDir = await initFixture("ExecCommand/basic");
 
-      const { exitCode } = await lernaExec(testDir)("boom", "--no-bail");
+      await lernaExec(testDir)("boom", "--no-bail");
 
-      expect(exitCode).toBe(0);
       expect(ChildProcessUtilities.spawn).toHaveBeenCalledTimes(2);
       expect(ChildProcessUtilities.spawn).lastCalledWith(
         "boom",
         [],
         expect.objectContaining({
           reject: false,
-        }),
-        expect.any(Function)
+        })
       );
     });
 
@@ -87,19 +84,14 @@ describe("ExecCommand", () => {
       await lernaExec(testDir)("ls", "--ignore", "package-1");
 
       expect(ChildProcessUtilities.spawn).toHaveBeenCalledTimes(1);
-      expect(ChildProcessUtilities.spawn).lastCalledWith(
-        "ls",
-        [],
-        {
-          cwd: path.join(testDir, "packages/package-2"),
-          env: expect.objectContaining({
-            LERNA_PACKAGE_NAME: "package-2",
-          }),
-          reject: true,
-          shell: true,
-        },
-        expect.any(Function)
-      );
+      expect(ChildProcessUtilities.spawn).lastCalledWith("ls", [], {
+        cwd: path.join(testDir, "packages/package-2"),
+        env: expect.objectContaining({
+          LERNA_PACKAGE_NAME: "package-2",
+        }),
+        reject: true,
+        shell: true,
+      });
     });
 
     it("should filter packages that are not updated with --since", async () => {
@@ -117,19 +109,14 @@ describe("ExecCommand", () => {
       await lernaExec(testDir)("ls", "--since");
 
       expect(ChildProcessUtilities.spawn).toHaveBeenCalledTimes(1);
-      expect(ChildProcessUtilities.spawn).lastCalledWith(
-        "ls",
-        [],
-        {
-          cwd: path.join(testDir, "packages/package-2"),
-          env: expect.objectContaining({
-            LERNA_PACKAGE_NAME: "package-2",
-          }),
-          reject: true,
-          shell: true,
-        },
-        expect.any(Function)
-      );
+      expect(ChildProcessUtilities.spawn).lastCalledWith("ls", [], {
+        cwd: path.join(testDir, "packages/package-2"),
+        env: expect.objectContaining({
+          LERNA_PACKAGE_NAME: "package-2",
+        }),
+        reject: true,
+        shell: true,
+      });
     });
 
     it("should run a command", async () => {
@@ -147,12 +134,7 @@ describe("ExecCommand", () => {
       await lernaExec(testDir)("ls", "--", "-la");
 
       expect(ChildProcessUtilities.spawn).toHaveBeenCalledTimes(2);
-      expect(ChildProcessUtilities.spawn).lastCalledWith(
-        "ls",
-        ["-la"],
-        expect.any(Object),
-        expect.any(Function)
-      );
+      expect(ChildProcessUtilities.spawn).lastCalledWith("ls", ["-la"], expect.any(Object));
     });
 
     it("runs a command for a given scope", async () => {
@@ -173,7 +155,7 @@ describe("ExecCommand", () => {
 
     it("executes a command in all packages with --parallel", async () => {
       const testDir = await initFixture("ExecCommand/basic");
-      ChildProcessUtilities.spawnStreaming = jest.fn(callsBack());
+      ChildProcessUtilities.spawnStreaming = jest.fn(() => Promise.resolve());
 
       await lernaExec(testDir)("--parallel", "ls");
 
@@ -182,7 +164,7 @@ describe("ExecCommand", () => {
 
     it("executes a command in all packages with --stream", async () => {
       const testDir = await initFixture("ExecCommand/basic");
-      ChildProcessUtilities.spawnStreaming = jest.fn(callsBack());
+      ChildProcessUtilities.spawnStreaming = jest.fn(() => Promise.resolve());
 
       await lernaExec(testDir)("--stream", "ls");
 

--- a/test/FileSystemUtilities.js
+++ b/test/FileSystemUtilities.js
@@ -11,23 +11,20 @@ const fs = require("fs-extra");
 const pathExists = require("path-exists");
 const ChildProcessUtilities = require("../src/ChildProcessUtilities");
 
-// helpers
-const callsBack = require("./helpers/callsBack");
-
 // file under test
 const FileSystemUtilities = require("../src/FileSystemUtilities");
 
 describe("FileSystemUtilities", () => {
   describe(".mkdirp()", () => {
-    it("calls fs.ensureDir", done => {
+    it("calls fs.ensureDir", async () => {
       expect.assertions(1);
       const dirPath = "mkdirp/test";
 
-      fs.ensureDir.mockImplementationOnce(callsBack());
+      fs.ensureDir.mockResolvedValueOnce();
 
-      FileSystemUtilities.mkdirp(dirPath, done);
+      await FileSystemUtilities.mkdirp(dirPath);
 
-      expect(fs.ensureDir).lastCalledWith(dirPath, done);
+      expect(fs.ensureDir).lastCalledWith(dirPath);
     });
   });
 
@@ -63,14 +60,14 @@ describe("FileSystemUtilities", () => {
   });
 
   describe(".writeFile()", () => {
-    it("calls fs.writeFile", done => {
+    it("calls fs.writeFile", async () => {
       expect.assertions(1);
       const filePath = "writeFile-test";
 
-      fs.writeFile.mockImplementationOnce(callsBack());
+      fs.writeFile.mockResolvedValueOnce();
 
-      FileSystemUtilities.writeFile(filePath, "contents", done);
-      expect(fs.writeFile).lastCalledWith(filePath, "contents\n", done);
+      await FileSystemUtilities.writeFile(filePath, "contents");
+      expect(fs.writeFile).lastCalledWith(filePath, "contents\n");
     });
   });
 
@@ -95,48 +92,41 @@ describe("FileSystemUtilities", () => {
   });
 
   describe(".rimraf()", () => {
-    it("calls rimraf CLI with arguments", done => {
+    it("calls rimraf CLI with arguments", async () => {
       expect.assertions(1);
       const dirPath = "rimraf/test";
 
       pathExists.mockResolvedValueOnce(true);
-      ChildProcessUtilities.spawn.mockImplementationOnce(callsBack());
+      ChildProcessUtilities.spawn.mockResolvedValueOnce();
 
-      FileSystemUtilities.rimraf(dirPath, () => {
-        // a Promise gating a callback means we can't do the shorthand done()
-        try {
-          expect(ChildProcessUtilities.spawn).lastCalledWith(
-            process.execPath,
-            [require.resolve("rimraf/bin"), "--no-glob", path.normalize(`${dirPath}/`)],
-            {},
-            expect.any(Function)
-          );
-          done();
-        } catch (err) {
-          done.fail(err);
-        }
-      });
+      await FileSystemUtilities.rimraf(dirPath);
+
+      expect(ChildProcessUtilities.spawn).lastCalledWith(process.execPath, [
+        require.resolve("rimraf/bin"),
+        "--no-glob",
+        path.normalize(`${dirPath}/`),
+      ]);
     });
 
-    it("does not attempt to delete a non-existent directory", done => {
+    it("does not attempt to delete a non-existent directory", async () => {
       expect.assertions(1);
       pathExists.mockResolvedValueOnce(false);
 
-      FileSystemUtilities.rimraf("rimraf/non-existent", done);
+      await FileSystemUtilities.rimraf("rimraf/non-existent");
       expect(ChildProcessUtilities.spawn).not.toBeCalled();
     });
   });
 
   describe(".rename()", () => {
-    it("calls fs.rename", done => {
+    it("calls fs.rename", async () => {
       expect.assertions(1);
       const srcPath = "rename-src";
       const dstPath = "rename-dst";
 
-      fs.rename.mockImplementationOnce(callsBack());
+      fs.rename.mockResolvedValueOnce();
 
-      FileSystemUtilities.rename(srcPath, dstPath, done);
-      expect(fs.rename).lastCalledWith(srcPath, dstPath, done);
+      await FileSystemUtilities.rename(srcPath, dstPath);
+      expect(fs.rename).lastCalledWith(srcPath, dstPath);
     });
   });
 

--- a/test/ImportCommand.js
+++ b/test/ImportCommand.js
@@ -11,7 +11,6 @@ const pathExists = require("path-exists");
 const PromptUtilities = require("../src/PromptUtilities");
 
 // helpers
-const callsBack = require("./helpers/callsBack");
 const initFixture = require("./helpers/initFixture");
 const updateLernaConfig = require("./helpers/updateLernaConfig");
 
@@ -22,7 +21,7 @@ const lernaImport = require("./helpers/command-runner")(require("../src/commands
 const lastCommitInDir = cwd => execa.stdout("git", ["log", "-1", "--format=%s"], { cwd });
 
 describe("ImportCommand", () => {
-  PromptUtilities.confirm.mockImplementation(callsBack(true));
+  PromptUtilities.confirm.mockResolvedValue(true);
 
   describe("import", () => {
     const initBasicFixtures = () =>
@@ -103,16 +102,15 @@ describe("ImportCommand", () => {
 
       await execa("git", ["commit", "--allow-empty", "-m", "Empty commit"], cwdExternalDir);
 
-      const { exitCode } = await lernaImport(testDir)(externalDir, "--flatten");
+      await lernaImport(testDir)(externalDir, "--flatten");
 
       expect(await lastCommitInDir(testDir)).toBe("Non-empty commit");
-      expect(exitCode).toBe(0);
     });
 
     it("exits early when confirmation is rejected", async () => {
       const [testDir, externalDir] = await initBasicFixtures();
 
-      PromptUtilities.confirm.mockImplementationOnce(callsBack(false));
+      PromptUtilities.confirm.mockResolvedValueOnce(false);
 
       await lernaImport(testDir)(externalDir);
 
@@ -121,9 +119,8 @@ describe("ImportCommand", () => {
 
     it("allows skipping confirmation prompt", async () => {
       const [testDir, externalDir] = await initBasicFixtures();
-      const { exitCode } = await lernaImport(testDir)(externalDir, "--yes");
+      await lernaImport(testDir)(externalDir, "--yes");
 
-      expect(exitCode).toBe(0);
       expect(PromptUtilities.confirm).not.toBeCalled();
     });
 
@@ -144,7 +141,6 @@ describe("ImportCommand", () => {
       try {
         await lernaImport(testDir)(missing);
       } catch (err) {
-        expect(err.exitCode).toBe(1);
         expect(err.message).toBe(`No repository found at "${missing}"`);
       }
     });
@@ -157,7 +153,6 @@ describe("ImportCommand", () => {
       try {
         await lernaImport(testDir)(externalDir);
       } catch (err) {
-        expect(err.exitCode).toBe(1);
         expect(err.message).toMatch("package.json");
         expect(err.code).toBe("MODULE_NOT_FOUND");
       }
@@ -172,7 +167,6 @@ describe("ImportCommand", () => {
       try {
         await lernaImport(testDir)(externalDir);
       } catch (err) {
-        expect(err.exitCode).toBe(1);
         expect(err.message).toBe(`No package name specified in "${packageJson}"`);
       }
     });
@@ -187,7 +181,6 @@ describe("ImportCommand", () => {
       try {
         await lernaImport(testDir)(externalDir);
       } catch (err) {
-        expect(err.exitCode).toBe(1);
         expect(err.message).toBe(`Target directory already exists "${relativePath}"`);
       }
     });
@@ -206,7 +199,6 @@ describe("ImportCommand", () => {
       try {
         await lernaImport(testDir)(externalDir);
       } catch (err) {
-        expect(err.exitCode).toBe(1);
         expect(err.message).toBe(`Target directory already exists "${relativePath}"`);
       }
     });
@@ -221,7 +213,6 @@ describe("ImportCommand", () => {
       try {
         await lernaImport(testDir)(externalDir);
       } catch (err) {
-        expect(err.exitCode).toBe(1);
         expect(err.message).toBe("Local repository has un-committed changes");
       }
     });

--- a/test/LinkCommand.js
+++ b/test/LinkCommand.js
@@ -14,11 +14,15 @@ const lernaLink = require("./helpers/command-runner")(require("../src/commands/L
 
 // assertion helpers
 const symlinkedDirectories = testDir =>
-  createSymlink.mock.calls.map(([src, dest, type]) => ({
-    _src: normalizeRelativeDir(testDir, src),
-    dest: normalizeRelativeDir(testDir, dest),
-    type,
-  }));
+  createSymlink.mock.calls
+    .slice()
+    // ensure sort is always consistent, despite promise variability
+    .sort((a, b) => (b[0] === a[0] ? b[1] < a[1] : b[0] < a[0]))
+    .map(([src, dest, type]) => ({
+      _src: normalizeRelativeDir(testDir, src),
+      dest: normalizeRelativeDir(testDir, dest),
+      type,
+    }));
 
 describe("LinkCommand", () => {
   // the underlying implementation of symlinkDependencies

--- a/test/LinkCommand.js
+++ b/test/LinkCommand.js
@@ -6,7 +6,6 @@ jest.mock("../src/utils/create-symlink");
 const createSymlink = require("../src/utils/create-symlink");
 
 // helpers
-const callsBack = require("./helpers/callsBack");
 const initFixture = require("./helpers/initFixture");
 const normalizeRelativeDir = require("./helpers/normalizeRelativeDir");
 
@@ -23,7 +22,7 @@ const symlinkedDirectories = testDir =>
 
 describe("LinkCommand", () => {
   // the underlying implementation of symlinkDependencies
-  createSymlink.mockImplementation(callsBack());
+  createSymlink.mockResolvedValue();
 
   describe("with local package dependencies", () => {
     it("should symlink all packages", async () => {

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -155,8 +155,8 @@ describe("PublishCommand", () => {
       const testDir = await initFixture("PublishCommand/normal");
       try {
         await lernaPublish(testDir)("--independent");
-      } catch (error) {
-        expect(error.exitCode).toBe(1);
+      } catch (err) {
+        expect(err.message).toMatch("independent");
       }
     });
   });
@@ -924,24 +924,27 @@ describe("PublishCommand", () => {
         GitUtilities.getCurrentBranch.mockReturnValueOnce("exact-match");
 
         const testDir = await initFixture("PublishCommand/normal");
-        const { exitCode } = await lernaPublish(testDir)("--allow-branch", "exact-match");
-        expect(exitCode).toBe(0);
+        await lernaPublish(testDir)("--allow-branch", "exact-match");
+
+        expect(publishedTagInDirectories(testDir)).toHaveLength(4);
       });
 
       it("should accept a branch that matches by wildcard", async () => {
         GitUtilities.getCurrentBranch.mockReturnValueOnce("feature/awesome");
 
         const testDir = await initFixture("PublishCommand/normal");
-        const { exitCode } = await lernaPublish(testDir)("--allow-branch", "feature/*");
-        expect(exitCode).toBe(0);
+        await lernaPublish(testDir)("--allow-branch", "feature/*");
+
+        expect(publishedTagInDirectories(testDir)).toHaveLength(4);
       });
 
       it("should accept a branch that matches one of the items passed", async () => {
         GitUtilities.getCurrentBranch.mockReturnValueOnce("feature/awesome");
 
         const testDir = await initFixture("PublishCommand/normal");
-        const { exitCode } = await lernaPublish(testDir)("--allow-branch", "master", "feature/*");
-        expect(exitCode).toBe(0);
+        await lernaPublish(testDir)("--allow-branch", "master", "feature/*");
+
+        expect(publishedTagInDirectories(testDir)).toHaveLength(4);
       });
     });
 
@@ -961,16 +964,18 @@ describe("PublishCommand", () => {
         GitUtilities.getCurrentBranch.mockReturnValueOnce("lerna");
 
         const testDir = await initFixture("PublishCommand/allow-branch-lerna");
-        const { exitCode } = await lernaPublish(testDir)();
-        expect(exitCode).toBe(0);
+        await lernaPublish(testDir)();
+
+        expect(publishedTagInDirectories(testDir)).toHaveLength(1);
       });
 
       it("should prioritize cli over defaults", async () => {
         GitUtilities.getCurrentBranch.mockReturnValueOnce("cli-override");
 
         const testDir = await initFixture("PublishCommand/allow-branch-lerna");
-        const { exitCode } = await lernaPublish(testDir)("--allow-branch", "cli-override");
-        expect(exitCode).toBe(0);
+        await lernaPublish(testDir)("--allow-branch", "cli-override");
+
+        expect(publishedTagInDirectories(testDir)).toHaveLength(1);
       });
     });
 
@@ -979,8 +984,7 @@ describe("PublishCommand", () => {
         const testDir = await initFixture("PublishCommand/normal");
         GitUtilities.getCurrentBranch.mockReturnValueOnce("other");
 
-        const { exitCode } = await lernaPublish(testDir)("--allow-branch", "master", "--canary");
-        expect(exitCode).toBe(0);
+        await lernaPublish(testDir)("--allow-branch", "master", "--canary");
         expect(updatedPackageVersions(testDir)).toMatchSnapshot("updated packages");
       });
     });

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -10,7 +10,6 @@ const npmRunScript = require("../src/utils/npm-run-script");
 const collectUpdates = require("../src/utils/collect-updates");
 
 // helpers
-const callsBack = require("./helpers/callsBack");
 const initFixture = require("./helpers/initFixture");
 const consoleOutput = require("./helpers/consoleOutput");
 const loggingOutput = require("./helpers/loggingOutput");
@@ -37,8 +36,8 @@ const ranInPackagesStreaming = testDir =>
   }, []);
 
 describe("RunCommand", () => {
-  npmRunScript.mockImplementation(callsBack(null, "stdout"));
-  npmRunScript.stream.mockImplementation(callsBack());
+  npmRunScript.mockResolvedValue({ stdout: "stdout" });
+  npmRunScript.stream.mockResolvedValue();
 
   describe("in a basic repo", () => {
     it("runs a script in packages", async () => {

--- a/test/UpdatedCommand.js
+++ b/test/UpdatedCommand.js
@@ -105,9 +105,12 @@ describe("UpdatedCommand", () => {
       const testDir = await initFixture("UpdatedCommand/basic");
 
       await gitTag(testDir);
+      await lernaUpdated(testDir)();
 
-      const { exitCode } = await lernaUpdated(testDir)();
-      expect(exitCode).toBe(1);
+      expect(process.exitCode).toBe(1);
+
+      // reset exit code
+      process.exitCode = undefined;
     });
   });
 
@@ -165,9 +168,12 @@ describe("UpdatedCommand", () => {
       const testDir = await initFixture("UpdatedCommand/circular");
 
       await gitTag(testDir);
+      await lernaUpdated(testDir)();
 
-      const { exitCode } = await lernaUpdated(testDir)();
-      expect(exitCode).toBe(1);
+      expect(process.exitCode).toBe(1);
+
+      // reset exit code
+      process.exitCode = undefined;
     });
   });
 

--- a/test/__snapshots__/BootstrapCommand.js.snap
+++ b/test/__snapshots__/BootstrapCommand.js.snap
@@ -297,11 +297,6 @@ Object {
 exports[`BootstrapCommand with multiple package locations hoists appropriately 2`] = `
 Array [
   Object {
-    "_src": "packages/package-1",
-    "dest": "packages/package-2/node_modules/@test/package-1",
-    "type": "junction",
-  },
-  Object {
     "_src": "package-3",
     "dest": "packages/package-4/node_modules/package-3",
     "type": "junction",
@@ -317,6 +312,16 @@ Array [
     "type": "exec",
   },
   Object {
+    "_src": "packages/package-1",
+    "dest": "package-3/node_modules/@test/package-1",
+    "type": "junction",
+  },
+  Object {
+    "_src": "packages/package-1",
+    "dest": "packages/package-2/node_modules/@test/package-1",
+    "type": "junction",
+  },
+  Object {
     "_src": "packages/package-2",
     "dest": "package-3/node_modules/package-2",
     "type": "junction",
@@ -325,11 +330,6 @@ Array [
     "_src": "packages/package-2/cli.js",
     "dest": "package-3/node_modules/.bin/package-2",
     "type": "exec",
-  },
-  Object {
-    "_src": "packages/package-1",
-    "dest": "package-3/node_modules/@test/package-1",
-    "type": "junction",
   },
 ]
 `;
@@ -362,11 +362,6 @@ Object {
 exports[`BootstrapCommand with multiple package locations should bootstrap packages 3`] = `
 Array [
   Object {
-    "_src": "packages/package-1",
-    "dest": "packages/package-2/node_modules/@test/package-1",
-    "type": "junction",
-  },
-  Object {
     "_src": "package-3",
     "dest": "packages/package-4/node_modules/package-3",
     "type": "junction",
@@ -382,6 +377,16 @@ Array [
     "type": "exec",
   },
   Object {
+    "_src": "packages/package-1",
+    "dest": "package-3/node_modules/@test/package-1",
+    "type": "junction",
+  },
+  Object {
+    "_src": "packages/package-1",
+    "dest": "packages/package-2/node_modules/@test/package-1",
+    "type": "junction",
+  },
+  Object {
     "_src": "packages/package-2",
     "dest": "package-3/node_modules/package-2",
     "type": "junction",
@@ -390,11 +395,6 @@ Array [
     "_src": "packages/package-2/cli.js",
     "dest": "package-3/node_modules/.bin/package-2",
     "type": "exec",
-  },
-  Object {
-    "_src": "packages/package-1",
-    "dest": "package-3/node_modules/@test/package-1",
-    "type": "junction",
   },
 ]
 `;

--- a/test/__snapshots__/BootstrapCommand.js.snap
+++ b/test/__snapshots__/BootstrapCommand.js.snap
@@ -317,11 +317,6 @@ Array [
     "type": "exec",
   },
   Object {
-    "_src": "packages/package-1",
-    "dest": "package-3/node_modules/@test/package-1",
-    "type": "junction",
-  },
-  Object {
     "_src": "packages/package-2",
     "dest": "package-3/node_modules/package-2",
     "type": "junction",
@@ -330,6 +325,11 @@ Array [
     "_src": "packages/package-2/cli.js",
     "dest": "package-3/node_modules/.bin/package-2",
     "type": "exec",
+  },
+  Object {
+    "_src": "packages/package-1",
+    "dest": "package-3/node_modules/@test/package-1",
+    "type": "junction",
   },
 ]
 `;
@@ -382,11 +382,6 @@ Array [
     "type": "exec",
   },
   Object {
-    "_src": "packages/package-1",
-    "dest": "package-3/node_modules/@test/package-1",
-    "type": "junction",
-  },
-  Object {
     "_src": "packages/package-2",
     "dest": "package-3/node_modules/package-2",
     "type": "junction",
@@ -395,6 +390,11 @@ Array [
     "_src": "packages/package-2/cli.js",
     "dest": "package-3/node_modules/.bin/package-2",
     "type": "exec",
+  },
+  Object {
+    "_src": "packages/package-1",
+    "dest": "package-3/node_modules/@test/package-1",
+    "type": "junction",
   },
 ]
 `;

--- a/test/__snapshots__/LinkCommand.js.snap
+++ b/test/__snapshots__/LinkCommand.js.snap
@@ -23,11 +23,6 @@ Array [
     "type": "exec",
   },
   Object {
-    "_src": "packages/package-1",
-    "dest": "packages/package-4/node_modules/@test/package-1",
-    "type": "junction",
-  },
-  Object {
     "_src": "packages/package-3",
     "dest": "packages/package-4/node_modules/package-3",
     "type": "junction",
@@ -41,6 +36,11 @@ Array [
     "_src": "packages/package-3/cli2.js",
     "dest": "packages/package-4/node_modules/.bin/package3cli2",
     "type": "exec",
+  },
+  Object {
+    "_src": "packages/package-1",
+    "dest": "packages/package-4/node_modules/@test/package-1",
+    "type": "junction",
   },
 ]
 `;

--- a/test/__snapshots__/LinkCommand.js.snap
+++ b/test/__snapshots__/LinkCommand.js.snap
@@ -13,6 +13,11 @@ Array [
     "type": "junction",
   },
   Object {
+    "_src": "packages/package-1",
+    "dest": "packages/package-4/node_modules/@test/package-1",
+    "type": "junction",
+  },
+  Object {
     "_src": "packages/package-2",
     "dest": "packages/package-3/node_modules/@test/package-2",
     "type": "junction",
@@ -36,11 +41,6 @@ Array [
     "_src": "packages/package-3/cli2.js",
     "dest": "packages/package-4/node_modules/.bin/package3cli2",
     "type": "exec",
-  },
-  Object {
-    "_src": "packages/package-1",
-    "dest": "packages/package-4/node_modules/@test/package-1",
-    "type": "junction",
   },
 ]
 `;

--- a/test/helpers/command-runner.js
+++ b/test/helpers/command-runner.js
@@ -34,8 +34,8 @@ function commandRunner(commandModule) {
         const context = {
           cwd,
           onResolved: result => {
-            Object.assign(result, yargsMeta);
-            resolve(result);
+            // success does not resolve anything, currently
+            resolve(Object.assign({}, result, yargsMeta));
           },
           onRejected: result => {
             Object.assign(result, yargsMeta);

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -57,7 +57,8 @@ describe("lerna exec", () => {
       "exec",
       EXEC_TEST_COMMAND,
       "--parallel",
-      // no --
+      // -- is required to pass args to command
+      "--",
       "-C",
     ];
 
@@ -73,13 +74,7 @@ describe("lerna exec", () => {
 
   test("--parallel <cmd>", async () => {
     const cwd = await initFixture("ExecCommand/basic");
-    const args = [
-      "exec",
-      "--parallel",
-      EXEC_TEST_COMMAND,
-      // no --
-      "-C",
-    ];
+    const args = ["exec", "--parallel", EXEC_TEST_COMMAND];
 
     const { stdout, stderr } = await cliRunner(cwd, env)(...args);
     expect(stderr).toMatch(EXEC_TEST_COMMAND);
@@ -93,7 +88,14 @@ describe("lerna exec", () => {
 
   test("<cmd> --stream", async () => {
     const cwd = await initFixture("ExecCommand/basic");
-    const args = ["exec", EXEC_TEST_COMMAND, "--stream", "-C"];
+    const args = [
+      "exec",
+      EXEC_TEST_COMMAND,
+      "--stream",
+      // -- is required to pass args to command
+      "--",
+      "-C",
+    ];
 
     const { stdout } = await cliRunner(cwd, env)(...args);
 
@@ -106,7 +108,7 @@ describe("lerna exec", () => {
 
   test("--stream <cmd>", async () => {
     const cwd = await initFixture("ExecCommand/basic");
-    const args = ["exec", "--stream", EXEC_TEST_COMMAND, "-C"];
+    const args = ["exec", "--stream", EXEC_TEST_COMMAND];
 
     const { stdout } = await cliRunner(cwd, env)(...args);
 

--- a/test/utils-npm-install.test.js
+++ b/test/utils-npm-install.test.js
@@ -11,15 +11,12 @@ const writePkg = require("write-pkg");
 const ChildProcessUtilities = require("../src/ChildProcessUtilities");
 const FileSystemUtilities = require("../src/FileSystemUtilities");
 
-// helpers
-const callsBack = require("./helpers/callsBack");
-
 // file under test
 const npmInstall = require("../src/utils/npm-install");
 
 describe("npm-install", () => {
   ChildProcessUtilities.exec.mockResolvedValue();
-  FileSystemUtilities.rename.mockImplementation(callsBack());
+  FileSystemUtilities.rename.mockResolvedValue();
   writePkg.mockResolvedValue();
 
   describe("npmInstall()", () => {
@@ -65,46 +62,35 @@ describe("npm-install", () => {
   });
 
   describe("npmInstall.dependencies()", () => {
-    it("installs dependencies in targeted directory", done => {
+    it("installs dependencies in targeted directory", async () => {
       const directory = path.normalize("/test/npm-install-deps");
       const dependencies = ["@scoped/caret@^2.0.0", "@scoped/exact@2.0.0", "caret@^1.0.0", "exact@1.0.0"];
       const config = {};
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        if (err) {
-          return done.fail(err);
-        }
+      await npmInstall.dependencies(directory, dependencies, config);
 
-        try {
-          expect(FileSystemUtilities.rename).lastCalledWith(
-            path.join(directory, "package.json"),
-            path.join(directory, "package.json.lerna_backup"),
-            expect.any(Function)
-          );
-          expect(FileSystemUtilities.renameSync).lastCalledWith(
-            path.join(directory, "package.json.lerna_backup"),
-            path.join(directory, "package.json")
-          );
-          expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
-            dependencies: {
-              "@scoped/caret": "^2.0.0",
-              "@scoped/exact": "2.0.0",
-              caret: "^1.0.0",
-              exact: "1.0.0",
-            },
-          });
-          expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install"], {
-            cwd: directory,
-          });
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
+      expect(FileSystemUtilities.rename).lastCalledWith(
+        path.join(directory, "package.json"),
+        path.join(directory, "package.json.lerna_backup")
+      );
+      expect(FileSystemUtilities.renameSync).lastCalledWith(
+        path.join(directory, "package.json.lerna_backup"),
+        path.join(directory, "package.json")
+      );
+      expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+        dependencies: {
+          "@scoped/caret": "^2.0.0",
+          "@scoped/exact": "2.0.0",
+          caret: "^1.0.0",
+          exact: "1.0.0",
+        },
+      });
+      expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install"], {
+        cwd: directory,
       });
     });
 
-    it("supports custom registry", done => {
+    it("supports custom registry", async () => {
       const registry = "https://custom-registry/npm-install-deps";
       const directory = path.normalize("/test/npm-install-deps");
       const dependencies = ["@scoped/tagged@next", "tagged@next"];
@@ -112,63 +98,43 @@ describe("npm-install", () => {
         registry,
       };
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        if (err) {
-          return done.fail(err);
-        }
+      await npmInstall.dependencies(directory, dependencies, config);
 
-        try {
-          expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
-            dependencies: {
-              "@scoped/tagged": "next",
-              tagged: "next",
-            },
-          });
-          expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install"], {
-            cwd: directory,
-            env: expect.objectContaining({
-              npm_config_registry: registry,
-            }),
-          });
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
+      expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+        dependencies: {
+          "@scoped/tagged": "next",
+          tagged: "next",
+        },
+      });
+      expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install"], {
+        cwd: directory,
+        env: expect.objectContaining({
+          npm_config_registry: registry,
+        }),
       });
     });
 
-    it("supports npm install --global-style", done => {
+    it("supports npm install --global-style", async () => {
       const directory = path.normalize("/test/npm-install-deps");
       const dependencies = ["@scoped/foo@latest", "foo@latest"];
       const config = {
         npmGlobalStyle: true,
       };
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        if (err) {
-          return done.fail(err);
-        }
+      await npmInstall.dependencies(directory, dependencies, config);
 
-        try {
-          expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
-            dependencies: {
-              "@scoped/foo": "latest",
-              foo: "latest",
-            },
-          });
-          expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install", "--global-style"], {
-            cwd: directory,
-          });
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
+      expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+        dependencies: {
+          "@scoped/foo": "latest",
+          foo: "latest",
+        },
+      });
+      expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install", "--global-style"], {
+        cwd: directory,
       });
     });
 
-    it("supports custom npmClient", done => {
+    it("supports custom npmClient", async () => {
       const directory = path.normalize("/test/npm-install-deps");
       const dependencies = ["@scoped/something@github:foo/bar", "something@github:foo/foo"];
       const config = {
@@ -176,64 +142,42 @@ describe("npm-install", () => {
         mutex: "network:12345",
       };
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        if (err) {
-          return done.fail(err);
-        }
+      await npmInstall.dependencies(directory, dependencies, config);
 
-        try {
-          expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
-            dependencies: {
-              "@scoped/something": "github:foo/bar",
-              something: "github:foo/foo",
-            },
-          });
-          expect(ChildProcessUtilities.exec).lastCalledWith(
-            "yarn",
-            ["install", "--mutex", "network:12345", "--non-interactive"],
-            { cwd: directory }
-          );
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
+      expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+        dependencies: {
+          "@scoped/something": "github:foo/bar",
+          something: "github:foo/foo",
+        },
       });
+      expect(ChildProcessUtilities.exec).lastCalledWith(
+        "yarn",
+        ["install", "--mutex", "network:12345", "--non-interactive"],
+        { cwd: directory }
+      );
     });
 
-    it("supports custom npmClientArgs", done => {
+    it("supports custom npmClientArgs", async () => {
       const directory = path.normalize("/test/npm-install-deps");
       const dependencies = ["@scoped/something@github:foo/bar", "something@github:foo/foo"];
       const config = {
         npmClientArgs: ["--production", "--no-optional"],
       };
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        if (err) {
-          return done.fail(err);
-        }
+      await npmInstall.dependencies(directory, dependencies, config);
 
-        try {
-          expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
-            dependencies: {
-              "@scoped/something": "github:foo/bar",
-              something: "github:foo/foo",
-            },
-          });
-          expect(ChildProcessUtilities.exec).lastCalledWith(
-            "npm",
-            ["install", "--production", "--no-optional"],
-            { cwd: directory }
-          );
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
+      expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+        dependencies: {
+          "@scoped/something": "github:foo/bar",
+          something: "github:foo/foo",
+        },
+      });
+      expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install", "--production", "--no-optional"], {
+        cwd: directory,
       });
     });
 
-    it("overrides custom npmClient when using global style", done => {
+    it("overrides custom npmClient when using global style", async () => {
       const directory = path.normalize("/test/npm-install-deps");
       const dependencies = ["@scoped/something@github:foo/bar", "something@github:foo/foo"];
       const config = {
@@ -242,48 +186,30 @@ describe("npm-install", () => {
         mutex: "network:12345",
       };
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        if (err) {
-          return done.fail(err);
-        }
+      await npmInstall.dependencies(directory, dependencies, config);
 
-        try {
-          expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
-            dependencies: {
-              "@scoped/something": "github:foo/bar",
-              something: "github:foo/foo",
-            },
-          });
-          expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install", "--global-style"], {
-            cwd: directory,
-          });
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
+      expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+        dependencies: {
+          "@scoped/something": "github:foo/bar",
+          something: "github:foo/foo",
+        },
+      });
+      expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["install", "--global-style"], {
+        cwd: directory,
       });
     });
 
-    it("finishes early when no dependencies exist", done => {
+    it("finishes early when no dependencies exist", async () => {
       const directory = path.normalize("/test/npm-install-deps");
       const dependencies = [];
       const config = {};
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        if (err) {
-          return done.fail(err);
-        }
-        try {
-          expect(ChildProcessUtilities.exec).not.toBeCalled();
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      });
+      await npmInstall.dependencies(directory, dependencies, config);
+
+      expect(ChildProcessUtilities.exec).not.toBeCalled();
     });
 
-    it("defaults temporary dependency versions to '*'", done => {
+    it("defaults temporary dependency versions to '*'", async () => {
       const directory = path.normalize("/test/npm-install-deps");
       const dependencies = [
         "noversion",
@@ -291,88 +217,66 @@ describe("npm-install", () => {
       ];
       const config = {};
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        if (err) {
-          return done.fail(err);
-        }
+      await npmInstall.dependencies(directory, dependencies, config);
 
-        try {
-          expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
-            dependencies: {
-              "@scoped/noversion": "*",
-              noversion: "*",
-            },
-          });
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
+      expect(writePkg).lastCalledWith(path.join(directory, "package.json"), {
+        dependencies: {
+          "@scoped/noversion": "*",
+          noversion: "*",
+        },
       });
     });
 
-    it("passes rename error to callback", done => {
+    it("passes rename error to callback", async () => {
       const directory = path.normalize("/test/npm-install-deps/renameError");
       const dependencies = ["I'm just here so we don't exit early"];
       const config = {};
 
-      FileSystemUtilities.rename.mockImplementationOnce(callsBack(new Error("Unable to rename file")));
+      FileSystemUtilities.rename.mockRejectedValueOnce(new Error("Unable to rename file"));
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        try {
-          expect(err.message).toBe("Unable to rename file");
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      });
+      try {
+        await npmInstall.dependencies(directory, dependencies, config);
+      } catch (err) {
+        expect(err.message).toBe("Unable to rename file");
+      }
     });
 
-    it("cleans up synchronously after writeFile error", done => {
+    it("cleans up synchronously after writeFile error", async () => {
       const directory = path.normalize("/test/npm-install-deps/writeError");
       const dependencies = ["just-here-so-we-dont-exit-early"];
       const config = {};
 
       writePkg.mockRejectedValueOnce(new Error("Unable to write file"));
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        try {
-          expect(err.message).toBe("Unable to write file");
+      try {
+        await npmInstall.dependencies(directory, dependencies, config);
+      } catch (err) {
+        expect(err.message).toBe("Unable to write file");
 
-          expect(FileSystemUtilities.renameSync).lastCalledWith(
-            path.join(directory, "package.json.lerna_backup"),
-            path.join(directory, "package.json")
-          );
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      });
+        expect(FileSystemUtilities.renameSync).lastCalledWith(
+          path.join(directory, "package.json.lerna_backup"),
+          path.join(directory, "package.json")
+        );
+      }
     });
 
-    it("cleans up synchronously after client install error", done => {
+    it("cleans up synchronously after client install error", async () => {
       const directory = path.normalize("/test/npm-install-deps/clientError");
       const dependencies = ["just-here-so-we-dont-exit-early"];
       const config = {};
 
       ChildProcessUtilities.exec.mockRejectedValueOnce(new Error("Unable to install dependency"));
 
-      npmInstall.dependencies(directory, dependencies, config, err => {
-        try {
-          expect(err.message).toBe("Unable to install dependency");
+      try {
+        await npmInstall.dependencies(directory, dependencies, config);
+      } catch (err) {
+        expect(err.message).toBe("Unable to install dependency");
 
-          expect(FileSystemUtilities.renameSync).lastCalledWith(
-            path.join(directory, "package.json.lerna_backup"),
-            path.join(directory, "package.json")
-          );
-
-          done();
-        } catch (ex) {
-          done.fail(ex);
-        }
-      });
+        expect(FileSystemUtilities.renameSync).lastCalledWith(
+          path.join(directory, "package.json.lerna_backup"),
+          path.join(directory, "package.json")
+        );
+      }
     });
   });
 });

--- a/test/utils-npm-install.test.js
+++ b/test/utils-npm-install.test.js
@@ -227,7 +227,7 @@ describe("npm-install", () => {
       });
     });
 
-    it("passes rename error to callback", async () => {
+    it("rejects with rename error", async () => {
       const directory = path.normalize("/test/npm-install-deps/renameError");
       const dependencies = ["I'm just here so we don't exit early"];
       const config = {};

--- a/test/utils-npm-publish.test.js
+++ b/test/utils-npm-publish.test.js
@@ -5,14 +5,11 @@ jest.mock("../src/ChildProcessUtilities");
 // mocked modules
 const ChildProcessUtilities = require("../src/ChildProcessUtilities");
 
-// helpers
-const callsBack = require("./helpers/callsBack");
-
 // file under test
 const npmPublish = require("../src/utils/npm-publish");
 
 describe("npm-publish", () => {
-  ChildProcessUtilities.exec.mockImplementation(callsBack());
+  ChildProcessUtilities.exec.mockResolvedValue();
 
   const pkg = {
     name: "test",
@@ -20,61 +17,45 @@ describe("npm-publish", () => {
     version: "1.10.100",
   };
 
-  it("runs npm publish in a directory with --tag support", done => {
-    npmPublish("published-tag", pkg, { npmClient: "npm" }, done);
+  it("runs npm publish in a directory with --tag support", async () => {
+    await npmPublish("published-tag", pkg, { npmClient: "npm" });
 
-    expect(ChildProcessUtilities.exec).lastCalledWith(
-      "npm",
-      ["publish", "--tag", "published-tag"],
-      {
-        cwd: pkg.location,
-      },
-      done
-    );
+    expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["publish", "--tag", "published-tag"], {
+      cwd: pkg.location,
+    });
   });
 
-  it("trims trailing whitespace in tag parameter", done => {
-    npmPublish("trailing-tag ", pkg, { npmClient: "npm" }, done);
+  it("trims trailing whitespace in tag parameter", async () => {
+    await npmPublish("trailing-tag ", pkg, { npmClient: "npm" });
 
-    expect(ChildProcessUtilities.exec).lastCalledWith(
-      "npm",
-      ["publish", "--tag", "trailing-tag"],
-      {
-        cwd: pkg.location,
-      },
-      done
-    );
+    expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["publish", "--tag", "trailing-tag"], {
+      cwd: pkg.location,
+    });
   });
 
-  it("supports custom registry", done => {
+  it("supports custom registry", async () => {
     const registry = "https://custom-registry/npmPublish";
 
-    npmPublish("custom-registry", pkg, { npmClient: "npm", registry }, done);
+    await npmPublish("custom-registry", pkg, { npmClient: "npm", registry });
 
-    expect(ChildProcessUtilities.exec).lastCalledWith(
-      "npm",
-      ["publish", "--tag", "custom-registry"],
-      {
-        cwd: pkg.location,
-        env: expect.objectContaining({
-          npm_config_registry: registry,
-        }),
-      },
-      done
-    );
+    expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["publish", "--tag", "custom-registry"], {
+      cwd: pkg.location,
+      env: expect.objectContaining({
+        npm_config_registry: registry,
+      }),
+    });
   });
 
   describe("with npmClient yarn", () => {
-    it("appends --new-version to avoid interactive prompt", done => {
-      npmPublish("yarn-publish", pkg, { npmClient: "yarn" }, done);
+    it("appends --new-version to avoid interactive prompt", async () => {
+      await npmPublish("yarn-publish", pkg, { npmClient: "yarn" });
 
       expect(ChildProcessUtilities.exec).lastCalledWith(
         "yarn",
         ["publish", "--tag", "yarn-publish", "--new-version", pkg.version],
         {
           cwd: pkg.location,
-        },
-        done
+        }
       );
     });
   });

--- a/test/utils-npm-run-script.test.js
+++ b/test/utils-npm-run-script.test.js
@@ -5,20 +5,15 @@ jest.mock("../src/ChildProcessUtilities");
 // mocked modules
 const ChildProcessUtilities = require("../src/ChildProcessUtilities");
 
-// helpers
-const callsBack = require("./helpers/callsBack");
-
 // file under test
 const npmRunScript = require("../src/utils/npm-run-script");
 
 describe("npm-run-script", () => {
-  ChildProcessUtilities.exec.mockImplementation(callsBack());
-  ChildProcessUtilities.spawnStreaming.mockImplementation(callsBack());
+  ChildProcessUtilities.exec.mockResolvedValue();
+  ChildProcessUtilities.spawnStreaming.mockResolvedValue();
 
   describe("npmRunScript()", () => {
-    it("runs an npm script in a directory", done => {
-      expect.assertions(1);
-
+    it("runs an npm script in a directory", async () => {
       const script = "foo";
       const config = {
         args: ["--bar", "baz"],
@@ -28,21 +23,14 @@ describe("npm-run-script", () => {
         npmClient: "npm",
       };
 
-      npmRunScript(script, config, done);
+      await npmRunScript(script, config);
 
-      expect(ChildProcessUtilities.exec).lastCalledWith(
-        "npm",
-        ["run", script, "--bar", "baz"],
-        {
-          cwd: config.pkg.location,
-        },
-        done
-      );
+      expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["run", script, "--bar", "baz"], {
+        cwd: config.pkg.location,
+      });
     });
 
-    it("supports a different npmClient", done => {
-      expect.assertions(1);
-
+    it("supports a different npmClient", async () => {
       const script = "foo";
       const config = {
         args: ["--bar", "baz"],
@@ -52,23 +40,16 @@ describe("npm-run-script", () => {
         npmClient: "yarn",
       };
 
-      npmRunScript(script, config, done);
+      await npmRunScript(script, config);
 
-      expect(ChildProcessUtilities.exec).lastCalledWith(
-        "yarn",
-        ["run", script, "--bar", "baz"],
-        {
-          cwd: config.pkg.location,
-        },
-        done
-      );
+      expect(ChildProcessUtilities.exec).lastCalledWith("yarn", ["run", script, "--bar", "baz"], {
+        cwd: config.pkg.location,
+      });
     });
   });
 
   describe("npmRunScript.stream()", () => {
-    it("runs an npm script in a package with streaming", done => {
-      expect.assertions(1);
-
+    it("runs an npm script in a package with streaming", async () => {
       const script = "foo";
       const config = {
         args: ["--bar", "baz"],
@@ -79,7 +60,7 @@ describe("npm-run-script", () => {
         npmClient: "npm",
       };
 
-      npmRunScript.stream(script, config, done);
+      await npmRunScript.stream(script, config);
 
       expect(ChildProcessUtilities.spawnStreaming).lastCalledWith(
         "npm",
@@ -87,8 +68,7 @@ describe("npm-run-script", () => {
         {
           cwd: config.pkg.location,
         },
-        config.pkg.name,
-        done
+        config.pkg.name
       );
     });
   });


### PR DESCRIPTION
## Description

* Anywhere that had a `callback` parameter, it has been removed.
* All commands now use Promise chains in their `initialize`/`execute` lifecycle methods.
* `ChildProcessUtilities` has been simplified, any dangling processes are simply warned, not waited for. Streaming processes are no longer re-wrapped by Promises, either.
* `Command` now initializes everything inside a Promise chain, dramatically simplifying error handling requirements.
* `AddCommand` was refactored into more readable chains of instance methods.
* `BootstrapCommand` is now completely async.
* `runParallelBatches()` was refactored to map Promises instead of `async` library calls.

Probably more that I forgot. sorry.

## Motivation and Context

The callbacks were only making the Command lifecycle hard to read and maintain.

Full conversion to async/await will be relatively painless, now.

## How Has This Been Tested?

The tests pass, as well as local thrashing of various real-world clones.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
