### PR TITLE
fix(publish): Generate safer canary version

### DIFF
--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -258,7 +258,7 @@ class PublishCommand extends Command {
 
       // semver.inc() starts a new prerelease at .0, git describe starts at .1
       // and build metadata is always ignored when comparing dependency ranges
-      return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}+${sha}`;
+      return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}.${sha}`;
     };
 
     if (this.project.isIndependent()) {


### PR DESCRIPTION
Previous way of generating canary version in lerna v3 (using `+`) is not compatible with all npm registries. We are using [ProGet](https://inedo.com/proget), and after upgradig to lerna 3, publishing a canary version fails because of the `+` sign. I didn't find any documentation on what characters are allowed in a prerelease version. Based on [npm's semver calculator](https://semver.npmjs.com/) both `+` and `.` should be fine. If you don't agree with the fix, could you kindly propose an alternative solution (maybe accepting a cli argument to override `+` if needed)? 

*Note: will update the specs once I get feedback if the change could be accepted*

## Motivation and Context
With `+` sign in package version, not all private registries will work with lerna v3 and this is blocking the upgrade.

## How Has This Been Tested?
Tested locally on Proget 4.7.14

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
