### PR TITLE
README. The configuration for custom message for releases section is missing an s.

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ This can be configured in lerna.json, as well:
 
 ```json
 {
-  "command": {
+  "commands": {
     "publish": {
       "message": "chore(release): publish %s"
     }


### PR DESCRIPTION
## Description
The is an error in the readme, specifically in the [publish](https://github.com/lerna/lerna#publish) section.
The provided example for configuring the custom publish message is missing an s in `commands`:

> If the message contains `%s`, it will be replaced with the new global version version number prefixed with a "v".
> If the message contains `%v`, it will be replaced with the new global version version number without the leading "v".
> Note that this only applies when using the default "fixed" versioning mode, as there is no "global" version when using `--independent`.
> This can be configured in lerna.json, as well:
> ```json
> {
>  "commands": {
>     "publish": {
>       "message": "chore(release): publish %s"
>     }
>   }
> }

`command*s*`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
