### PR TITLE
Fix last tag detection to also include tags in branches

### DIFF
--- a/utils/describe-ref/__tests__/describe-ref.test.js
+++ b/utils/describe-ref/__tests__/describe-ref.test.js
@@ -5,7 +5,7 @@ jest.mock("@lerna/child-process");
 const childProcess = require("@lerna/child-process");
 const describeRef = require("../lib/describe-ref");
 
-const DEFAULT_ARGS = ["describe", "--always", "--long", "--dirty", "--first-parent"];
+const DEFAULT_ARGS = ["describe", "--tags", "v1.2.3-4-g567890a", "--always", "--long", "--first-parent"];
 
 childProcess.exec.mockResolvedValue({ stdout: "v1.2.3-4-g567890a" });
 childProcess.execSync.mockReturnValue("v1.2.3-4-g567890a");


### PR DESCRIPTION
## Description
Lerna fails to detect tags that are not on the current branch. 
This results in that if you tag for example on a `release` branch, `lerna changed` returns all changes until the last tag of the current branch.

Let's say you have the following setup:
![screenshot 2018-09-28 13 29 06](https://user-images.githubusercontent.com/363802/46206608-cec42480-c324-11e8-96bb-89e90efa3f58.png)

When running `lerna changed` results in this output:

```
yarn lerna changed
yarn run v1.3.2
$ /Users/haza/Projects/sentry-javascript/node_modules/.bin/lerna changed
lerna notice cli v3.4.0
lerna info Looking for changed packages since 4.0.5
@sentry/browser
@sentry/core
@sentry/hub
@sentry/minimal
@sentry/node
@sentry/types
@sentry/utils
lerna success found 7 packages ready to publish
✨  Done in 0.95s.
```
When clearly there is a merged release branch with version `4.0.6`.
It's still true that `4.0.5` was tagged on the master branch.
`lerna` runs following command under the hood: `git describe --always --long --dirty --first-parent` which returns: `4.0.5-9-g89885fae` which is correct but not taking tags on other branches into the calculation.

This fix takes the last `tag` from all branches into account. 
If I run `lerna changed` with this fix:
```
yarn lerna changed
yarn run v1.3.2
$ /Users/haza/Projects/sentry-javascript/node_modules/.bin/lerna changed
lerna notice cli v3.4.0
lerna notice Current HEAD is already released, skipping change detection.
lerna info No changed packages found
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Command running under the hood is: `git describe --tags $(git rev-list --tags --max-count=1) --always --long --first-parent` which returns `4.0.6-0-gf474d18d` (which is correct).

We are using `lerna` for our javascript SDKs https://github.com/getsentry/sentry-javascript
If you need anything let me know.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
