### PR TITLE
Preserve package.json structure during bootstrap mangling

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -425,7 +425,7 @@ class BootstrapCommand extends Command {
         }
 
         return npmInstall
-          .dependencies(rootPkg.location, depsToInstallInRoot, this.npmConfig)
+          .dependencies(rootPkg, depsToInstallInRoot, this.npmConfig)
           .then(() =>
             // Link binaries into dependent packages so npm scripts will
             // have access to them.
@@ -501,7 +501,7 @@ class BootstrapCommand extends Command {
         actions.push(() => {
           const dependencies = deps.map(({ dependency }) => dependency);
 
-          return npmInstall.dependencies(leafNode.location, dependencies, leafNpmConfig).then(() => {
+          return npmInstall.dependencies(leafNode.pkg, dependencies, leafNpmConfig).then(() => {
             tracker.verbose("installed leaf", leafNode.name);
             tracker.completeWork(1);
           });

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -22,8 +22,8 @@ const lernaBootstrap = require("./helpers/command-runner")(require("../src/comma
 
 // assertion helpers
 const installedPackagesInDirectories = testDir =>
-  npmInstall.dependencies.mock.calls.reduce((obj, [location, dependencies]) => {
-    const relative = normalizeRelativeDir(testDir, location);
+  npmInstall.dependencies.mock.calls.reduce((obj, [pkg, dependencies]) => {
+    const relative = normalizeRelativeDir(testDir, pkg.location);
     obj[relative || "ROOT"] = dependencies;
     return obj;
   }, {});
@@ -109,7 +109,9 @@ describe("BootstrapCommand", () => {
 
       // root includes explicit dependencies and hoisted from leaves
       expect(npmInstall.dependencies).toBeCalledWith(
-        testDir,
+        expect.objectContaining({
+          name: "basic",
+        }),
         ["bar@^2.0.0", "foo@^1.0.0", "@test/package-1@^0.0.0"],
         {
           registry: undefined,
@@ -122,7 +124,9 @@ describe("BootstrapCommand", () => {
 
       // foo@0.1.2 differs from the more common foo@^1.0.0
       expect(npmInstall.dependencies).lastCalledWith(
-        expect.stringContaining("package-3"),
+        expect.objectContaining({
+          name: "package-3",
+        }),
         ["foo@0.1.12"],
         expect.objectContaining({
           npmGlobalStyle: true,
@@ -189,7 +193,9 @@ describe("BootstrapCommand", () => {
       await lernaBootstrap(testDir)();
 
       expect(npmInstall.dependencies).toBeCalledWith(
-        expect.any(String),
+        expect.objectContaining({
+          name: "@test/package-2",
+        }),
         expect.arrayContaining(["foo@^1.0.0"]),
         expect.objectContaining({
           npmGlobalStyle: false,
@@ -346,7 +352,9 @@ describe("BootstrapCommand", () => {
 
       expect(installedPackagesInDirectories(testDir)).toMatchSnapshot();
       expect(npmInstall.dependencies).lastCalledWith(
-        expect.any(String),
+        expect.objectContaining({
+          name: "@test/package-1",
+        }),
         expect.arrayContaining(["foo@^1.0.0"]),
         expect.objectContaining({
           registry: "https://my-secure-registry/npm",

--- a/test/fixtures/BootstrapCommand/integration/package-1/build.js
+++ b/test/fixtures/BootstrapCommand/integration/package-1/build.js
@@ -6,4 +6,8 @@ const path = require("path");
 const indexSource = path.resolve("./index.src.js");
 const indexTarget = path.resolve("./index.js");
 
-fs.copyFileSync(indexSource, indexTarget);
+const reader = fs.createReadStream(indexSource);
+const writer = fs.createWriteStream(indexTarget);
+
+// fs.copyFileSync is node >=8.5.0
+reader.pipe(writer);

--- a/test/fixtures/BootstrapCommand/integration/package-1/build.js
+++ b/test/fixtures/BootstrapCommand/integration/package-1/build.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const indexSource = path.resolve("./index.src.js");
+const indexTarget = path.resolve("./index.js");
+
+fs.copyFileSync(indexSource, indexTarget);

--- a/test/fixtures/BootstrapCommand/integration/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/integration/package-1/package.json
@@ -4,12 +4,9 @@
   "private": true,
   "scripts": {
     "test": "echo package-1",
-    "prepublish": "cp index.src.js index.js"
+    "prepare": "node build.js"
   },
   "dependencies": {
     "pify": "^2.0.0"
-  },
-  "devDependencies": {
-    "cash-cp": "^0.2.0"
   }
 }

--- a/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/test/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -39,3 +39,28 @@ cli package-2 OK
 package-3 cli1 OK
 package-3 cli2 package-2 OK
 `;
+
+exports[`lerna bootstrap hoists correctly: stderr 1`] = `
+lerna info version __TEST_VERSION__
+lerna info Bootstrapping 4 packages
+lerna info lifecycle preinstall
+lerna WARN EHOIST_PKG_VERSION "@integration/package-3" package depends on pify@^1.0.0, which differs from the hoisted pify@^2.0.0.
+lerna info Installing external dependencies
+lerna info hoist Installing hoisted dependencies into root
+lerna info hoist Pruning hoisted dependencies
+lerna info hoist Finished pruning hoisted dependencies
+lerna info hoist Finished bootstrapping root
+lerna info Symlinking packages and binaries
+lerna info lifecycle postinstall
+lerna info lifecycle prepublish
+lerna info lifecycle prepare
+lerna success Bootstrapped 4 packages
+`;
+
+exports[`lerna bootstrap hoists correctly: stdout 1`] = `
+package-1
+package-2
+cli package-2 OK
+package-3 cli1 OK
+package-3 cli2 package-2 OK
+`;


### PR DESCRIPTION
## Description

Instead of nuking the entire package.json, just edit what we don't want installed (the sibling packages that are instead symlinked). This helps avoid incorrect `package-lock.json` output due to missing `package.json` properties (name and version, specifically).

* Adds an actual integration test for `lerna bootstrap --hoist`
* Replaces bloated `cash-cp` fixture dep with basic node.js copy

## Motivation and Context

Credit @compulim for the initial idea, #1287

Fixes #1136

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
