### PR TITLE
docs: Fix link to hoist docs in bootstrap README

### DIFF
--- a/commands/bootstrap/README.md
+++ b/commands/bootstrap/README.md
@@ -49,7 +49,7 @@ the default is `**` (hoist everything). This option only affects the
 $ lerna bootstrap --hoist
 ```
 
-For background on `--hoist`, see the [hoist documentation](doc/hoist.md).
+For background on `--hoist`, see the [hoist documentation](../../doc/hoist.md).
 
 Note: If packages depend on different _versions_ of an external dependency,
 the most commonly used version will be hoisted, and a warning will be emitted.


### PR DESCRIPTION
The current hoist document link in bootstrap command README file is wrong, this PR fix it.

## Description
Modify the relative path to a correct one.

## Motivation and Context
This correction could help developers find out hoist document quickly. 

## How Has This Been Tested?
Document change, tested on my fork README page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
