### PR TITLE
docs: Clarify that lerna list takes all filter flags

### DIFF
--- a/commands/list/README.md
+++ b/commands/list/README.md
@@ -29,7 +29,7 @@ In any case, you can always pass `--loglevel silent` to create pristine chains o
 * [`-l`, `--long`](#--long)
 * [`-p`, `--parseable`](#--parseable)
 
-`lerna ls` respects the `--ignore` and `--scope` flags (see [Filter Flags](https://www.npmjs.com/package/@lerna/filter-options)).
+`lerna ls` also respects all available [Filter Flags](https://www.npmjs.com/package/@lerna/filter-options).
 
 ### `--json`
 


### PR DESCRIPTION
## Description
Clarify docs like mentioned in #1559 

## Motivation and Context
It wasn't clear that `list` accepted all filter options. Just changed the wording to make it more clear
