### PR TITLE
feat(version): Add version SKIP to allow user skip the package

### DIFF
--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -100,7 +100,9 @@ class PublishCommand extends Command {
       this.updatesVersions = new Map(result.updatesVersions);
 
       this.runPackageLifecycle = createRunner(this.options);
-      this.packagesToPublish = this.updates.map(({ pkg }) => pkg).filter(pkg => !pkg.private);
+      this.packagesToPublish = this.updates
+        .map(({ pkg }) => pkg)
+        .filter(pkg => this.updateVersions.get(pkg.name) && !pkg.private);
       this.batchedPackages = this.toposort
         ? batchPackages(
             this.packagesToPublish,

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -308,6 +308,13 @@ class VersionCommand extends Command {
   }
 
   setUpdatesForVersions(versions) {
+    // Get rid of the package, if it set to 'SKIP'
+    versions.forEach((value, key) => {
+      if (value === null) {
+        versions.delete(key);
+      }
+    });
+
     if (this.project.isIndependent() || versions.size === this.packageGraph.size) {
       // only partial fixed versions need to be checked
       this.updatesVersions = versions;
@@ -331,13 +338,18 @@ class VersionCommand extends Command {
   setBatchUpdates() {
     // Skip the package, if the version set to null
     this.packagesToVersion = this.updates
-      .filter(({ pkg }) => this.updatesVersions.get(pkg.name) === null)
+      .filter(({ pkg }) => this.updatesVersions.get(pkg.name)) // Make sure it's in the updateVersions
       .map(({ pkg }) => pkg);
 
     this.batchedPackages = batchPackages(this.packagesToVersion, this.options.rejectCycles);
   }
 
   confirmVersions() {
+    if (this.packagesToVersion.length === 0) {
+      this.logger.success(`No packages need to be updated`);
+      return false;
+    }
+
     const changes = this.packagesToVersion.map(pkg => {
       let line = ` - ${pkg.name}: ${pkg.version} => ${this.updatesVersions.get(pkg.name)}`;
       if (pkg.private) {

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -329,7 +329,11 @@ class VersionCommand extends Command {
   }
 
   setBatchUpdates() {
-    this.packagesToVersion = this.updates.map(({ pkg }) => pkg);
+    // Skip the package, if the version set to null
+    this.packagesToVersion = this.updates
+      .filter(({ pkg }) => this.updatesVersions.get(pkg.name) === null)
+      .map(({ pkg }) => pkg);
+
     this.batchedPackages = batchPackages(this.packagesToVersion, this.options.rejectCycles);
   }
 

--- a/commands/version/lib/prompt-version.js
+++ b/commands/version/lib/prompt-version.js
@@ -38,6 +38,7 @@ function promptVersion(currentVersion, name, prereleaseId) {
       { value: premajor, name: `Premajor (${premajor})` },
       { value: "PRERELEASE", name: "Custom Prerelease" },
       { value: "CUSTOM", name: "Custom Version" },
+      { value: "SKIP", name: "Skip The Package" },
     ],
   }).then(choice => {
     if (choice === "CUSTOM") {
@@ -55,6 +56,11 @@ function promptVersion(currentVersion, name, prereleaseId) {
       return PromptUtilities.input(`Enter a prerelease identifier ${prompt}`, {
         filter: v => semver.inc(currentVersion, "prerelease", v || prereleaseId),
       });
+    }
+
+    // If the user do not want to publish the package, then can choose "SKIP" option.
+    if (choice === "SKIP") {
+      return null;
     }
 
     return choice;

--- a/utils/check-working-tree/lib/check-working-tree.js
+++ b/utils/check-working-tree/lib/check-working-tree.js
@@ -14,8 +14,6 @@ function checkWorkingTree({ cwd } = {}) {
 
   // wrap each test separately to allow all applicable errors to be reported
   const tests = [
-    // prevent duplicate versioning
-    chain.then(throwIfReleased),
     // prevent publish of uncommitted changes
     chain.then(throwIfUncommitted),
   ];

--- a/utils/collect-updates/collect-updates.js
+++ b/utils/collect-updates/collect-updates.js
@@ -1,9 +1,7 @@
 "use strict";
 
 const log = require("npmlog");
-const describeRef = require("@lerna/describe-ref");
 
-const hasTags = require("./lib/has-tags");
 const collectDependents = require("./lib/collect-dependents");
 const getForcedPackages = require("./lib/get-forced-packages");
 const makeDiffPredicate = require("./lib/make-diff-predicate");
@@ -17,31 +15,15 @@ function collectUpdates(filteredPackages, packageGraph, execOpts, commandOptions
       ? packageGraph
       : new Map(filteredPackages.map(({ name }) => [name, packageGraph.get(name)]));
 
-  let committish = commandOptions.since;
+  const committish = commandOptions.since;
 
-  if (hasTags(execOpts)) {
-    // describe the last annotated tag in the current branch
-    const { sha, refCount, lastTagName } = describeRef.sync(execOpts);
-    // TODO: warn about dirty tree?
-
-    if (refCount === "0" && forced.size === 0) {
-      // no commits since previous release
-      log.notice("", "Current HEAD is already released, skipping change detection.");
-
-      return [];
-    }
-
-    if (commandOptions.canary) {
-      // if it's a merge commit, it will return all the commits that were part of the merge
-      // ex: If `ab7533e` had 2 commits, ab7533e^..ab7533e would contain 2 commits + the merge commit
-      committish = `${sha}^..${sha}`;
-    } else if (!committish) {
-      // if no tags found, this will be undefined and we'll use the initial commit
-      committish = lastTagName;
-    }
+  // If committish is set, then looking for changes since the committish
+  // If it's not set, then looking for the changes in every package, since last commit they tagged.
+  if (committish) {
+    log.info("", `Looking for changed packages since ${committish || "initial commit."}`);
+  } else {
+    log.info("", "Looking for changed packages");
   }
-
-  log.info("", `Looking for changed packages since ${committish || "initial commit."}`);
 
   if (forced.size) {
     // "warn" might seem a bit loud, but it is appropriate for logging anything _forced_


### PR DESCRIPTION
Add a "SKIP" choose when select a package version.

## Description
If user do not want to publish the package, he can choose "SKIP".

## Motivation and Context
For example. You have many independent packages, and you updated 10+ packages, and only one package need a emergency release, the others are not ready yet. Currently you have no way to publish the only one package except manually publish it.
So I added the "SKIP" option, then user can ignore the package, if they don't want to publish it for now.

FYI: https://github.com/lerna/lerna/issues/1691

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
