### PR TITLE
feat(unit-test): use docker to run unit test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+from node:latest
+label name="lerna/test-runner"
+label maintainer="https://github.com/lerna/lerna"
+
+copy . /opt/lerna
+run apt remove -y git &&\
+    echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu trusty  main" >> /etc/apt/sources.list &&\
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 &&\
+    apt update &&\
+    apt install -y git &&\
+    rm -rf /var/lib/apt/lists/*
+
+workdir /opt/lerna
+run npm install
+
+cmd ["npm","test"]
+    


### PR DESCRIPTION
I've noticed that the unit test is highly dependent on your host machine settings, e.g.
1. if you have a global `.gitignore` file, unit test will fail (`packages/**`, `bin/**`  by default are git ignored but are checked in jest snapshot)
2. if you use `yarn`  to run the test, it will fail because of `package.json` default registry field issue;
3. if your git version is old, it will fail because of `git diff` format issue in snapshot;
4. if your npm version is old, it will fail because of https://github.com/npm/npm/issues/9388#issuecomment-385962805

In short, it is very picky on the environment it runs in, so it's better to use a docker container for that