### PR TITLE
feat: Check for upstream changes before attempting to publish

### DIFF
--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -84,6 +84,18 @@ class PublishCommand extends Command {
           `
         );
       }
+
+      if (GitUtilities.isBehindUpstream(this.gitRemote, this.execOpts)) {
+        const remote = `${this.gitRemote}/${currentBranch} `;
+        throw new ValidationError(
+          "EBEHIND",
+          dedent`
+            Local branch '${currentBranch}' is behind remote upstream ${remote}
+            Please merge in remote changes into '${currentBranch}'. 
+            Remote changes can be fetched and merged with git pull 
+          `
+        );
+      }
     }
 
     this.conf = npmConf(this.options);

--- a/core/git-utils/__tests__/git-utils.test.js
+++ b/core/git-utils/__tests__/git-utils.test.js
@@ -347,4 +347,48 @@ describe("GitUtilities", () => {
       expect(GitUtilities.hasCommit()).toBe(false);
     });
   });
+
+  describe(".isBehindUpstream()", () => {
+    const aheadBehindCountOriginal = GitUtilities.aheadBehindCount;
+    afterEach(() => {
+      GitUtilities.aheadBehindCount = aheadBehindCountOriginal;
+    });
+
+    it("returns true when behind upstream", () => {
+      const opts = { cwd: "test" };
+      GitUtilities.aheadBehindCount = jest.fn(() => ({ ahead: 0, behind: 1 }));
+      expect(GitUtilities.isBehindUpstream("origin", opts)).toBe(true);
+    });
+
+    it("returns false when not behind upstream", () => {
+      const opts = { cwd: "test" };
+      GitUtilities.aheadBehindCount = jest.fn(() => ({ ahead: 0, behind: 0 }));
+      expect(GitUtilities.isBehindUpstream("origin", opts)).toBe(false);
+    });
+  });
+
+  describe(".aheadBehindCount()", () => {
+    const getCurrentBranchOriginal = GitUtilities.getCurrentBranch;
+    afterEach(() => {
+      GitUtilities.getCurrentBranch = getCurrentBranchOriginal;
+    });
+
+    it("returns the number of commits the local repo is behind upstream", () => {
+      const opts = { cwd: "test" };
+      GitUtilities.getCurrentBranch = jest.fn(() => "master");
+      ChildProcessUtilities.execSync.mockReturnValueOnce("5\t0");
+
+      const aheadBehindCount = GitUtilities.aheadBehindCount("origin", opts);
+      expect(aheadBehindCount.behind).toBe(5);
+    });
+
+    it("returns the number of commits the local repo is ahead upstream", () => {
+      const opts = { cwd: "test" };
+      GitUtilities.getCurrentBranch = jest.fn(() => "master");
+      ChildProcessUtilities.execSync.mockReturnValueOnce("0\t2");
+
+      const aheadBehindCount = GitUtilities.aheadBehindCount("origin", opts);
+      expect(aheadBehindCount.ahead).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Check the git remote upstream for changes before attempting to publish. Exit with an error if upstream changes are detected. 

## Motivation and Context

Partly fixes #1177, in the case that there are remote changes at the time when `lerna publish` is run.

It is still possible that during the publish to npm, changes are added to the remote; which would make the git push fail. 

## How Has This Been Tested?

- unit tests
- manually publishing locally with `lerna publish --skip-npm`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
