### PR TITLE
`git describe --tags --abbrev=0` instead of `git describe --abbrev=0`

### DIFF
--- a/utils/collect-updates/collect-updates.js
+++ b/utils/collect-updates/collect-updates.js
@@ -27,7 +27,7 @@ function collectUpdates(filteredPackages, packageGraph, execOpts, commandOptions
       committish = `${sha}^..${sha}`;
     } else if (!committish) {
       // attempt to find the last annotated tag in the current branch
-      committish = childProcess.execSync("git", ["describe", "--abbrev=0"], execOpts);
+      committish = childProcess.execSync("git", ["describe", "--tags", "--abbrev=0"], execOpts);
     }
   }
 


### PR DESCRIPTION
Fix for https://github.com/lerna/lerna/issues/16

## Description

Added `--tags` to `git describe` call

## Motivation and Context

There was an error that occurred when running `lerna updated`

## How Has This Been Tested?

Run `lerna updated` on a repo that has not been published by lerna.

## Types of changes

Add `--tags` option. Same solution as a previously merged fix - https://github.com/lerna/lerna/pull/17
