### PR TITLE
feat(publish): added warning when skip-git or skip-npm are used

### DIFF
--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -348,6 +348,14 @@ describe("PublishCommand", () => {
 
       expect(publishedTagInDirectories(testDir)).toMatchSnapshot("npm published");
     });
+
+    it("should display a message that git is skipped", async () => {
+      const testDir = await initFixture("normal");
+      await lernaPublish(testDir)("--skip-git");
+
+      const info = loggingOutput("info");
+      expect(info).toContain("Skipping git...");
+    });
   });
 
   /** =========================================================================
@@ -367,6 +375,13 @@ describe("PublishCommand", () => {
       expect(gitCommitMessage()).toEqual("v1.0.1");
       // FIXME
       // expect(GitUtilities.pushWithTags).lastCalledWith("origin", ["v1.0.1"]);
+    });
+    it("should display a message that npm is skipped", async () => {
+      const testDir = await initFixture("normal");
+      await lernaPublish(testDir)("--skip-npm");
+
+      const info = loggingOutput("info");
+      expect(info).toContain("Skipping npm...");
     });
   });
 
@@ -404,6 +419,14 @@ describe("PublishCommand", () => {
       expect(npmDistTag.check).not.toBeCalled();
       expect(npmDistTag.remove).not.toBeCalled();
       expect(npmDistTag.add).not.toBeCalled();
+    });
+    it("should display a message that npm and git are skipped", async () => {
+      const testDir = await initFixture("normal");
+      await lernaPublish(testDir)("--skip-git", "--skip-npm");
+
+      const logMessages = loggingOutput("info");
+      expect(logMessages).toContain("Skipping git...");
+      expect(logMessages).toContain("Skipping npm...");
     });
   });
 

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -353,8 +353,8 @@ describe("PublishCommand", () => {
       const testDir = await initFixture("normal");
       await lernaPublish(testDir)("--skip-git");
 
-      const info = loggingOutput("info");
-      expect(info).toContain("Skipping git...");
+      const logMessages = loggingOutput("info");
+      expect(logMessages).toContain("Skipping git commit/push");
     });
   });
 
@@ -376,12 +376,13 @@ describe("PublishCommand", () => {
       // FIXME
       // expect(GitUtilities.pushWithTags).lastCalledWith("origin", ["v1.0.1"]);
     });
+
     it("should display a message that npm is skipped", async () => {
       const testDir = await initFixture("normal");
       await lernaPublish(testDir)("--skip-npm");
 
-      const info = loggingOutput("info");
-      expect(info).toContain("Skipping npm...");
+      const logMessages = loggingOutput("info");
+      expect(logMessages).toContain("Skipping publish to registry");
     });
   });
 
@@ -420,13 +421,14 @@ describe("PublishCommand", () => {
       expect(npmDistTag.remove).not.toBeCalled();
       expect(npmDistTag.add).not.toBeCalled();
     });
+
     it("should display a message that npm and git are skipped", async () => {
       const testDir = await initFixture("normal");
       await lernaPublish(testDir)("--skip-git", "--skip-npm");
 
       const logMessages = loggingOutput("info");
-      expect(logMessages).toContain("Skipping git...");
-      expect(logMessages).toContain("Skipping npm...");
+      expect(logMessages).toContain("Skipping git commit/push");
+      expect(logMessages).toContain("Skipping publish to registry");
     });
   });
 

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -140,22 +140,18 @@ class PublishCommand extends Command {
 
     tasks.push(() => this.updateUpdatedPackages());
 
-    if (!this.gitEnabled) {
-      this.logger.info("Skipping git...");
-    }
-
     if (this.gitEnabled) {
       tasks.push(() => this.commitAndTagUpdates());
+    } else {
+      this.logger.info("execute", "Skipping git commit/push");
     }
 
     tasks.push(() => this.resolveLocalDependencyLinks());
     tasks.push(() => this.annotateGitHead());
 
     if (this.options.skipNpm) {
-      this.logger.info("Skipping npm...");
-    }
-
-    if (!this.options.skipNpm) {
+      this.logger.info("execute", "Skipping publish to registry");
+    } else {
       tasks.push(() => this.publishPackagesToNpm());
     }
 

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -140,12 +140,20 @@ class PublishCommand extends Command {
 
     tasks.push(() => this.updateUpdatedPackages());
 
+    if (!this.gitEnabled) {
+      this.logger.info("Skipping git...");
+    }
+
     if (this.gitEnabled) {
       tasks.push(() => this.commitAndTagUpdates());
     }
 
     tasks.push(() => this.resolveLocalDependencyLinks());
     tasks.push(() => this.annotateGitHead());
+
+    if (this.options.skipNpm) {
+      this.logger.info("Skipping npm...");
+    }
 
     if (!this.options.skipNpm) {
       tasks.push(() => this.publishPackagesToNpm());


### PR DESCRIPTION
Added a warning when `--skip-git` or `--skip-npm` arguments are used

## Description
When you use a --skip-git or --skip-npm, there is now a message:
- `lerna info Skipping git...` when `--skip-git` is used
- `lerna info Skipping npm...` when `--skip-npm` is used

## Motivation and Context
Issue #1314  

## How Has This Been Tested?
I tested this change by myself ([log](https://hastebin.com/ofewinerat)):
1. I linked local Lerna on my computer
2. I cloned `https://github.com/ElemeFE/mint-ui` repository on my computer
3. I launched `lerna bootstrap`
4. I launched `lerna publish --skip-git --skip-npm`. The messages `Skipping git...` and `Skipping npm...` appeared
5. I launched `lerna publish --skip-npm`. The messages `Skipping npm...` appeared
6. I launched `lerna publish --skip-git`. The messages `Skipping git...` appeared

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
