### PR TITLE
fix(version): Prioritize `--preid` over existing prerelease ID

### DIFF
--- a/commands/version/__tests__/version-bump-prerelease.test.js
+++ b/commands/version/__tests__/version-bump-prerelease.test.js
@@ -18,6 +18,7 @@ const showCommit = require("@lerna-test/show-commit");
 const gitAdd = require("@lerna-test/git-add");
 const gitTag = require("@lerna-test/git-tag");
 const gitCommit = require("@lerna-test/git-commit");
+const getCommitMessage = require("@lerna-test/get-commit-message");
 
 // test command
 const lernaVersion = require("@lerna-test/command-runner")(require("../command"));
@@ -77,4 +78,14 @@ test("version prerelease with previous prerelease supersedes --conventional-comm
 
   const patch = await showCommit(testDir);
   expect(patch).toMatchSnapshot();
+});
+
+test("version prerelease with existing preid bumps with the preid provide as argument", async () => {
+  const testDir = await initFixture("republish-prereleased");
+  // Version bump should have the new rc preid
+  await setupChanges(testDir);
+  await lernaVersion(testDir)("prerelease", "--preid", "rc");
+
+  const message = await getCommitMessage(testDir);
+  expect(message).toBe("v1.0.1-rc.0");
 });

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -201,7 +201,7 @@ class VersionCommand extends Command {
     const increment = bump && !semver.valid(bump) ? bump : "";
     const isPrerelease = increment.startsWith("pre");
 
-    const resolvePrereleaseId = existingPreid => (isPrerelease && existingPreid) || preid || "alpha";
+    const resolvePrereleaseId = existingPreid => preid || (isPrerelease && existingPreid) || "alpha";
 
     const makeGlobalVersionPredicate = nextVersion => {
       this.globalVersion = nextVersion;


### PR DESCRIPTION
in order to switch a prerelease id from alpha version to rc I needed to change condition to prioritize preid insteed of an existing preid


## Description

I juste change order of OR statement to take first preid
 const resolvePrereleaseId = existingPreid => preid || (isPrerelease && existingPreid) || "alpha";

## Motivation and Context
On my continuous integration workflow version my app on alpha prerelease, then on it goes to release candidate, so I try tu use lerna version prerelease --preid rc but because my previous tag was  dam/library-client@0.1.1-alpha.10 lerna 3.0.4 used my existing preid.
The solution was to change order on the test statement.

## How Has This Been Tested?
It has been test on my project, it works 👍 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
