### PR TITLE
fix(deps): update conventional changelog deps

### DIFF
--- a/core/conventional-commits/package.json
+++ b/core/conventional-commits/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@lerna/validation-error": "file:../validation-error",
     "conventional-changelog-angular": "^1.6.6",
-    "conventional-changelog-core": "^2.0.5",
-    "conventional-recommended-bump": "^2.0.6",
+    "conventional-changelog-core": "^3.1.0",
+    "conventional-recommended-bump": "^3.0.0",
     "dedent": "^0.7.0",
     "fs-extra": "^7.0.0",
     "get-stream": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -365,8 +365,8 @@
       "requires": {
         "@lerna/validation-error": "file:core/validation-error",
         "conventional-changelog-angular": "^1.6.6",
-        "conventional-changelog-core": "^2.0.5",
-        "conventional-recommended-bump": "^2.0.6",
+        "conventional-changelog-core": "^3.1.0",
+        "conventional-recommended-bump": "^3.0.0",
         "dedent": "^0.7.0",
         "fs-extra": "^7.0.0",
         "get-stream": "^4.0.0",
@@ -6518,9 +6518,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
       "dev": true,
       "optional": true
     },


### PR DESCRIPTION
## Description
This bumps the version to the latest major. The biggest change
was that it requires Node 6+ and since Lerna already requries
that this bump should not affect consumers.

## Motivation and Context
See issue #1641 

## How Has This Been Tested?
I tried running npm run test locally, but start getting jest timeouts. Is there something I can do to get that fully test. I assume the PR will trigger some CI to test so many it's not needed?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
