### PR TITLE
Remove misleading license name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,7 +21,7 @@ Enforcement ("ICE"):
 - "LinkedIn Corporation"
 - "United Parcel Service Co"
 
-MIT License
+License
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
MIT license has it's defined form and meaning. Latest changes have violated the core of MIT license. 
Prohibiting anyone to use the software is not compatible with the MIT license.
