### PR TITLE
feat: add verify flag to bypass --no-verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,14 @@ and you are not on the branch `master` lerna will prevent you from publishing. T
 $ lerna publish --allow-branch my-new-feature
 ```
 
+#### --verify
+
+```sh
+$ lerna publish --git-verify
+```
+
+When run with this flag, `publish` will run the git command without `--no-verify`, which means all commit hooks will run.
+
 ### updated
 
 ```sh

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -50,7 +50,11 @@ export default class GitUtilities {
 
   static commit(message, opts) {
     log.silly("commit", message);
-    const args = ["commit", "--no-verify"];
+    const args = ["commit"];
+
+    if (opts && opts.noVerify) {
+      args.push("--no-verify");
+    }
 
     if (message.indexOf(EOL) > -1) {
       // Use tempfile to allow multi\nline strings.

--- a/src/commands/PublishCommand.js
+++ b/src/commands/PublishCommand.js
@@ -141,6 +141,12 @@ export const builder = {
     describe: "Specify which branches to allow publishing from.",
     type: "array",
   },
+  "git-verify": {
+    group: "Command Options:",
+    describe: "Run git commit without --no-verify flag",
+    type: "boolean",
+    default: false,
+  },
 };
 
 export default class PublishCommand extends Command {
@@ -153,6 +159,7 @@ export default class PublishCommand extends Command {
       tempTag: false,
       yes: false,
       allowBranch: false,
+      gitVerify: false,
     });
   }
 
@@ -169,6 +176,7 @@ export default class PublishCommand extends Command {
   }
 
   initialize(callback) {
+    this.execOpts.noVerify = this.options.gitVerify !== true;
     this.gitRemote = this.options.gitRemote || "origin";
     this.gitEnabled = !(this.options.canary || this.options.skipGit);
 

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -88,11 +88,27 @@ describe("GitUtilities", () => {
       const opts = { cwd: "oneline" };
       GitUtilities.commit("foo", opts);
 
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git", ["commit", "-m", "foo"], opts);
+      expect(tempWrite.sync).not.toBeCalled();
+    });
+
+    it("calls git commit with no-verify", () => {
+      const opts = { cwd: "oneline", noVerify: true };
+      GitUtilities.commit("foo", opts);
+
       expect(ChildProcessUtilities.execSync).lastCalledWith(
         "git",
         ["commit", "--no-verify", "-m", "foo"],
         opts
       );
+      expect(tempWrite.sync).not.toBeCalled();
+    });
+
+    it("calls git commit without no-verify", () => {
+      const opts = { cwd: "oneline", noVerify: false };
+      GitUtilities.commit("foo", opts);
+
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git", ["commit", "-m", "foo"], opts);
       expect(tempWrite.sync).not.toBeCalled();
     });
 
@@ -102,11 +118,7 @@ describe("GitUtilities", () => {
       const opts = { cwd: "multiline" };
       GitUtilities.commit(`foo${EOL}bar`, opts);
 
-      expect(ChildProcessUtilities.execSync).lastCalledWith(
-        "git",
-        ["commit", "--no-verify", "-F", "TEMPFILE"],
-        opts
-      );
+      expect(ChildProcessUtilities.execSync).lastCalledWith("git", ["commit", "-F", "TEMPFILE"], opts);
       expect(tempWrite.sync).lastCalledWith(`foo${EOL}bar`, "lerna-commit.txt");
     });
   });

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -804,6 +804,57 @@ describe("PublishCommand", () => {
   });
 
   /** =========================================================================
+   * NORMAL - GIT-VERIFY
+   * ======================================================================= */
+
+  describe("normal mode with --git-verify", () => {
+    let testDir;
+
+    beforeEach(() =>
+      initFixture("PublishCommand/normal").then(dir => {
+        testDir = dir;
+      })
+    );
+
+    it("commits changes running commit hooks (no --no-verify option)", () =>
+      run(testDir)("-m", "message", "--git-verify").then(() => {
+        expect(GitUtilities.commit).lastCalledWith("message", { cwd: testDir, noVerify: false });
+      }));
+
+    it("commits changes without running commit hooks", () =>
+      run(testDir)("-m", "message").then(() => {
+        expect(GitUtilities.commit).lastCalledWith("message", execOpts(testDir));
+      }));
+  });
+
+  /** =========================================================================
+   * INDEPENDENT - GIT-VERIFY
+   * ======================================================================= */
+
+  describe("independent mode with --git-verify", () => {
+    let testDir;
+
+    beforeEach(() =>
+      initFixture("PublishCommand/independent").then(dir => {
+        testDir = dir;
+      })
+    );
+
+    it("commits changes running commit hooks (no --no-verify option)", () =>
+      run(testDir)("-m", "message", "--git-verify").then(() => {
+        expect(GitUtilities.commit).lastCalledWith(expect.stringContaining("message"), {
+          cwd: testDir,
+          noVerify: false,
+        });
+      }));
+
+    it("commits changes without running commit hooks", () =>
+      run(testDir)("-m", "message").then(() => {
+        expect(GitUtilities.commit).lastCalledWith(expect.stringContaining("message"), execOpts(testDir));
+      }));
+  });
+
+  /** =========================================================================
    * CONVENTIONAL COMMITS
    * ======================================================================= */
 


### PR DESCRIPTION
## Description
Some setups (e.g. Gerrit) require commit hooks that add a change id.

So that lerna publish can properly push the commit in these
environments, the `--no-verify` commit flag should not be specified.
This adds a new flag `verify`, that if set to `true` will run the commit
command without thta option, so that all hooks are run.

## Motivation and Context
lerna publish does not work in Gerrit environments

## How Has This Been Tested?
- Tested publish in our Gerrit environment with --verify option
- Added unit tests for option

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
