### PR TITLE
run npm publish after git push

### DIFF
--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -273,6 +273,12 @@ export default class PublishCommand extends Command {
     if (this.options.skipNpm) {
       callback(null, true);
     } else {
+      if (this.gitEnabled) {
+        this.logger.info("git", "Pushing tags...");
+        this.logger.silly(`new tags: ${this.tags}`);
+        GitUtilities.pushWithTags(this.gitRemote, this.tags, this.execOpts);
+        this.logger.info("git", "git push with tags finished.");
+      }
       this.publishPackagesToNpm(callback);
     }
   }
@@ -298,11 +304,6 @@ export default class PublishCommand extends Command {
         if (updateError) {
           callback(updateError);
           return;
-        }
-
-        if (this.gitEnabled) {
-          this.logger.info("git", "Pushing tags...");
-          GitUtilities.pushWithTags(this.gitRemote, this.tags, this.execOpts);
         }
 
         const message = this.packagesToPublish.map(pkg => ` - ${pkg.name}@${pkg.version}`);


### PR DESCRIPTION
this PR is to address 'double publish' issue. i.e. while one developer commits a change and is running `lerna publish`, another developer commits a new change and starts running `lerna publish` as well. 
At the moment both `lerna publish` will fail but packages will be published, rendering the project into a chaotic state.  An realistic example is illustrated in https://github.com/lerna/lerna/issues/1385

To solve this issue, ideally, we should wrap `npm publish` and `git push with tags` into an transaction and make it atomic. By putting `git push` ahead of `npm publish`,  in the case where `lerna publish` is not running based on latest code,  `git push` will fail and `npm publish` won't be run,  and therefore atomicity is better reflected.

I believe this will have a huge benefit in production use of lerna 

