### PR TITLE
feat: Support --no-prefix for streaming output

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ $ lerna run --parallel watch
 
 Run an [npm script](https://docs.npmjs.com/misc/scripts) in each package that contains that script. A double-dash (`--`) is necessary to pass dashed arguments to the script execution.
 
-`lerna run` respects the `--concurrency`, `--scope`, `--ignore`, `--stream`, and `--parallel` flags (see [Flags](#flags)).
+`lerna run` respects the `--concurrency`, `--scope`, `--ignore`, `--stream`, `--prefix` and `--parallel` flags (see [Flags](#flags)).
 
 ```sh
 $ lerna run --scope my-component test
@@ -645,7 +645,7 @@ $ lerna exec -- protractor conf.js
 Run an arbitrary command in each package.
 A double-dash (`--`) is necessary to pass dashed flags to the spawned command, but is not necessary when all the arguments are positional.
 
-`lerna exec` respects the `--concurrency`, `--scope`, `--ignore`, `--stream` and `--parallel` flags (see [Flags](#flags)).
+`lerna exec` respects the `--concurrency`, `--scope`, `--ignore`, `--stream`  `--prefix` and `--parallel` flags (see [Flags](#flags)).
 
 ```sh
 $ lerna exec --scope my-component -- ls -la
@@ -1082,6 +1082,16 @@ package name. This allows output from different packages to be interleaved.
 
 ```sh
 $ lerna run watch --stream
+```
+
+#### --prefix
+
+By default, stream output is prefixed with the originating package name. This flag can be turned off
+so that the output can be parsed by a tool such as Visual Studio Code can highlight the result by type
+for all packages in the same project.
+
+```sh
+$ lerna run build --stream --no-prefix
 ```
 
 #### --parallel

--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -41,8 +41,11 @@ export default class ChildProcessUtilities {
     const color = chalk[colorName];
     const spawned = _spawn(command, args, options, callback);
 
-    const prefixedStdout = logTransformer({ tag: `${color.bold(prefix)}:` });
-    const prefixedStderr = logTransformer({ tag: `${color(prefix)}:`, mergeMultiline: true });
+    const stdoutTag = prefix ? `${color.bold(prefix)}:` : "";
+    const stderrTag = prefix ? `${color(prefix)}:` : "";
+
+    const prefixedStdout = logTransformer({ tag: stdoutTag });
+    const prefixedStderr = logTransformer({ tag: stderrTag, mergeMultiline: true });
 
     // Avoid "Possible EventEmitter memory leak detected" warning due to piped stdio
     if (children > process.stdout.listenerCount("close")) {

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -129,11 +129,13 @@ export default class NpmUtilities {
     ChildProcessUtilities.execSync(npmClient, ["run", script, ...args], opts, callback);
   }
 
-  static runScriptInPackageStreaming(script, { args, pkg, npmClient }, callback) {
+  static runScriptInPackageStreaming(script, { args, pkg, npmClient, prefix }, callback) {
     log.silly("runScriptInPackageStreaming", [script, args, pkg.name]);
 
     const opts = NpmUtilities.getExecOpts(pkg.location);
-    ChildProcessUtilities.spawnStreaming(npmClient, ["run", script, ...args], opts, pkg.name, callback);
+    // prefix is default to `true` if it's undefined
+    const prefixStr = prefix === false ? "" : pkg.name;
+    ChildProcessUtilities.spawnStreaming(npmClient, ["run", script, ...args], opts, prefixStr, callback);
   }
 
   static publishTaggedInDir(tag, pkg, { npmClient, registry }, callback) {

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -27,6 +27,14 @@ export const builder = {
     type: "boolean",
     default: undefined,
   },
+  // This option controls prefix for stream output so that it can be disabled to be friendly
+  // to tools like Visual Studio Code to highlight the raw results
+  prefix: {
+    group: "Command Options:",
+    describe: "Enable prefix for stream output",
+    type: "boolean",
+    default: undefined,
+  },
   parallel: {
     group: "Command Options:",
     describe: "Run command in all packages with unlimited concurrency, streaming prefixed output",
@@ -44,6 +52,7 @@ export default class ExecCommand extends Command {
     return Object.assign({}, super.defaultOptions, {
       bail: true,
       parallel: false,
+      prefix: true,
     });
   }
 
@@ -107,7 +116,8 @@ export default class ExecCommand extends Command {
 
     async.parallel(
       this.filteredPackages.map(pkg => done => {
-        ChildProcessUtilities.spawnStreaming(this.command, this.args, this.getOpts(pkg), pkg.name, done);
+        const prefixStr = this.options.prefix ? pkg.name : "";
+        ChildProcessUtilities.spawnStreaming(this.command, this.args, this.getOpts(pkg), prefixStr, done);
       }),
       callback
     );
@@ -122,7 +132,8 @@ export default class ExecCommand extends Command {
     };
 
     if (this.options.stream) {
-      ChildProcessUtilities.spawnStreaming(this.command, this.args, this.getOpts(pkg), pkg.name, done);
+      const prefixStr = this.options.prefix ? pkg.name : "";
+      ChildProcessUtilities.spawnStreaming(this.command, this.args, this.getOpts(pkg), prefixStr, done);
     } else {
       ChildProcessUtilities.spawn(this.command, this.args, this.getOpts(pkg), done);
     }

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -22,6 +22,14 @@ export const builder = {
     type: "boolean",
     default: undefined,
   },
+  // This option controls prefix for stream output so that it can be disabled to be friendly
+  // to tools like Visual Studio Code to highlight the raw results
+  prefix: {
+    group: "Command Options:",
+    describe: "Enable prefix for stream output",
+    type: "boolean",
+    default: undefined,
+  },
   parallel: {
     group: "Command Options:",
     describe: "Run script in all packages with unlimited concurrency, streaming prefixed output",
@@ -45,6 +53,7 @@ export default class RunCommand extends Command {
     return Object.assign({}, super.defaultOptions, {
       parallel: false,
       stream: false,
+      prefix: true,
     });
   }
 
@@ -153,6 +162,7 @@ export default class RunCommand extends Command {
         args: this.args,
         pkg,
         npmClient: this.npmClient,
+        prefix: this.options.prefix,
       },
       callback
     );

--- a/test/NpmUtilities.js
+++ b/test/NpmUtilities.js
@@ -206,6 +206,32 @@ describe("NpmUtilities", () => {
         expect.any(Function)
       );
     });
+
+    it("runs an npm script in a package with streaming without prefix", () => {
+      const script = "foo";
+      const config = {
+        args: ["--bar", "baz"],
+        pkg: {
+          name: "qux",
+          location: "/test/runScriptInPackageStreaming",
+        },
+        npmClient: "npm",
+        prefix: false,
+      };
+      const callback = () => {};
+
+      NpmUtilities.runScriptInPackageStreaming(script, config, callback);
+
+      expect(ChildProcessUtilities.spawnStreaming).lastCalledWith(
+        "npm",
+        ["run", "foo", "--bar", "baz"],
+        {
+          cwd: config.pkg.location,
+        },
+        "",
+        expect.any(Function)
+      );
+    });
   });
 
   describe(".publishTaggedInDir()", () => {

--- a/test/integration/__snapshots__/lerna-exec.test.js.snap
+++ b/test/integration/__snapshots__/lerna-exec.test.js.snap
@@ -16,6 +16,8 @@ exports[`stderr: test --stream 1`] = `"lerna info version __TEST_VERSION__"`;
 
 exports[`stderr: test --stream 2`] = `"lerna info version __TEST_VERSION__"`;
 
+exports[`stderr: test --stream --no-prefix 1`] = `"lerna info version __TEST_VERSION__"`;
+
 exports[`stderr: without -- 1`] = `"lerna info version __TEST_VERSION__"`;
 
 exports[`stdout: echo LERNA_PACKAGE_NAME 1`] = `

--- a/test/integration/__snapshots__/lerna-run.test.js.snap
+++ b/test/integration/__snapshots__/lerna-run.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`stderr: my-script --parallel --no-prefix 1`] = `
+"lerna info version __TEST_VERSION__
+lerna info run in 2 package(s): npm run my-script --silent --onload-script=false
+lerna success run Ran npm script 'my-script' in packages:
+lerna success - package-1
+lerna success - package-3"
+`;
+
 exports[`stderr: my-script --parallel 1`] = `
 "lerna info version __TEST_VERSION__
 lerna info run in 2 package(s): npm run my-script --silent --onload-script=false
@@ -32,6 +40,15 @@ lerna success - package-3
 lerna success - package-4"
 `;
 
+exports[`stderr: test --stream --no-prefix 1`] = `
+"lerna info version __TEST_VERSION__
+lerna success run Ran npm script 'test' in packages:
+lerna success - package-1
+lerna success - package-2
+lerna success - package-3
+lerna success - package-4"
+`;
+
 exports[`stderr: test --stream 1`] = `
 "lerna info version __TEST_VERSION__
 lerna success run Ran npm script 'test' in packages:
@@ -44,6 +61,13 @@ lerna success - package-4"
 exports[`stdout: my-script --scope 1`] = `"package-1"`;
 
 exports[`stdout: test --ignore 1`] = `"package-4"`;
+
+exports[`stdout: test --stream --no-prefix 1`] = `
+"package-3
+package-4
+package-1
+package-2"
+`;
 
 exports[`stdout: test --stream 1`] = `
 "package-3: package-3

--- a/test/integration/lerna-exec.test.js
+++ b/test/integration/lerna-exec.test.js
@@ -137,6 +137,20 @@ describe("lerna exec", () => {
     expect(stdout).toMatch("package-2: package.json");
   });
 
+  test.concurrent("--stream --no-prefix <cmd>", async () => {
+    const cwd = await initFixture("ExecCommand/basic");
+    const args = ["exec", "--stream", EXEC_TEST_COMMAND, "-C"];
+
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd, env });
+    expect(stderr).toMatchSnapshot("stderr: test --stream --no-prefix");
+
+    // order is non-deterministic, so assert individually
+    expect(stdout).toMatch("file-1.js");
+    expect(stdout).toMatch("package.json");
+    expect(stdout).toMatch("file-2.js");
+    expect(stdout).toMatch("package.json");
+  });
+
   test.concurrent("--bail=false <cmd>", async () => {
     const cwd = await initFixture("ExecCommand/basic");
     const args = ["exec", "--bail=false", "--concurrency=1", "--", "npm run fail-or-succeed"];

--- a/test/integration/lerna-run.test.js
+++ b/test/integration/lerna-run.test.js
@@ -60,6 +60,24 @@ describe("lerna run", () => {
     expect(stderr).toMatchSnapshot("stderr: test --stream");
   });
 
+  test.concurrent("test --stream --no-prefix", async () => {
+    const cwd = await initFixture("RunCommand/integration-lifecycle");
+    const args = [
+      "run",
+      "--stream",
+      "--no-prefix",
+      "test",
+      "--concurrency=1",
+      // args below tell npm to be quiet
+      "--",
+      "--silent",
+      "--onload-script=false",
+    ];
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stdout).toMatchSnapshot("stdout: test --stream --no-prefix");
+    expect(stderr).toMatchSnapshot("stderr: test --stream --no-prefix");
+  });
+
   test.concurrent("test --parallel", async () => {
     const cwd = await initFixture("RunCommand/integration-lifecycle");
     const args = [
@@ -74,7 +92,7 @@ describe("lerna run", () => {
     const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
     expect(stderr).toMatchSnapshot("stderr: test --parallel");
 
-    // order is non-deterministic, so assert each item seperately
+    // order is non-deterministic, so assert each item separately
     expect(stdout).toMatch("package-1: package-1");
     expect(stdout).toMatch("package-2: package-2");
     expect(stdout).toMatch("package-3: package-3");
@@ -95,10 +113,32 @@ describe("lerna run", () => {
     const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
     expect(stderr).toMatchSnapshot("stderr: my-script --parallel");
 
-    // order is non-deterministic, so assert each item seperately
+    // order is non-deterministic, so assert each item separately
     expect(stdout).toMatch("package-1: package-1");
     expect(stdout).not.toMatch("package-2");
     expect(stdout).toMatch("package-3: package-3");
+    expect(stdout).not.toMatch("package-4");
+  });
+
+  test.concurrent("my-script --parallel --no-prefix", async () => {
+    const cwd = await initFixture("RunCommand/basic");
+    const args = [
+      "run",
+      "--parallel",
+      "--no-prefix",
+      "my-script",
+      // args below tell npm to be quiet
+      "--",
+      "--silent",
+      "--onload-script=false",
+    ];
+    const { stdout, stderr } = await execa(LERNA_BIN, args, { cwd });
+    expect(stderr).toMatchSnapshot("stderr: my-script --parallel --no-prefix");
+
+    // order is non-deterministic, so assert each item separately
+    expect(stdout).toMatch("package-1");
+    expect(stdout).not.toMatch("package-2");
+    expect(stdout).toMatch("package-3");
     expect(stdout).not.toMatch("package-4");
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

By default, stream output is prefixed with the originating package name. This flag allows us to disable the prefix (`--no-prefix`) so that the output can be parsed by a tool like Visual Studio Code to highlight the result by type for all packages in the same project.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We set up the monorepo with npm scripts so that we can run `tsc` and `mocha`. When the scripts are 
triggered inside Visual Studio Code, the stream prefix gets in the way and `tsc` problem matcher cannot
recognize the output.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A few test cases are added to the PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
