### PR TITLE
Updates license text to "Lerna License," because this is not MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,7 +21,7 @@ Enforcement ("ICE"):
 - "LinkedIn Corporation"
 - "United Parcel Service Co"
 
-MIT License
+Lerna License
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
it is illegal for you to misrepresent your license under someone else's title this way

your license is incredibly different than the mit license in both intent and impact

## Description
Fixes misrepresentation of license as MIT license

## Motivation and Context
This license misrepresents itself as the MIT license.  Automated license checkers will give false safety claims.  The real license forbids use on most hosts, and blocks essentially every major CI provider (including github's entire non-self-hosted list,) as well as github itself, so, this is an incredibly serious problem for downstream users.

## How Has This Been Tested?
There is no need to test a text change in a license

## Types of changes
This fixes the misrepresentation of this license as the MIT license

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
