### PR TITLE
feat: set LERNA_ROOT_PATH when invoking npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,10 @@ $ lerna run --scope my-component test
 > may be harmful to your shell's equanimity (or maximum file descriptor limit,
 > for example). YMMV
 
+You can detect presence of Lerna in your package npm scripts by checking
+for the environment variable `LERNA_ROOT_PATH`. This variable points
+to repository's root directory.
+
 ### exec
 
 ```sh

--- a/core/package/index.js
+++ b/core/package/index.js
@@ -39,6 +39,9 @@ class Package {
       location: {
         value: location,
       },
+      repositoryRootPath: {
+        value: rootPath,
+      },
       private: {
         value: Boolean(pkg.private),
       },

--- a/integration/__fixtures__/lerna-run/packages/package-1/package.json
+++ b/integration/__fixtures__/lerna-run/packages/package-1/package.json
@@ -5,6 +5,7 @@
     "package-3": "^1.0.0"
   },
   "scripts": {
+    "dump-root": "echo $LERNA_ROOT_PATH",
     "my-script": "echo package-1",
     "test": "echo package-1"
   }

--- a/integration/__snapshots__/lerna-bootstrap.test.js.snap
+++ b/integration/__snapshots__/lerna-bootstrap.test.js.snap
@@ -1,25 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lerna bootstrap --npm-client yarn: stderr 1`] = `
-lerna info version __TEST_VERSION__
-lerna info Bootstrapping 4 packages
-lerna info lifecycle package-4@1.0.0~preinstall: package-4@1.0.0
-lerna info Installing external dependencies
-lerna info Symlinking packages and binaries
-lerna info lifecycle @integration/package-3@1.0.0~postinstall: @integration/package-3@1.0.0
-lerna info lifecycle @integration/package-2@1.0.0~prepublish: @integration/package-2@1.0.0
-lerna info lifecycle @integration/package-1@1.0.0~prepare: @integration/package-1@1.0.0
-lerna success Bootstrapped 4 packages
-`;
-
-exports[`lerna bootstrap --npm-client yarn: stdout 1`] = `
-package-1
-package-2
-cli package-2 OK
-package-3 cli1 OK
-package-3 cli2 package-2 OK
-`;
-
 exports[`lerna bootstrap bootstraps all packages: stderr 1`] = `
 lerna info version __TEST_VERSION__
 lerna info Bootstrapping 4 packages

--- a/integration/__snapshots__/lerna-run.test.js.snap
+++ b/integration/__snapshots__/lerna-run.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lerna run LERNA_ROOT_PATH: stderr 1`] = `
+lerna info version __TEST_VERSION__
+lerna success run Ran npm script 'dump-root' in packages:
+lerna success - package-1
+`;
+
 exports[`lerna run my-script --parallel: stderr 1`] = `
 lerna info version __TEST_VERSION__
 lerna info run in 2 package(s): npm run my-script --silent

--- a/integration/lerna-run.test.js
+++ b/integration/lerna-run.test.js
@@ -96,4 +96,20 @@ describe("lerna run", () => {
     expect(stdout).toMatch("package-3: package-3");
     expect(stdout).not.toMatch("package-4");
   });
+
+  test("LERNA_ROOT_PATH", async () => {
+    const cwd = await initFixture("lerna-run");
+    const args = [
+      "run",
+      "dump-root",
+      // args below tell npm to be quiet
+      "--",
+      "--silent",
+    ];
+    const { stdout, stderr } = await cliRunner(cwd)(...args);
+    expect(stderr).toMatchSnapshot("stderr");
+
+    // order is non-deterministic, so assert each item seperately
+    expect(stdout).toMatch(cwd);
+  });
 });

--- a/utils/get-npm-exec-opts/get-npm-exec-opts.js
+++ b/utils/get-npm-exec-opts/get-npm-exec-opts.js
@@ -9,9 +9,15 @@ function getExecOpts(pkg, registry) {
     cwd: pkg.location,
   };
 
+  if (pkg.repositoryRootPath) {
+    opts.env = {
+      LERNA_ROOT_PATH: pkg.repositoryRootPath,
+    };
+  }
+
   if (registry) {
     opts.extendEnv = false;
-    opts.env = Object.assign({}, process.env, {
+    opts.env = Object.assign({}, process.env, opts.env, {
       npm_config_registry: registry,
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, the environment variable LERNA_ROOT_PATH was set only for `lerna exec` command (see #873). This patch modifies the way how `npm` scripts are executed to set LERNA_ROOT_PATH too.

<!--- Describe your changes in detail -->

## Motivation and Context

In LoopBack (see https://github.com/strongloop/loopback-next), we are using Lerna together with Typescript. One issue we are facing that TypeScript compilation errors report paths relative to current working directory, which is a per-package directory. This makes it difficult for tooling like VisualStudio Code to correctly parse errors and convert them to clickable/navigate-able entries in Problems window.

We would like to modify our build script to report paths relative to monorepo root (to fix VS Code integration), but only when the per-package build script is invoked via Lerna (see https://github.com/strongloop/loopback-next/issues/1010) - to keep individual per-package scripts still useful when run on their own via `npm`.

As I was reading Lerna documentation, I discovered LERNA_ROOT_PATH. This env variable is perfect for our needs, except the fact that it's not set by `lerna run` command. And so this patch was born.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I added a new test case to the integration tests to verify my new use case.

FWIW, `npm run lint` is failing in a node_modules folder for me, I think `.gitignore` file needs to be changed to ignore _all_ node_module directories, not only the top/monorepo-level one. I am leaving that change out of my pull request though, as it's not related.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.