### PR TITLE
fix(publish): Get tagged packages from merge commit

### DIFF
--- a/commands/publish/lib/get-tagged-packages.js
+++ b/commands/publish/lib/get-tagged-packages.js
@@ -12,7 +12,7 @@ function getTaggedPackages(packageGraph, rootPath, opts) {
   // @see https://stackoverflow.com/a/424142/5707
   // FIXME: --root is only necessary for tests :P
   return childProcess
-    .exec("git", ["diff-tree", "--name-only", "--no-commit-id", "--root", "-r", "HEAD"], opts)
+    .exec("git", ["diff-tree", "--name-only", "--no-commit-id", "--root", "-r", "-c", "HEAD"], opts)
     .then(({ stdout }) => {
       const manifests = stdout.split("\n").filter(fp => path.basename(fp) === "package.json");
       const locations = new Set(manifests.map(fp => path.join(rootPath, path.dirname(fp))));


### PR DESCRIPTION
## Description
Add the `-c` option to the command `git diff-tree --name-only --no-commit-id --root -r HEAD` used in `publish` command in `get-tagged-package.js`.

## Motivation and Context
The `git diff-tree --name-only --no-commit-id --root -r HEAD` does not show differences for merge commits (as described in the [git diff-tree documentation](https://git-scm.com/docs/git-diff-tree)), causing command `lerna publish from-git` to not publish anything when `lerna version --amend` was used on a merge commit.
With `-c` option, `git diff-tree` shows differences of the commit from all of its parents. Note that it does not affect the behavior of the command on other commits.

## How Has This Been Tested?
Problem and solution can be easily tested on a branching matching this kind of pattern:
```
*   - (HEAD -> master, tag: moduleA@0.5.0, tag: mobuleB@0.5.0)Merge branch 'chore/update'
|\
| * -chore: update 2
| * -chore: update 1
|/
*   - (master~1)
```
I only tested manually, first by using the git command directly, then I published my project with the patched version of lerna.

As it is a git command matter, i am not sure it's relevant to write unit test. But I can try if you need it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Thanks for reading