### PR TITLE
fix(publish): allow forcePublish on 'publish' command when used with canary option

### DIFF
--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -195,7 +195,7 @@ class PublishCommand extends Command {
   }
 
   detectCanaryVersions() {
-    const { bump = "prepatch", preid = "alpha", tagVersionPrefix = "v", ignoreChanges } = this.options;
+    const { bump = "prepatch", preid = "alpha", tagVersionPrefix = "v", ignoreChanges, forcePublish } = this.options;
     // "prerelease" and "prepatch" are identical, for our purposes
     const release = bump.startsWith("pre") ? bump.replace("release", "patch") : `pre${bump}`;
 
@@ -210,6 +210,7 @@ class PublishCommand extends Command {
         bump: "prerelease",
         canary: true,
         ignoreChanges,
+        forcePublish
       })
     );
 

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -195,7 +195,13 @@ class PublishCommand extends Command {
   }
 
   detectCanaryVersions() {
-    const { bump = "prepatch", preid = "alpha", tagVersionPrefix = "v", ignoreChanges, forcePublish } = this.options;
+    const {
+      bump = "prepatch",
+      preid = "alpha",
+      tagVersionPrefix = "v",
+      ignoreChanges,
+      forcePublish,
+    } = this.options;
     // "prerelease" and "prepatch" are identical, for our purposes
     const release = bump.startsWith("pre") ? bump.replace("release", "patch") : `pre${bump}`;
 
@@ -210,7 +216,7 @@ class PublishCommand extends Command {
         bump: "prerelease",
         canary: true,
         ignoreChanges,
-        forcePublish
+        forcePublish,
       })
     );
 


### PR DESCRIPTION
## Description
Allows publish command to support `force-publish` in conjunction with `--canary`

## Motivation and Context
From the documentation technically `force-publish` only is allowed on version, I think it should also be supported in publish

## How Has This Been Tested?
Tested it locally, changes are pretty trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
