### PR TITLE
feat: Execute atomic publish lifecycle during lerna publish

### DIFF
--- a/commands/publish/__tests__/__fixtures__/lifecycle/package.json
+++ b/commands/publish/__tests__/__fixtures__/lifecycle/package.json
@@ -4,6 +4,10 @@
   "scripts": {
     "preversion": "echo preversion-root",
     "version": "echo version-root",
-    "postversion": "echo postversion-root"
+    "postversion": "echo postversion-root",
+    "prepublish": "echo prepublish-root",
+    "prepare": "echo prepare-root",
+    "prepublishOnly": "echo prepublishOnly-root",
+    "postpublish": "echo postpublish-root"
   }
 }

--- a/commands/publish/__tests__/__fixtures__/lifecycle/packages/package-1/package.json
+++ b/commands/publish/__tests__/__fixtures__/lifecycle/packages/package-1/package.json
@@ -4,6 +4,10 @@
   "scripts": {
     "preversion": "echo preversion-package-1",
     "version": "echo version-package-1",
-    "postversion": "echo postversion-package-1"
+    "postversion": "echo postversion-package-1",
+    "prepublish": "echo prepublish-package-1",
+    "prepare": "echo prepare-package-1",
+    "prepublishOnly": "echo prepublish-package-1",
+    "postpublish": "echo postpublish-package-1"
   }
 }

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -1110,11 +1110,11 @@ describe("PublishCommand", () => {
    * ======================================================================= */
 
   describe("lifecycle scripts", () => {
-    it("calls version lifecycle scripts for root and packages", async () => {
+    it("calls version and publish lifecycle scripts for root and packages", async () => {
       const testDir = await initFixture("lifecycle");
       await lernaPublish(testDir)();
 
-      expect(runLifecycle).toHaveBeenCalledTimes(6);
+      expect(runLifecycle).toHaveBeenCalledTimes(10);
 
       ["preversion", "version", "postversion"].forEach(script => {
         expect(runLifecycle).toHaveBeenCalledWith(
@@ -1143,6 +1143,10 @@ describe("PublishCommand", () => {
         ["lifecycle", "version"],
         ["package-1", "postversion"],
         ["lifecycle", "postversion"],
+        ["package-1", "prepublish"],
+        ["package-1", "prepare"],
+        ["package-1", "prepublishOnly"],
+        ["package-1", "postpublish"],
       ]);
     });
 
@@ -1153,7 +1157,7 @@ describe("PublishCommand", () => {
 
       await lernaPublish(testDir)();
 
-      expect(runLifecycle).toHaveBeenCalledTimes(6);
+      expect(runLifecycle).toHaveBeenCalledTimes(10);
       expect(updatedPackageVersions(testDir)).toMatchSnapshot("updated packages");
 
       const [errorLog] = loggingOutput("error");

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -1114,7 +1114,7 @@ describe("PublishCommand", () => {
       const testDir = await initFixture("lifecycle");
       await lernaPublish(testDir)();
 
-      expect(runLifecycle).toHaveBeenCalledTimes(14);
+      expect(runLifecycle).toHaveBeenCalledTimes(12);
 
       ["preversion", "version", "postversion"].forEach(script => {
         expect(runLifecycle).toHaveBeenCalledWith(
@@ -1143,10 +1143,8 @@ describe("PublishCommand", () => {
         ["lifecycle", "version"],
         ["package-1", "postversion"],
         ["lifecycle", "postversion"],
-        ["lifecycle", "prepublish"],
         ["lifecycle", "prepare"],
         ["lifecycle", "prepublishOnly"],
-        ["package-1", "prepublish"],
         ["package-1", "prepare"],
         ["package-1", "prepublishOnly"],
         ["package-1", "postpublish"],
@@ -1161,7 +1159,7 @@ describe("PublishCommand", () => {
 
       await lernaPublish(testDir)();
 
-      expect(runLifecycle).toHaveBeenCalledTimes(14);
+      expect(runLifecycle).toHaveBeenCalledTimes(12);
       expect(updatedPackageVersions(testDir)).toMatchSnapshot("updated packages");
 
       const [errorLog] = loggingOutput("error");

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -1114,7 +1114,7 @@ describe("PublishCommand", () => {
       const testDir = await initFixture("lifecycle");
       await lernaPublish(testDir)();
 
-      expect(runLifecycle).toHaveBeenCalledTimes(10);
+      expect(runLifecycle).toHaveBeenCalledTimes(14);
 
       ["preversion", "version", "postversion"].forEach(script => {
         expect(runLifecycle).toHaveBeenCalledWith(
@@ -1143,10 +1143,14 @@ describe("PublishCommand", () => {
         ["lifecycle", "version"],
         ["package-1", "postversion"],
         ["lifecycle", "postversion"],
+        ["lifecycle", "prepublish"],
+        ["lifecycle", "prepare"],
+        ["lifecycle", "prepublishOnly"],
         ["package-1", "prepublish"],
         ["package-1", "prepare"],
         ["package-1", "prepublishOnly"],
         ["package-1", "postpublish"],
+        ["lifecycle", "postpublish"],
       ]);
     });
 
@@ -1157,7 +1161,7 @@ describe("PublishCommand", () => {
 
       await lernaPublish(testDir)();
 
-      expect(runLifecycle).toHaveBeenCalledTimes(10);
+      expect(runLifecycle).toHaveBeenCalledTimes(14);
       expect(updatedPackageVersions(testDir)).toMatchSnapshot("updated packages");
 
       const [errorLog] = loggingOutput("error");

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -594,12 +594,10 @@ class PublishCommand extends Command {
     const promise = Promise.resolve()
       .then(() => this.runPrepublishScripts(rootPkg))
       .then(() =>
-        Promise.all(
-          this.updates.map(({ pkg }) => {
-            this.execScript(pkg, "prepublish");
-            return this.runPrepublishScripts(pkg);
-          })
-        )
+        pMap(this.updates, ({ pkg }) => {
+          this.execScript(pkg, "prepublish");
+          return this.runPrepublishScripts(pkg);
+        })
       );
 
     tracker.addWork(this.packagesToPublish.length);

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -583,7 +583,12 @@ class PublishCommand extends Command {
     // if we skip temp tags we should tag with the proper value immediately
     const distTag = this.options.tempTag ? "lerna-temp" : this.getDistTag();
 
-    this.updates.forEach(({ pkg }) => this.execScript(pkg, "prepublish"));
+    this.updates.forEach(({ pkg }) => {
+      this.execScript(pkg, "prepublish");
+      this.runPackageLifecycle(pkg, "prepublish");
+      this.runPackageLifecycle(pkg, "prepare");
+      this.runPackageLifecycle(pkg, "prepublishOnly");
+    });
 
     tracker.addWork(this.packagesToPublish.length);
 
@@ -595,6 +600,7 @@ class PublishCommand extends Command {
         tracker.completeWork(1);
 
         this.execScript(pkg, "postpublish");
+        this.runPackageLifecycle(pkg, "postpublish");
       });
     };
 

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -583,7 +583,7 @@ class PublishCommand extends Command {
     // if we skip temp tags we should tag with the proper value immediately
     const distTag = this.options.tempTag ? "lerna-temp" : this.getDistTag();
 
-    const rootPkg = this.repository.package;
+    const rootPkg = this.project.package;
     this.runPackageLifecycle(rootPkg, "prepublish");
     this.runPackageLifecycle(rootPkg, "prepare");
     this.runPackageLifecycle(rootPkg, "prepublishOnly");

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -579,9 +579,9 @@ class PublishCommand extends Command {
   }
 
   runPrepublishScripts(pkg) {
-    return Promise.resolve(this.runPackageLifecycle(pkg, "prepublish"))
-      .then(() => this.runPackageLifecycle(pkg, "prepare"))
-      .then(() => this.runPackageLifecycle(pkg, "prepublishOnly"));
+    return Promise.resolve(this.runPackageLifecycle(pkg, "prepare")).then(() =>
+      this.runPackageLifecycle(pkg, "prepublishOnly")
+    );
   }
 
   npmPublish() {

--- a/utils/npm-publish/__tests__/npm-publish.test.js
+++ b/utils/npm-publish/__tests__/npm-publish.test.js
@@ -20,15 +20,19 @@ describe("npm-publish", () => {
   it("runs npm publish in a directory with --tag support", async () => {
     await npmPublish(pkg, "published-tag", { npmClient: "npm" });
 
-    expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["publish", "--tag", "published-tag"], {
-      cwd: pkg.location,
-    });
+    expect(ChildProcessUtilities.exec).lastCalledWith(
+      "npm",
+      ["publish", "--ignore-scripts", "--tag", "published-tag"],
+      {
+        cwd: pkg.location,
+      }
+    );
   });
 
   it("does not pass --tag when none present (npm default)", async () => {
     await npmPublish(pkg, undefined, { npmClient: "npm" });
 
-    expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["publish"], {
+    expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["publish", "--ignore-scripts"], {
       cwd: pkg.location,
     });
   });
@@ -36,9 +40,13 @@ describe("npm-publish", () => {
   it("trims trailing whitespace in tag parameter", async () => {
     await npmPublish(pkg, "trailing-tag ", { npmClient: "npm" });
 
-    expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["publish", "--tag", "trailing-tag"], {
-      cwd: pkg.location,
-    });
+    expect(ChildProcessUtilities.exec).lastCalledWith(
+      "npm",
+      ["publish", "--ignore-scripts", "--tag", "trailing-tag"],
+      {
+        cwd: pkg.location,
+      }
+    );
   });
 
   it("supports custom registry", async () => {
@@ -46,13 +54,17 @@ describe("npm-publish", () => {
 
     await npmPublish(pkg, "custom-registry", { npmClient: "npm", registry });
 
-    expect(ChildProcessUtilities.exec).lastCalledWith("npm", ["publish", "--tag", "custom-registry"], {
-      cwd: pkg.location,
-      env: expect.objectContaining({
-        npm_config_registry: registry,
-      }),
-      extendEnv: false,
-    });
+    expect(ChildProcessUtilities.exec).lastCalledWith(
+      "npm",
+      ["publish", "--ignore-scripts", "--tag", "custom-registry"],
+      {
+        cwd: pkg.location,
+        env: expect.objectContaining({
+          npm_config_registry: registry,
+        }),
+        extendEnv: false,
+      }
+    );
   });
 
   describe("with npmClient yarn", () => {
@@ -61,7 +73,15 @@ describe("npm-publish", () => {
 
       expect(ChildProcessUtilities.exec).lastCalledWith(
         "yarn",
-        ["publish", "--tag", "yarn-publish", "--new-version", pkg.version, "--non-interactive"],
+        [
+          "publish",
+          "--ignore-scripts",
+          "--tag",
+          "yarn-publish",
+          "--new-version",
+          pkg.version,
+          "--non-interactive",
+        ],
         {
           cwd: pkg.location,
         }

--- a/utils/npm-publish/npm-publish.js
+++ b/utils/npm-publish/npm-publish.js
@@ -12,7 +12,7 @@ function npmPublish(pkg, tag, { npmClient, registry }) {
 
   const distTag = tag && tag.trim();
   const opts = getExecOpts(pkg, registry);
-  const args = ["publish"];
+  const args = ["publish", "--ignore-scripts"];
 
   if (distTag) {
     args.push("--tag", distTag);


### PR DESCRIPTION
## Description
Changes Lerna to run the following [npm lifecycle scripts][1] when running `lerna publish`:
1. in root package:
    1. `prepublish`
    2. `prepare`
    3. `prepublishOnly`
2. sequentially in each subpackage:
    1. `prepublish`
    2. `prepare`
    3. `prepublishOnly`
3. parallel in each subpackage:
    1. (the npm package is published)
    2. `postpublish`
4. in root package:
    1. `postpublish`

[1]: https://docs.npmjs.com/misc/scripts#description

These scripts will only be run when the `--skip-npm` flag is **not** preset and after creating git commits, so `preversion`, `version` and `postversion` scripts will execute before these. This means that a failing `prepublish` will not prevent the creation of git commits or tags, but will prevent any of the packages from being published to npm.

## Motivation and Context
Lifecycle scripts are standard way in npm to execute functionality after certain events. It is convenient to be able to add a `prepublish` or `prepare` script to either the root package or a subpackage to for instance run the project's tests and compile source files for publishing. Lerna currently executes `npm publish` for each subpackage which in turns calls the scripts, but this can lead to a corrupted state where some of the packages have been successfully published and some have not. By running prepublish scripts before any of the packages is actually published, any error in the scripts will prevent any of the packages from being published.

## How Has This Been Tested?
Unit tested by augmenting the current lifecycle mock expectations in `publish-command.test.js`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

There are some tests in `master` which are already failing. I wanted to gather feedback before making changes to documentation.
