### PR TITLE
fix(tests): Special handling for Windows CI issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm config set loglevel warn
   - npm install --global npm@latest
-  - set PATH=%APPDATA%\npm;%PATH%
+  - set PATH=%APPDATA%\npm;"C:\Program Files\Git\mingw64\bin";%PATH%
   - npm ci
 
 before_test:

--- a/helpers/cli-runner/index.js
+++ b/helpers/cli-runner/index.js
@@ -12,5 +12,5 @@ function runner(cwd, env) {
     env: Object.assign({ CI: true }, env),
   };
 
-  return (...args) => execa(LERNA_BIN, args, opts);
+  return (...args) => execa("node", [LERNA_BIN].concat(args), opts);
 }

--- a/helpers/cli-runner/index.js
+++ b/helpers/cli-runner/index.js
@@ -9,7 +9,7 @@ module.exports = runner;
 function runner(cwd, env) {
   const opts = {
     cwd,
-    env: Object.assign({ CI: true }, env),
+    env: Object.assign({ CI: "true" }, env),
   };
 
   return (...args) => execa("node", [LERNA_BIN].concat(args), opts);

--- a/integration/lerna-init.test.js
+++ b/integration/lerna-init.test.js
@@ -11,14 +11,12 @@ describe("lerna init", () => {
   const parsePackageJson = cwd => loadJsonFile(path.join(cwd, "package.json"));
   const parseLernaJson = cwd => loadJsonFile(path.join(cwd, "lerna.json"));
   const loadMetaData = cwd => Promise.all([parsePackageJson(cwd), parseLernaJson(cwd)]);
-  const fsPromisesExperimentalWarning =
-    "(node:7121) ExperimentalWarning: The fs.promises API is experimental\n";
 
   test("initializes empty directory", async () => {
     const cwd = tempy.directory();
 
     const { stderr } = await cliRunner(cwd)("init");
-    expect(stderr.replace(fsPromisesExperimentalWarning, "")).toMatchSnapshot("stderr");
+    expect(stderr).toMatchSnapshot("stderr");
 
     const [packageJson, lernaJson] = await loadMetaData(cwd);
     expect(packageJson).toMatchSnapshot("package.json");
@@ -29,7 +27,7 @@ describe("lerna init", () => {
     const cwd = await initFixture("lerna-init");
 
     const { stderr } = await cliRunner(cwd)("init", "--exact");
-    expect(stderr.replace(fsPromisesExperimentalWarning, "")).toMatchSnapshot("stderr");
+    expect(stderr).toMatchSnapshot("stderr");
 
     const [packageJson, lernaJson] = await loadMetaData(cwd);
     expect(packageJson).toMatchSnapshot("package.json");

--- a/integration/lerna-init.test.js
+++ b/integration/lerna-init.test.js
@@ -11,12 +11,14 @@ describe("lerna init", () => {
   const parsePackageJson = cwd => loadJsonFile(path.join(cwd, "package.json"));
   const parseLernaJson = cwd => loadJsonFile(path.join(cwd, "lerna.json"));
   const loadMetaData = cwd => Promise.all([parsePackageJson(cwd), parseLernaJson(cwd)]);
+  const fsPromisesExperimentalWarning =
+    "(node:7121) ExperimentalWarning: The fs.promises API is experimental\n";
 
   test("initializes empty directory", async () => {
     const cwd = tempy.directory();
 
     const { stderr } = await cliRunner(cwd)("init");
-    expect(stderr).toMatchSnapshot("stderr");
+    expect(stderr.replace(fsPromisesExperimentalWarning, "")).toMatchSnapshot("stderr");
 
     const [packageJson, lernaJson] = await loadMetaData(cwd);
     expect(packageJson).toMatchSnapshot("package.json");
@@ -27,7 +29,7 @@ describe("lerna init", () => {
     const cwd = await initFixture("lerna-init");
 
     const { stderr } = await cliRunner(cwd)("init", "--exact");
-    expect(stderr).toMatchSnapshot("stderr");
+    expect(stderr.replace(fsPromisesExperimentalWarning, "")).toMatchSnapshot("stderr");
 
     const [packageJson, lernaJson] = await loadMetaData(cwd);
     expect(packageJson).toMatchSnapshot("package.json");


### PR DESCRIPTION
I've noticed the `master` build [is failing](https://travis-ci.org/lerna/lerna/jobs/377976519). I'm trying to fix the problem.

## Description
1. When ran on Node 10, there is a warning about `fs.promises` being experimental. This warning fails two tests, which rely on exact string matching. The warning is irrelevant in the testing context. I turned off the warnings per advice under this PR.
2. Several tests failed on Windows, because they could not find git binaries in PATH (specifically `git-receive-pack`). I found a working solution in the [go-git's AppVeyor config](https://github.com/src-d/go-git/blob/master/appveyor.yml).
3. The Windows builds were failing on `integration\lerna-exec.test.js`. It is a super weird issue with environment variables and to me it seems like a bug in Node or AppVeyor. It took me several days to debug. Details are in the commit message.

## Motivation and Context
I want to contribute to this project and I want to be sure whether I broke something or not.

## How Has This Been Tested?
:)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
