### PR TITLE
Fix links to flag documentation

### DIFF
--- a/commands/run/README.md
+++ b/commands/run/README.md
@@ -17,7 +17,7 @@ Run an [npm script](https://docs.npmjs.com/misc/scripts) in each package that co
 
 ## Options
 
-`lerna run` respects the `--concurrency`, `--scope`, and `--ignore` flags (see [Filter Flags](https://www.npmjs.com/package/@lerna/filter-options)).
+`lerna run` respects the `--concurrency`, `--scope`, and `--ignore` flags (see [Global Flags](https://github.com/lerna/lerna/tree/master/core/global-options) and [Filter Flags](https://github.com/lerna/lerna/tree/master/core/filter-options)).
 
 ```sh
 $ lerna run --scope my-component test


### PR DESCRIPTION
Links redirect to documentation and not to the flags npm repository

## Motivation and Context
I was looking for examples of how to use the --concurrency option and I got lost with links redirecting to NPM repo with no README. After searching, I found the correct link to Filter Flags but --concurrency was in globals.
