### PR TITLE
feat(add): Add examples to `--help` output

### DIFF
--- a/commands/add/README.md
+++ b/commands/add/README.md
@@ -36,6 +36,9 @@ Add the new package with an exact version (e.g., `1.0.1`) rather than the defaul
 ## Examples
 
 ```sh
+# Adds the module-1 package to the packages in the 'prefix-' prefixed folders
+lerna add module-1 packages/prefix-*
+
 # Install module-1 to module-2
 lerna add module-1 --scope=module-2
 

--- a/commands/add/command.js
+++ b/commands/add/command.js
@@ -32,7 +32,15 @@ exports.builder = yargs => {
         alias: "E",
         describe: "Save version exactly",
       },
-    });
+    })
+    .example(
+      "$0 add module-1 packages/prefix-*",
+      "Adds the module-1 package to the packages in the 'prefix-' prefixed folders"
+    )
+    .example("$0 add module-1 --scope=module-2", "Install module-1 to module-2")
+    .example("$0 add module-1 --scope=module-2 --dev", "Install module-1 to module-2 in devDependencies")
+    .example("$0 add module-1", "Install module-1 in all modules except module-1")
+    .example("$0 add babel-core", "Install babel-core in all modules");
 
   return filterable(yargs);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Uses `yargs` [`.examples`](https://github.com/yargs/yargs/blob/HEAD/docs/api.md#examplecmd-desc) to add the examples of the readme into the CLI `--help` + also adds an example for the glob case

## Motivation and Context
fixes https://github.com/lerna/lerna/issues/1608

## How Has This Been Tested?
manually by `npm link`-ing and inspecting the output of `lerna add --help`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

If accepted, this method of using `.examples` could be used in the other commands as well.
It also _could_ be beneficial to generate the README's as to have a single source of truth.