### PR TITLE
Add gitHead property to package.json before publish

### DIFF
--- a/commands/publish/__tests__/__fixtures__/relative-file-specs/packages/package-1/package.json
+++ b/commands/publish/__tests__/__fixtures__/relative-file-specs/packages/package-1/package.json
@@ -1,6 +1,7 @@
 {
   "name": "package-1",
   "version": "1.0.0",
+  "changed": false,
   "dependencies": {
     "tiny-tarball": "^1.0.0"
   }

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -138,6 +138,12 @@ describe("PublishCommand", () => {
       expect(gitAddedFiles(testDir)).toMatchSnapshot("git added files");
       expect(gitCommitMessage()).toEqual("v1.0.1");
       expect(gitTagsAdded()).toEqual(["v1.0.1"]);
+      expect(GitUtilities.checkoutChanges).lastCalledWith(
+        expect.stringContaining("packages/*/package.json"),
+        expect.objectContaining({
+          cwd: testDir,
+        })
+      );
 
       expect(publishedTagInDirectories(testDir)).toMatchSnapshot("npm published");
 
@@ -197,7 +203,6 @@ describe("PublishCommand", () => {
       expect(gitAddedFiles(testDir)).toMatchSnapshot("git added files");
       expect(gitCommitMessage()).toMatchSnapshot("git commit message");
       expect(gitTagsAdded()).toMatchSnapshot("git tags added");
-      expect(GitUtilities.checkoutChanges).not.toBeCalled();
 
       expect(publishedTagInDirectories(testDir)).toMatchSnapshot("npm published");
 
@@ -1171,22 +1176,6 @@ describe("PublishCommand", () => {
       // private packages do not need local version resolution
       expect(updatedPackageJSON("package-7").dependencies).toMatchObject({
         "package-1": "file:../package-1",
-      });
-    });
-
-    it("reverts overwritten link after publish", async () => {
-      const testDir = await initFixture("relative-file-specs");
-
-      await lernaPublish(testDir)("--cd-version", "minor", "--yes");
-
-      // notably missing is package-1, which has no relative file: dependencies
-      ["package-2", "package-3", "package-4", "package-5"].forEach(pkgDir => {
-        expect(GitUtilities.checkoutChanges).toBeCalledWith(
-          path.join(testDir, "packages", pkgDir, "package.json"),
-          expect.objectContaining({
-            cwd: testDir,
-          })
-        );
       });
     });
 

--- a/integration/__snapshots__/lerna-publish.test.js.snap
+++ b/integration/__snapshots__/lerna-publish.test.js.snap
@@ -315,36 +315,56 @@ index SHA..SHA 100644
 `;
 
 exports[`lerna publish replaces file: specifier with local version before npm publish but after git commit: unstaged 1`] = `
+diff --git a/packages/package-1/package.json b/packages/package-1/package.json
+index SHA..SHA 100644
+--- a/packages/package-1/package.json
++++ b/packages/package-1/package.json
+@@ -7 +7,2 @@
+-	}
++	},
++	"gitHead": "GIT_HEAD"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
-@@ -5 +5 @@
+@@ -5,2 +5,3 @@
 -    "package-1": "file:../package-1"
+-  }
 +    "package-1": "^2.0.0"
++  },
++  "gitHead": "GIT_HEAD"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
-@@ -5 +5 @@
+@@ -5,2 +5,3 @@
 -    "package-2": "file:../package-2"
+-  }
 +    "package-2": "^2.0.0"
++  },
++  "gitHead": "GIT_HEAD"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
-@@ -5 +5 @@
+@@ -5,2 +5,3 @@
 -    "package-3": "file:../package-3"
+-  }
 +    "package-3": "^2.0.0"
++  },
++  "gitHead": "GIT_HEAD"
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
-@@ -5,2 +5,2 @@
+@@ -5,3 +5,4 @@
 -    "package-4": "file:../package-4",
 -    "package-6": "file:../package-6"
+-  }
 +    "package-4": "^2.0.0",
 +    "package-6": "^1.0.0"
++  },
++  "gitHead": "GIT_HEAD"
 `;
 
 exports[`lerna publish silences lifecycle scripts with --loglevel=silent 1`] = `
@@ -366,6 +386,7 @@ Array [
   Object {
     change: true,
     description: no local dependencies, four local dependents (three transitive),
+    gitHead: GIT_HEAD,
     name: package-1,
     version: 2.0.0,
   },
@@ -374,6 +395,7 @@ Array [
       package-1: ^2.0.0,
     },
     description: one local dependency, one direct dependent, no transitive dependencies,
+    gitHead: GIT_HEAD,
     name: package-2,
     version: 2.0.0,
   },
@@ -382,6 +404,7 @@ Array [
       package-2: ^2.0.0,
     },
     description: one local dependency, one direct dependent, one transitive dependency,
+    gitHead: GIT_HEAD,
     name: package-3,
     version: 2.0.0,
   },
@@ -390,6 +413,7 @@ Array [
       package-3: ^2.0.0,
     },
     description: one local dependency, one direct dependent, two transitive dependencies,
+    gitHead: GIT_HEAD,
     name: package-4,
     version: 2.0.0,
   },
@@ -398,6 +422,7 @@ Array [
       package-4: ^2.0.0,
     },
     description: one local dependency, no dependents, three transitive dependencies,
+    gitHead: GIT_HEAD,
     name: package-5,
     version: 2.0.0,
   },
@@ -412,6 +437,7 @@ v1.0.1
 exports[`lerna publish updates fixed versions: packages 1`] = `
 Array [
   Object {
+    gitHead: GIT_HEAD,
     name: package-1,
     version: 1.0.1,
   },
@@ -419,6 +445,7 @@ Array [
     dependencies: Object {
       package-1: ^1.0.1,
     },
+    gitHead: GIT_HEAD,
     name: package-2,
     version: 1.0.1,
   },
@@ -426,6 +453,7 @@ Array [
     devDependencies: Object {
       package-2: ^1.0.1,
     },
+    gitHead: GIT_HEAD,
     name: package-3,
     peerDependencies: Object {
       package-2: ^1.0.0,
@@ -436,6 +464,7 @@ Array [
     dependencies: Object {
       package-1: ^0.0.0,
     },
+    gitHead: GIT_HEAD,
     name: package-4,
     version: 1.0.1,
   },
@@ -475,6 +504,7 @@ Publish
 exports[`lerna publish updates independent versions: packages 1`] = `
 Array [
   Object {
+    gitHead: GIT_HEAD,
     name: package-1,
     version: 2.0.0,
   },
@@ -482,6 +512,7 @@ Array [
     dependencies: Object {
       package-1: ^2.0.0,
     },
+    gitHead: GIT_HEAD,
     name: package-2,
     version: 3.0.0,
   },
@@ -489,6 +520,7 @@ Array [
     devDependencies: Object {
       package-2: ^3.0.0,
     },
+    gitHead: GIT_HEAD,
     name: package-3,
     version: 4.0.0,
   },
@@ -496,6 +528,7 @@ Array [
     dependencies: Object {
       package-1: ^0.0.0,
     },
+    gitHead: GIT_HEAD,
     name: package-4,
     version: 5.0.0,
   },

--- a/integration/lerna-publish.test.js
+++ b/integration/lerna-publish.test.js
@@ -21,7 +21,8 @@ const normalizeTestRoot = require("@lerna-test/normalize-test-root");
 expect.addSnapshotSerializer({
   print(val) {
     return normalizeNewline(val)
-      .replace(/\b[a-f0-9]{7,8}\b/g, "SHA")
+      .replace(/\b[0-9a-f]{7,8}\b/g, "SHA")
+      .replace(/\b[0-9a-f]{40}\b/g, "GIT_HEAD")
       .replace(/\(\d{4}-\d{2}-\d{2}\)/g, "(YYYY-MM-DD)");
   },
   test(val) {
@@ -159,7 +160,7 @@ describe("lerna publish", () => {
     const cwd = await initFixture("relative-file-specs");
 
     await execa("git", ["tag", "v1.0.0", "-m", "v1.0.0"], { cwd });
-    await commitChangeToPackage(cwd, "package-1", "feat(package-1): Add foo", { foo: true });
+    await commitChangeToPackage(cwd, "package-1", "feat(package-1): changed", { changed: true });
 
     await cliRunner(cwd)("publish", "--cd-version=major", "--skip-npm", "--yes");
 


### PR DESCRIPTION
## Description

This mimics [read-package-json](https://github.com/npm/read-package-json/blob/b5a9f47c437d9b01d4e86372a3fc1bd04a89313f/read-json.js#L327)'s annotation of the current git `HEAD` during `npm publish`.

## Motivation and Context

This helps users and automated processes understand "when" a given version was published in terms of a raw SHA1. Sometimes the tags get nuked, mutated, or otherwise perverted. The SHA of a git revison (theoretically) is simpler to back-track.

## How Has This Been Tested?

Updated tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
