### PR TITLE
fix(publish): Exit early when publishing w/o commits

### DIFF
--- a/commands/publish/__tests__/get-current-branch.test.js
+++ b/commands/publish/__tests__/get-current-branch.test.js
@@ -1,10 +1,21 @@
 "use strict";
 
-const initFixture = require("@lerna-test/init-fixture")(__dirname);
 const getCurrentBranch = require("../lib/get-current-branch");
+const initFixture = require("@lerna-test/init-fixture")(__dirname);
+const initFixtureWithoutCommits = require("@lerna-test/init-fixture")(__dirname, true);
 
 test("getCurrentBranch", async () => {
   const cwd = await initFixture("root-manifest-only");
 
   expect(getCurrentBranch({ cwd })).toBe("master");
+});
+
+test("getCurrentBranch without commit", async () => {
+  const cwd = await initFixtureWithoutCommits("root-manifest-only");
+  expect.assertions(1);
+  try {
+    await getCurrentBranch({ cwd });
+  } catch (err) {
+    expect(err.message).toMatch(/Command failed: git rev-parse --abbrev-ref HEAD.*/);
+  }
 });

--- a/commands/publish/__tests__/get-current-branch.test.js
+++ b/commands/publish/__tests__/get-current-branch.test.js
@@ -2,7 +2,6 @@
 
 const getCurrentBranch = require("../lib/get-current-branch");
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
-const initFixtureWithoutCommits = require("@lerna-test/init-fixture")(__dirname, true);
 
 test("getCurrentBranch", async () => {
   const cwd = await initFixture("root-manifest-only");
@@ -11,7 +10,7 @@ test("getCurrentBranch", async () => {
 });
 
 test("getCurrentBranch without commit", async () => {
-  const cwd = await initFixtureWithoutCommits("root-manifest-only");
+  const cwd = await initFixture("root-manifest-only", false);
   expect.assertions(1);
   try {
     await getCurrentBranch({ cwd });

--- a/commands/publish/__tests__/get-current-branch.test.js
+++ b/commands/publish/__tests__/get-current-branch.test.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const getCurrentBranch = require("../lib/get-current-branch");
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
+const getCurrentBranch = require("../lib/get-current-branch");
 
 test("getCurrentBranch", async () => {
   const cwd = await initFixture("root-manifest-only");

--- a/commands/publish/__tests__/is-anything-commited.test.js
+++ b/commands/publish/__tests__/is-anything-commited.test.js
@@ -1,9 +1,8 @@
 "use strict";
 
 const execa = require("execa");
-const isAnythingCommited = require("../lib/is-anything-commited");
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
-const initFixtureWithoutCommits = require("@lerna-test/init-fixture")(__dirname, true);
+const isAnythingCommited = require("../lib/is-anything-commited");
 
 test("isAnythingCommited", async () => {
   const cwd = await initFixture("root-manifest-only");
@@ -12,7 +11,7 @@ test("isAnythingCommited", async () => {
 });
 
 test("isAnythingCommited without and with a commit", async () => {
-  const cwd = await initFixtureWithoutCommits("root-manifest-only");
+  const cwd = await initFixture("root-manifest-only", false);
 
   expect(isAnythingCommited({ cwd })).toBe(false);
 

--- a/commands/publish/__tests__/is-anything-commited.test.js
+++ b/commands/publish/__tests__/is-anything-commited.test.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const execa = require("execa");
+const isAnythingCommited = require("../lib/is-anything-commited");
+const initFixture = require("@lerna-test/init-fixture")(__dirname);
+const initFixtureWithoutCommits = require("@lerna-test/init-fixture")(__dirname, true);
+
+test("isAnythingCommited", async () => {
+  const cwd = await initFixture("root-manifest-only");
+
+  expect(isAnythingCommited({ cwd })).toBe(true);
+});
+
+test("isAnythingCommited without and with a commit", async () => {
+  const cwd = await initFixtureWithoutCommits("root-manifest-only");
+
+  expect(isAnythingCommited({ cwd })).toBe(false);
+
+  await execa("git", ["commit", "--allow-empty", "-m", "change"], { cwd });
+
+  expect(isAnythingCommited({ cwd })).toBe(true);
+});

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -24,6 +24,7 @@ const gitAdd = require("@lerna-test/git-add");
 const gitTag = require("@lerna-test/git-tag");
 const gitCommit = require("@lerna-test/git-commit");
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
+
 const showCommit = require("@lerna-test/show-commit");
 const getCommitMessage = require("@lerna-test/get-commit-message");
 

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -24,7 +24,6 @@ const gitAdd = require("@lerna-test/git-add");
 const gitTag = require("@lerna-test/git-tag");
 const gitCommit = require("@lerna-test/git-commit");
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
-const initFixtureWithoutCommits = require("@lerna-test/init-fixture")(__dirname, true);
 const showCommit = require("@lerna-test/show-commit");
 const getCommitMessage = require("@lerna-test/get-commit-message");
 
@@ -228,7 +227,7 @@ describe("PublishCommand", () => {
 
   it("exists with an error when no commits are present", async () => {
     expect.assertions(2);
-    const testDir = await initFixtureWithoutCommits("normal");
+    const testDir = await initFixture("normal", false);
     try {
       await lernaPublish(testDir)();
     } catch (err) {

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -24,6 +24,7 @@ const gitAdd = require("@lerna-test/git-add");
 const gitTag = require("@lerna-test/git-tag");
 const gitCommit = require("@lerna-test/git-commit");
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
+const initFixtureWithoutCommits = require("@lerna-test/init-fixture")(__dirname, true);
 const showCommit = require("@lerna-test/show-commit");
 const getCommitMessage = require("@lerna-test/get-commit-message");
 
@@ -223,6 +224,19 @@ describe("PublishCommand", () => {
       expect(warning).toMatch("behind remote upstream");
       expect(warning).toMatch("exiting");
     });
+  });
+
+  it("exists with an error when no commits are present", async () => {
+    expect.assertions(2);
+    const testDir = await initFixtureWithoutCommits("normal");
+    try {
+      await lernaPublish(testDir)();
+    } catch (err) {
+      expect(err.prefix).toBe("ENOCOMMIT");
+      expect(err.message).toBe(
+        "No commits in this repository. Please commit something before using publish."
+      );
+    }
   });
 
   it("exits with an error when git HEAD is detached", async () => {

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -24,7 +24,6 @@ const gitAdd = require("@lerna-test/git-add");
 const gitTag = require("@lerna-test/git-tag");
 const gitCommit = require("@lerna-test/git-commit");
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
-
 const showCommit = require("@lerna-test/show-commit");
 const getCommitMessage = require("@lerna-test/get-commit-message");
 

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -34,6 +34,7 @@ const gitPush = require("./lib/git-push");
 const gitTag = require("./lib/git-tag");
 const isBehindUpstream = require("./lib/is-behind-upstream");
 const isBreakingChange = require("./lib/is-breaking-change");
+const isAnythingCommited = require("./lib/is-anything-commited");
 
 module.exports = factory;
 
@@ -81,6 +82,13 @@ class PublishCommand extends Command {
 
     // git validation, if enabled, should happen before updates are calculated and versions picked
     if (this.gitEnabled) {
+      if (!isAnythingCommited(this.execOpts)) {
+        throw new ValidationError(
+          "ENOCOMMIT",
+          "No commits in this repository. Please commit something before using publish."
+        );
+      }
+
       this.currentBranch = getCurrentBranch(this.execOpts);
 
       if (this.currentBranch === "HEAD") {

--- a/commands/publish/lib/is-anything-commited.js
+++ b/commands/publish/lib/is-anything-commited.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const log = require("npmlog");
+const childProcess = require("@lerna/child-process");
+
+module.exports = isAnythingCommited;
+
+function isAnythingCommited(opts) {
+  log.silly("isAnythingCommited");
+
+  const anyCommits = childProcess.execSync("git", ["rev-list", "--count", "--all", "--max-count=1"], opts);
+
+  log.verbose("isAnythingCommited", anyCommits);
+
+  return Boolean(parseInt(anyCommits, 10));
+}

--- a/helpers/init-fixture/index.js
+++ b/helpers/init-fixture/index.js
@@ -8,9 +8,17 @@ const gitInit = require("@lerna-test/git-init");
 
 module.exports = initFixture;
 
-function initFixture(startDir) {
+function initFixture(startDir, skipCommit) {
   return (fixtureName, commitMessage = "Init commit") => {
     const cwd = tempy.directory();
+
+    if (skipCommit) {
+      return Promise.resolve()
+        .then(() => process.chdir(cwd))
+        .then(() => copyFixture(cwd, fixtureName, startDir))
+        .then(() => gitInit(cwd, "."))
+        .then(() => cwd);
+    }
 
     return Promise.resolve()
       .then(() => process.chdir(cwd))

--- a/helpers/init-fixture/index.js
+++ b/helpers/init-fixture/index.js
@@ -23,4 +23,5 @@ function initFixture(startDir) {
     }
 
     return chain.then(() => cwd);
+  };
 }

--- a/helpers/init-fixture/index.js
+++ b/helpers/init-fixture/index.js
@@ -8,24 +8,19 @@ const gitInit = require("@lerna-test/git-init");
 
 module.exports = initFixture;
 
-function initFixture(startDir, skipCommit) {
+function initFixture(startDir) {
   return (fixtureName, commitMessage = "Init commit") => {
     const cwd = tempy.directory();
+    let chain = Promise.resolve();
 
-    if (skipCommit) {
-      return Promise.resolve()
-        .then(() => process.chdir(cwd))
-        .then(() => copyFixture(cwd, fixtureName, startDir))
-        .then(() => gitInit(cwd, "."))
-        .then(() => cwd);
+    chain = chain.then(() => process.chdir(cwd));
+    chain = chain.then(() => copyFixture(cwd, fixtureName, startDir));
+    chain = chain.then(() => gitInit(cwd, "."));
+
+    if (commitMessage) {
+      chain = chain.then(() => gitAdd(cwd, "-A"));
+      chain = chain.then(() => gitCommit(cwd, commitMessage));
     }
 
-    return Promise.resolve()
-      .then(() => process.chdir(cwd))
-      .then(() => copyFixture(cwd, fixtureName, startDir))
-      .then(() => gitInit(cwd, "."))
-      .then(() => gitAdd(cwd, "-A"))
-      .then(() => gitCommit(cwd, commitMessage))
-      .then(() => cwd);
-  };
+    return chain.then(() => cwd);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Running the publish command on a new initialized lerna repo, e.g. with no commits at all, will lead to an error message as reported in issue #773. This change will add a test if there are any commits and will exit the publish command with a more elaborated error message in order to push the user in the right direction what happened and why publish won't proceed.

## Motivation and Context
The issue is described in #773. The error message leads the user in a wrong direction what the issue with the failing publish really is: there are no commits, therefore there's nothing to publish.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I refactored the init-fixture in order to prepare the test environment without any commits. Afterwards I wrote the tests for the added functionality, which is located in `commands/publish/lib/is-anything-commited.js` and updated the tests for this and for `get-current-branch.js` as well.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The change affects `@lerna-test/init-fixture` as well as `commands/publish/get-current-branch.js`. Tested on macOS 10.13.4 w/ git version 2.15.1 (Apple Git-101).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
