### PR TITLE
fix(publish): Allow tag check to fail with strong warning

### DIFF
--- a/core/git-utils/index.js
+++ b/core/git-utils/index.js
@@ -70,8 +70,13 @@ function addTag(tag, opts) {
 
 function hasTags(opts) {
   log.silly("hasTags");
+  let yes = false;
 
-  const yes = !!ChildProcessUtilities.execSync("git", ["tag"], opts);
+  try {
+    yes = !!ChildProcessUtilities.execSync("git", ["tag"], opts);
+  } catch (err) {
+    log.verbose("hasTags error", err);
+  }
   log.verbose("hasTags", yes);
 
   return yes;

--- a/core/git-utils/index.js
+++ b/core/git-utils/index.js
@@ -70,16 +70,18 @@ function addTag(tag, opts) {
 
 function hasTags(opts) {
   log.silly("hasTags");
-  let yes = false;
+  let result = false;
 
   try {
-    yes = !!ChildProcessUtilities.execSync("git", ["tag"], opts);
+    result = !!ChildProcessUtilities.execSync("git", ["tag"], opts);
   } catch (err) {
+    log.warn("ENOTAGS", "No git tags were reachable from this branch!");
     log.verbose("hasTags error", err);
   }
-  log.verbose("hasTags", yes);
 
-  return yes;
+  log.verbose("hasTags", result);
+
+  return result;
 }
 
 function getLastTaggedCommit(opts) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When using the `lerna publish` command the `--skip-git` option is not taking in consideration.

In this case, even when using the `--skip-git` option, before the `npm publish`, lerna is trying to get and create the tag for the publishing.

Passing the `s=--skip-git` option should avoid the git interaction on this flow.

## Motivation and Context
Related to https://github.com/lerna/lerna/issues/16

## How Has This Been Tested?
 - Current state:
`lerna publish --skip-git` will check and create the tags before publishing the packages
- This PR:
`lerna publish --skip-git` will skip the tags check and creation and publish the modules to NPM


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [-] I have added tests to cover my changes.
- [-] All new and existing tests passed.

Some tests are not passing, but looks like it is not related to my changes.

I need some help writing a test to cover this flow.
