### PR TITLE
feat(add): Add `--exact` option to `lerna add`

### DIFF
--- a/commands/add/README.md
+++ b/commands/add/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```sh
-$ lerna add <package>[@version] [--dev]
+$ lerna add <package>[@version] [--dev] [--exact]
 ```
 
 Add local or remote `package` as dependency to packages in the current Lerna repo.
@@ -24,6 +24,14 @@ If no `version` specifier is provided, it defaults to the `latest` dist-tag, jus
 ### `--dev`
 
 Add the new package to `devDependencies` instead of `dependencies`.
+
+### --exact
+
+```sh
+$ lerna add --exact
+```
+
+Add the new package with an exact version (e.g., `1.0.1`) rather than the default `^` semver range (e.g., `^1.0.1`).
 
 ## Examples
 

--- a/commands/add/__tests__/add-command.test.js
+++ b/commands/add/__tests__/add-command.test.js
@@ -87,6 +87,16 @@ describe("AddCommand", () => {
     expect(await readPkg(testDir, "packages/package-2")).toDependOn("@test/package-1", "~1");
   });
 
+  it("should reference exact version if --exact", async () => {
+    const testDir = await initFixture("basic");
+
+    await lernaAdd(testDir)("@test/package-1", "--exact");
+
+    expect(await readPkg(testDir, "packages/package-2")).toDependOn("@test/package-1", "1.0.0", {
+      exact: true,
+    });
+  });
+
   it("should add target package to devDependencies", async () => {
     const testDir = await initFixture("basic");
 
@@ -153,7 +163,7 @@ describe("AddCommand", () => {
 
     await lernaAdd(testDir)("tiny-tarball@1.0.0");
 
-    expect(await readPkg(testDir, "packages/package-1")).toDependOn("tiny-tarball", "1.0.0");
+    expect(await readPkg(testDir, "packages/package-1")).toDependOn("tiny-tarball", "1.0.0", { exact: true });
   });
 
   it("should bootstrap changed packages", async () => {
@@ -198,5 +208,16 @@ describe("AddCommand", () => {
     await lernaAdd(testDir)("@test/package-1");
 
     expect(bootstrap).not.toHaveBeenCalled();
+  });
+
+  it("should reset a dependency from caret to exact", async () => {
+    const testDir = await initFixture("basic");
+
+    await lernaAdd(testDir)("@test/package-1");
+    await lernaAdd(testDir)("@test/package-1", "--exact");
+
+    expect(await readPkg(testDir, "packages/package-2")).toDependOn("@test/package-1", "1.0.0", {
+      exact: true,
+    });
   });
 });

--- a/commands/add/command.js
+++ b/commands/add/command.js
@@ -26,6 +26,12 @@ exports.builder = yargs => {
         alias: "D",
         describe: "Save to devDependencies",
       },
+      exact: {
+        group: "Command Options:",
+        type: "boolean",
+        alias: "E",
+        describe: "Save version exactly",
+      },
     });
 
   return filterable(yargs);

--- a/commands/add/index.js
+++ b/commands/add/index.js
@@ -29,6 +29,9 @@ class AddCommand extends Command {
     this.dirs = new Set(this.options.globs.map(fp => path.resolve(this.project.rootPath, fp)));
     this.selfSatisfied = this.packageSatisfied();
 
+    // https://docs.npmjs.com/misc/config#save-prefix
+    this.savePrefix = this.options.exact ? "" : "^";
+
     if (this.packageGraph.has(this.spec.name) && !this.selfSatisfied) {
       const available = this.packageGraph.get(this.spec.name).version;
 
@@ -107,7 +110,7 @@ class AddCommand extends Command {
         return true;
       }
 
-      return getRangeToReference(this.spec, deps) !== deps[targetName];
+      return getRangeToReference(this.spec, deps, this.savePrefix) !== deps[targetName];
     });
 
     return result;
@@ -118,7 +121,7 @@ class AddCommand extends Command {
 
     return pMap(this.packagesToChange, pkg => {
       const deps = this.getPackageDeps(pkg);
-      const range = getRangeToReference(this.spec, deps);
+      const range = getRangeToReference(this.spec, deps, this.savePrefix);
 
       this.logger.verbose("add", `${targetName}@${range} as ${this.dependencyType} in ${pkg.name}`);
       deps[targetName] = range;

--- a/commands/add/lib/get-range-to-reference.js
+++ b/commands/add/lib/get-range-to-reference.js
@@ -4,11 +4,11 @@ const semver = require("semver");
 
 module.exports = getRangeToReference;
 
-function getRangeToReference(spec, deps) {
+function getRangeToReference(spec, deps, prefix) {
   const current = deps[spec.name];
-  const resolved = spec.type === "tag" ? `^${spec.version}` : spec.fetchSpec;
+  const resolved = spec.type === "tag" ? `${prefix}${spec.version}` : spec.fetchSpec;
 
-  if (current && semver.intersects(current, resolved)) {
+  if (prefix && current && semver.intersects(current, resolved)) {
     return current;
   }
 

--- a/helpers/pkg-matchers/index.js
+++ b/helpers/pkg-matchers/index.js
@@ -21,7 +21,8 @@ const matchBinaryLinks = () => (pkgRef, raw) => {
       ? inputs.reduce((acc, input) => [...acc, input, [input, "cmd"].join(".")], [])
       : inputs;
 
-  const expectation = `expected ${pkg.name} to link to ${links.join(", ")}`;
+  const expectedName = `expected ${pkg.name}`;
+  const expectedAction = `to link to ${links.join(", ")}`;
 
   let found;
 
@@ -29,7 +30,10 @@ const matchBinaryLinks = () => (pkgRef, raw) => {
     found = fs.readdirSync(pkg.binLocation);
   } catch (err) {
     if (links.length === 0 && err.code === "ENOENT") {
-      return { message: "expected no binary links", pass: true };
+      return {
+        message: () => `${expectedName} to have binary links`,
+        pass: true,
+      };
     }
 
     throw err;
@@ -40,7 +44,8 @@ const matchBinaryLinks = () => (pkgRef, raw) => {
 
   if (missing.length > 0 || superfluous.length > 0) {
     const message = [
-      expectation,
+      expectedName,
+      expectedAction,
       missing.length > 0 ? `missing: ${missing.join(", ")}` : "",
       superfluous.length > 0 ? `superfluous: ${superfluous.join(", ")}` : "",
     ]
@@ -48,13 +53,13 @@ const matchBinaryLinks = () => (pkgRef, raw) => {
       .join("\n");
 
     return {
-      message,
+      message: () => message,
       pass: false,
     };
   }
 
   return {
-    message: expectation,
+    message: () => `${expectedName} not ${expectedAction}`,
     pass: true,
   };
 };
@@ -64,12 +69,14 @@ const matchDependency = dependencyType => (manifest, pkg, range) => {
   const id = [pkg, range].filter(Boolean).join("@");
   const verb = dependencyType === "dependencies" ? "depend" : "dev-depend";
 
-  const expectation = `expected ${manifest.name} to ${verb} on ${id}`;
+  const expectedName = `expected ${manifest.name}`;
+  const expectedAction = `to ${verb} on ${id}`;
+  const expectation = `${expectedName} ${expectedAction}`;
   const json = JSON.stringify(manifest[dependencyType], null, "  ");
 
   if (noDeps) {
     return {
-      message: `${expectation} but no .${dependencyType} specified`,
+      message: () => `${expectation} but no .${dependencyType} specified`,
       pass: false,
     };
   }
@@ -78,7 +85,7 @@ const matchDependency = dependencyType => (manifest, pkg, range) => {
 
   if (missingDep) {
     return {
-      message: `${expectation} but it is missing from .${dependencyType}\n${json}`,
+      message: () => `${expectation} but it is missing from .${dependencyType}\n${json}`,
       pass: false,
     };
   }
@@ -88,13 +95,13 @@ const matchDependency = dependencyType => (manifest, pkg, range) => {
 
   if (mismatchedDep) {
     return {
-      message: `${expectation} but ${version} does not satisfy ${range}\n${json}`,
+      message: () => `${expectation} but ${version} does not satisfy ${range}\n${json}`,
       pass: false,
     };
   }
 
   return {
-    message: expectation,
+    message: () => `${expectedName} not ${expectedAction}`,
     pass: true,
   };
 };
@@ -104,8 +111,9 @@ const X_OK = (fs.constants || fs).X_OK;
 
 const matchExecutableFile = () => (pkgRef, raw) => {
   const files = Array.isArray(raw) ? raw : [raw];
-  const expectation = `expected ${files.join(", ")} to be executable`;
-
+  const expectedFiles = `expected ${files.join(", ")}`;
+  const expectedAction = "to be executable";
+  const expectation = `${expectedFiles} ${expectedAction}`;
   const pkg = toPackage(pkgRef);
 
   const failed = files.filter(file => {
@@ -120,11 +128,11 @@ const matchExecutableFile = () => (pkgRef, raw) => {
   const verb = failed.length > 1 ? "were" : "was";
 
   const message = pass
-    ? expectation
+    ? `${expectedFiles} not ${expectedAction}`
     : `${expectation} while ${failed.join(", ")} ${verb} found to be not executable.`;
 
   return {
-    message,
+    message: () => message,
     pass,
   };
 };


### PR DESCRIPTION
## Description

This PR adds an `--exact` flag to `lerna add` for installing dependencies at a fixed version, and it ensures that `config.commands.add.exact` is able to override the setting.

## Motivation and Context

Both `npm install` and `yarn add` are able to install dependencies at a fixed version using `--save-exact` and `--exact`, respectively. `lerna` has an `exact` option available in `init` and `publish`, and some users expect that behavior to also exist in `add`.

Closes #1470

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I updated the unit tests to cover the new functionality. I also `yarn link`ed lerna and tested on a local monorepo:

- [x] `lerna add --exact` to add new remote dependency
- [x] `lerna add --exact` to move `^` remote dependency to exact
- [x] `lerna add` with `commands.add.exact` in `lerna.json` set to true
- [x] `lerna add` with `exact` in `lerna.json` set to true
- [x] `lerna add` (with config in lerna.json) to add new local dependency
- [x] `lerna add` (with config in lerna.json) to move `^` local dependency to exact

**Setup**
- macOS 10.13
- Node v8.11.2
- npm 6.1.0
- yarn 1.7.0

During the course of updating the unit tests, I noticed that the `pkg-matchers` `extend` matchers were not actually returning the correct objects, so I fixed those up as well. The object returned should be...

```js
{
  pass: boolean,
  message: () => string
}
```

...and `message` for `pass: true` should be for the `.not` case. See [jest docs](https://facebook.github.io/jest/docs/en/expect.html#expectextendmatchers).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
