### PR TITLE
fix(utils): Use safe relative path when calling git diff

### DIFF
--- a/core/git-utils/__tests__/git-utils.test.js
+++ b/core/git-utils/__tests__/git-utils.test.js
@@ -259,6 +259,21 @@ describe("GitUtilities", () => {
         opts
       );
     });
+
+    it("returns list of files changed since commit at location when location equals cwd", () => {
+      const cwd = process.cwd();
+      const opts = { cwd };
+      const testLocation = cwd;
+
+      ChildProcessUtilities.execSync.mockReturnValueOnce("files");
+
+      expect(GitUtilities.diffSinceIn("v1.0.0", testLocation, opts)).toBe("files");
+      expect(ChildProcessUtilities.execSync).lastCalledWith(
+        "git",
+        ["diff", "--name-only", "v1.0.0", "--", "."],
+        opts
+      );
+    });
   });
 
   describe(".getWorkspaceRoot()", () => {

--- a/core/git-utils/index.js
+++ b/core/git-utils/index.js
@@ -134,7 +134,9 @@ function describeTag(ref, opts) {
 }
 
 function diffSinceIn(committish, location, opts) {
-  const formattedLocation = slash(path.relative(opts.cwd, location));
+  const relativePath = path.relative(opts.cwd, location);
+  const nonEmptyRelativePath = relativePath === "" ? "." : relativePath;
+  const formattedLocation = slash(nonEmptyRelativePath);
 
   log.silly("diffSinceIn", committish, formattedLocation);
 


### PR DESCRIPTION
When location is the same as the cwd, return '.' instead of empty string
otherwise git diff will fail

refs #1322

<!--- Provide a general summary of your changes in the Title above -->

## Description
Using path.relative is not enough for git params as when comparing two identical paths (`path.relative`) it will return an empty string

## Motivation and Context
Fixes #1322

## How Has This Been Tested?
I added a test case and was not able to reproduce it as in #1322 anymore

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
