### PR TITLE
docs: Update `--npm-client` details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,8 +1028,12 @@ $ lerna bootstrap --hoist --nohoist=babel-*
 
 #### --npm-client [client]
 
-Install external dependencies using `[client] install`. Must be an executable
-that knows how to install npm dependencies.
+This will apply to actions below:
+* Install external dependencies using `[client] install`
+* Publish packages with `[client] publish`
+* Run scripts with `[client] run [command]`
+
+Must be an executable that knows how to install npm dependencies, publish packages, and run scripts.
 
 ```sh
 $ lerna bootstrap --npm-client=yarn


### PR DESCRIPTION
## Description

The `npmClient` option is already used for publish, but not written in doc
So I added it.

Documents additions from #1145