### PR TITLE
fix(git-utils): Pass --no-verify to `git push`

### DIFF
--- a/core/git-utils/index.js
+++ b/core/git-utils/index.js
@@ -106,9 +106,7 @@ function pushWithTags(remote, tags, opts) {
   log.silly("pushWithTags", [remote, tags]);
 
   return Promise.resolve(exports.getCurrentBranch(opts)).then(branch =>
-    ChildProcessUtilities.exec("git", ["push", remote, branch], opts).then(() =>
-      ChildProcessUtilities.exec("git", ["push", remote].concat(tags), opts)
-    )
+    ChildProcessUtilities.exec("git", ["push", "--no-verify", remote, branch].concat(tags), opts)
   );
 }
 


### PR DESCRIPTION
## Description
Adds the `--no-verify` flag to the git argument in `pushWithTags()`

Also, condenses the two `git push` calls into one call.

Closes #1366

## Motivation and Context
#1366

## How Has This Been Tested?
This function has tests to check that the tags were pushed.
@evocateur stated in #1366 that an integration test to check for the `--no-verify` change would be unnecessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
