### PR TITLE
docs: Add 'lerna create' command to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   - [`lerna clean`](./commands/clean#readme)
   - [`lerna import`](./commands/import#readme)
   - [`lerna link`](./commands/link#readme)
+  - [`lerna create`](./commands/create#readme)
 * [Concepts](#concepts)
 * [Lerna.json](#lernajson)
 * [Global Flags](./core/global-options)


### PR DESCRIPTION
## Description
This PR adds missing `lerna create` command to `README.md`

## Motivation and Context
I've noticed that `create` command exists in `commands` directory but is missing from `README.md`

## How Has This Been Tested?
`README.md` is rendering with added line

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Possibly the `website` repository could be updated with this as well https://github.com/lerna/website/blob/master/index.html
