### PR TITLE
Add --include-filtered-dependents option

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -56,6 +56,11 @@ export const builder = {
     type: "string",
     requiresArg: true,
   },
+  "include-filtered-dependents": {
+    describe: dedent`
+      Include all transitive dependents when running a command, regardless of --scope, --since or --ignore.
+    `,
+  },
   "include-filtered-dependencies": {
     describe: dedent`
       Include all transitive dependencies when running a command, regardless of --scope, --since or --ignore.
@@ -347,6 +352,10 @@ export default class Command {
       if (typeof since === "string") {
         const updated = new UpdatedPackagesCollector(this).getUpdates().map(update => update.package.name);
         this.filteredPackages = this.filteredPackages.filter(pkg => updated.indexOf(pkg.name) > -1);
+      }
+
+      if (this.options.includeFilteredDependents) {
+        this.filteredPackages = PackageUtilities.addDependents(this.filteredPackages, this.packageGraph);
       }
 
       if (this.options.includeFilteredDependencies) {

--- a/src/PackageGraph.js
+++ b/src/PackageGraph.js
@@ -9,6 +9,7 @@ export class PackageGraphNode {
   constructor(pkg) {
     this.package = pkg;
     this.dependencies = [];
+    this.localDependents = [];
   }
 
   satisfies(versionRange) {
@@ -51,6 +52,7 @@ export default class PackageGraph {
 
           if (packageNode.satisfies(depVersion)) {
             node.dependencies.push(depName);
+            packageNode.localDependents.push(node.package.name);
           }
         }
       }

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -92,6 +92,19 @@ export default class PackageUtilities {
 
   /**
    * Takes a list of Packages and returns a list of those same Packages with any Packages
+   * that depend on them. i.e if packageC depended on packageD
+   * `PackageUtilities.addDependents([packageD], this.packageGraph)`
+   * would return [packageC, packageD]
+   * @param {!Array.<Package>} packages The packages to include dependencies for.
+   * @param {!<PackageGraph>} packageGraph The package graph for the whole repository.
+   * @return {Array.<Package>} The packages with any dependencies that were't already included.
+   */
+  static addDependents(packages, packageGraph) {
+    return PackageUtilities.extendList(packages, packageGraph, 'localDependents');
+  }
+
+  /**
+   * Takes a list of Packages and returns a list of those same Packages with any Packages
    * they depend on. i.e if packageA depended on packageB
    * `PackageUtilities.addDependencies([packageA], this.packageGraph)`
    * would return [packageA, packageB]
@@ -100,30 +113,35 @@ export default class PackageUtilities {
    * @return {Array.<Package>} The packages with any dependencies that were't already included.
    */
   static addDependencies(packages, packageGraph) {
-    const dependentPackages = [];
+    return PackageUtilities.extendList(packages, packageGraph, 'dependencies');
+  }
+
+  static extendList(packages, packageGraph, propertyName) {
+    const result = [];
+
+    const packageNodes = packages.map((pkg) => packageGraph.get(pkg.name));
 
     // the current list of packages we are expanding using breadth-first-search
-    const fringe = packages.slice();
+    const fringe = packageNodes.slice();
     const packageExistsInRepository = packageName => !!packageGraph.get(packageName);
-    const packageAlreadyFound = packageName => dependentPackages.some(pkg => pkg.name === packageName);
-    const packageInFringe = packageName => fringe.some(pkg => pkg.name === packageName);
+    const packageAlreadyFound = packageName => result.some(node => node.package.name === packageName);
+    const packageInFringe = packageName => fringe.some(node => node.package.name === packageName);
 
     while (fringe.length !== 0) {
-      const pkg = fringe.shift();
-      const pkgDeps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
+      const node = fringe.shift();
 
-      Object.keys(pkgDeps).forEach(dep => {
+      node[propertyName].forEach(dep => {
         if (packageExistsInRepository(dep) && !packageAlreadyFound(dep) && !packageInFringe(dep)) {
-          fringe.push(packageGraph.get(dep).package);
+          fringe.push(packageGraph.get(dep));
         }
       });
 
-      if (!packageAlreadyFound(pkg.name)) {
-        dependentPackages.push(pkg);
+      if (!packageAlreadyFound(node.package.name)) {
+        result.push(node);
       }
     }
 
-    return dependentPackages;
+    return result.map((node) => node.package);
   }
 
   /**

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -100,7 +100,7 @@ export default class PackageUtilities {
    * @return {Array.<Package>} The packages with any dependencies that were't already included.
    */
   static addDependents(packages, packageGraph) {
-    return PackageUtilities.extendList(packages, packageGraph, 'localDependents');
+    return PackageUtilities.extendList(packages, packageGraph, "localDependents");
   }
 
   /**
@@ -113,13 +113,13 @@ export default class PackageUtilities {
    * @return {Array.<Package>} The packages with any dependencies that were't already included.
    */
   static addDependencies(packages, packageGraph) {
-    return PackageUtilities.extendList(packages, packageGraph, 'dependencies');
+    return PackageUtilities.extendList(packages, packageGraph, "dependencies");
   }
 
   static extendList(packages, packageGraph, propertyName) {
     const result = [];
 
-    const packageNodes = packages.map((pkg) => packageGraph.get(pkg.name));
+    const packageNodes = packages.map(pkg => packageGraph.get(pkg.name));
 
     // the current list of packages we are expanding using breadth-first-search
     const fringe = packageNodes.slice();
@@ -141,7 +141,7 @@ export default class PackageUtilities {
       }
     }
 
-    return result.map((node) => node.package);
+    return result.map(node => node.package);
   }
 
   /**

--- a/test/LsCommand.js
+++ b/test/LsCommand.js
@@ -63,6 +63,14 @@ describe("LsCommand", () => {
     });
   });
 
+  describe("with --include-filtered-dependents", () => {
+    it("should list packages, including filtered ones", async () => {
+      const lernaLs = run(await initFixture("LsCommand/include-filtered-dependencies"));
+      await lernaLs("--scope", "@test/package-1", "--include-filtered-dependents");
+      expect(consoleOutput()).toMatchSnapshot();
+    });
+  });
+
   describe("with an undefined version", () => {
     it("should list packages", async () => {
       const lernaLs = run(await initFixture("LsCommand/undefined-version"));

--- a/test/__snapshots__/LsCommand.js.snap
+++ b/test/__snapshots__/LsCommand.js.snap
@@ -44,6 +44,13 @@ Array [
 ]
 `;
 
+exports[`LsCommand with --include-filtered-dependents should list packages, including filtered ones 1`] = `
+Array [
+  "@test/package-1 v1.0.0 
+@test/package-2 v1.0.0 ",
+]
+`;
+
 exports[`LsCommand with --json should list packages as json objects 1`] = `
 Array [
   Object {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Repeat of https://github.com/lerna/lerna/pull/1393 for 2.x

## Description
<!--- Describe your changes in detail -->
Adds a `localDependents` attribute to `PackageGraphNode`, modifies `addDependencies` to operate more like 3.x and rely on `PackageGraphNode`, and re-uses the BFS for `addDependents`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#611 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the cli on a local repository and added a unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
