### PR TITLE
Disable all non-error logging when stdout is piped

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -25,6 +25,17 @@ function CLI(argv, cwd) {
   if (isCI || !process.stderr.isTTY) {
     log.disableColor();
     log.disableProgress();
+  } else if (!process.stdout.isTTY) {
+    // stdout is being piped, don't log non-errors or progress bars
+    log.disableProgress();
+
+    cli.check(parsedArgv => {
+      // eslint-disable-next-line no-param-reassign
+      parsedArgv.loglevel = "error";
+
+      // return truthy or else it blows up
+      return parsedArgv;
+    });
   } else if (process.stderr.isTTY) {
     log.enableColor();
     log.enableUnicode();


### PR DESCRIPTION
## Description

Another conditional during CLI execution to avoid interpolating log output into piped results.

## Motivation and Context

```
lerna run env --scope my-pkg | grep npm_
lerna ls | wc -l
```

Currently, both of these commands will randomly interpolate bits of log text, such as the success message and the lerna version info. It's not the end of the world, and it _doesn't_ alter the results of the piped commands (all the logging is on a different pipe, `stderr`), but it's sloppy and visually confusing.

## How Has This Been Tested?

Ran the commands above in a few local monorepos. It's just log output.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
