### PR TITLE
fix(version): Add friendly error message when remote branch is missing

### DIFF
--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -8,6 +8,7 @@ jest.mock("../lib/get-npm-username");
 jest.mock("../../version/lib/git-push");
 jest.mock("../../version/lib/is-anything-committed");
 jest.mock("../../version/lib/is-behind-upstream");
+jest.mock("../../version/lib/remote-branch-exists");
 
 // mocked or stubbed modules
 const npmDistTag = require("@lerna/npm-dist-tag");

--- a/commands/publish/__tests__/publish-licenses.test.js
+++ b/commands/publish/__tests__/publish-licenses.test.js
@@ -9,6 +9,7 @@ jest.mock("../lib/remove-temp-licenses", () => jest.fn(() => Promise.resolve()))
 jest.mock("../../version/lib/git-push");
 jest.mock("../../version/lib/is-anything-committed");
 jest.mock("../../version/lib/is-behind-upstream");
+jest.mock("../../version/lib/remote-branch-exists");
 
 const path = require("path");
 

--- a/commands/publish/__tests__/publish-lifecycle-scripts.test.js
+++ b/commands/publish/__tests__/publish-lifecycle-scripts.test.js
@@ -8,6 +8,7 @@ jest.mock("../lib/get-npm-username");
 jest.mock("../../version/lib/git-push");
 jest.mock("../../version/lib/is-anything-committed");
 jest.mock("../../version/lib/is-behind-upstream");
+jest.mock("../../version/lib/remote-branch-exists");
 
 // mocked modules
 const runLifecycle = require("@lerna/run-lifecycle");

--- a/commands/publish/__tests__/publish-relative-file-specifiers.test.js
+++ b/commands/publish/__tests__/publish-relative-file-specifiers.test.js
@@ -11,6 +11,7 @@ jest.mock("../lib/get-npm-username");
 jest.mock("../../version/lib/git-push");
 jest.mock("../../version/lib/is-anything-committed");
 jest.mock("../../version/lib/is-behind-upstream");
+jest.mock("../../version/lib/remote-branch-exists");
 
 const fs = require("fs-extra");
 const path = require("path");

--- a/commands/publish/__tests__/publish-tagging.test.js
+++ b/commands/publish/__tests__/publish-tagging.test.js
@@ -8,6 +8,7 @@ jest.mock("../lib/get-npm-username");
 jest.mock("../../version/lib/git-push");
 jest.mock("../../version/lib/is-anything-committed");
 jest.mock("../../version/lib/is-behind-upstream");
+jest.mock("../../version/lib/remote-branch-exists");
 
 // mocked modules
 const collectUpdates = require("@lerna/collect-updates");

--- a/commands/version/__tests__/remote-branch-exists.test.js
+++ b/commands/version/__tests__/remote-branch-exists.test.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const execa = require("execa");
+const cloneFixture = require("@lerna-test/clone-fixture")(__dirname);
+const remoteBranchExists = require("../lib/remote-branch-exists");
+
+test("remoteBranchExists", async () => {
+  const { cwd } = await cloneFixture("root-manifest-only");
+
+  expect(remoteBranchExists("origin", "new-branch", { cwd })).toBe(false);
+
+  await execa("git", ["checkout", "-b", "new-branch"], { cwd });
+  await execa("git", ["push", "-u", "origin", "new-branch"], { cwd });
+
+  expect(remoteBranchExists("origin", "new-branch", { cwd })).toBe(true);
+});

--- a/commands/version/__tests__/version-allow-branch.test.js
+++ b/commands/version/__tests__/version-allow-branch.test.js
@@ -4,6 +4,7 @@
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const path = require("path");
 const execa = require("execa");

--- a/commands/version/__tests__/version-bump-prerelease.test.js
+++ b/commands/version/__tests__/version-bump-prerelease.test.js
@@ -8,6 +8,7 @@ jest.unmock("@lerna/conventional-commits");
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const fs = require("fs-extra");
 const path = require("path");

--- a/commands/version/__tests__/version-bump.test.js
+++ b/commands/version/__tests__/version-bump.test.js
@@ -4,6 +4,7 @@
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const path = require("path");
 

--- a/commands/version/__tests__/version-command.test.js
+++ b/commands/version/__tests__/version-command.test.js
@@ -4,6 +4,7 @@
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const fs = require("fs-extra");
 const path = require("path");
@@ -18,6 +19,7 @@ const checkWorkingTree = require("@lerna/check-working-tree");
 const libPush = require("../lib/git-push");
 const isAnythingCommitted = require("../lib/is-anything-committed");
 const isBehindUpstream = require("../lib/is-behind-upstream");
+const remoteBranchExists = require("../lib/remote-branch-exists");
 
 // helpers
 const loggingOutput = require("@lerna-test/logging-output");
@@ -78,6 +80,20 @@ describe("VersionCommand", () => {
       } catch (err) {
         expect(err.message).toMatch("independent");
       }
+    });
+
+    it("throws an error when remote branch doesn't exist", async () => {
+      remoteBranchExists.mockReturnValueOnce(false);
+
+      const testDir = await initFixture("normal");
+
+      try {
+        await lernaVersion(testDir)();
+      } catch (err) {
+        expect(err.message).toMatch("doesn't exist in remote");
+      }
+
+      expect.assertions(1);
     });
 
     it("throws an error when uncommitted changes are present", async () => {

--- a/commands/version/__tests__/version-conventional-commits.test.js
+++ b/commands/version/__tests__/version-conventional-commits.test.js
@@ -4,6 +4,7 @@
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const path = require("path");
 const semver = require("semver");

--- a/commands/version/__tests__/version-git-hosted-siblings.test.js
+++ b/commands/version/__tests__/version-git-hosted-siblings.test.js
@@ -4,6 +4,7 @@
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const path = require("path");
 

--- a/commands/version/__tests__/version-ignore-changes.test.js
+++ b/commands/version/__tests__/version-ignore-changes.test.js
@@ -7,6 +7,7 @@ jest.unmock("@lerna/collect-updates");
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const fs = require("fs-extra");
 const path = require("path");

--- a/commands/version/__tests__/version-lifecycle-scripts.test.js
+++ b/commands/version/__tests__/version-lifecycle-scripts.test.js
@@ -4,6 +4,7 @@
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const path = require("path");
 

--- a/commands/version/__tests__/version-message.test.js
+++ b/commands/version/__tests__/version-message.test.js
@@ -4,6 +4,7 @@
 jest.mock("../lib/git-push");
 jest.mock("../lib/is-anything-committed");
 jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
 
 const path = require("path");
 

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -26,6 +26,7 @@ const gitCommit = require("./lib/git-commit");
 const gitPush = require("./lib/git-push");
 const gitTag = require("./lib/git-tag");
 const isBehindUpstream = require("./lib/is-behind-upstream");
+const remoteBranchExists = require("./lib/remote-branch-exists");
 const isBreakingChange = require("./lib/is-breaking-change");
 const isAnythingCommitted = require("./lib/is-anything-committed");
 const makePromptVersion = require("./lib/prompt-version");
@@ -88,6 +89,16 @@ class VersionCommand extends Command {
 
     if (this.currentBranch === "HEAD") {
       throw new ValidationError("ENOGIT", "Detached git HEAD, please checkout a branch to choose versions.");
+    }
+
+    if (this.pushToRemote && !remoteBranchExists(this.gitRemote, this.currentBranch, this.execOpts)) {
+      throw new ValidationError(
+        "EMISSREMOTEBRANCH",
+        dedent`
+          Branch '${this.currentBranch}' doesn't exist in remote '${this.gitRemote}'.
+          If this is a new branch, please make sure you push it to the remote first.
+        `
+      );
     }
 
     if (

--- a/commands/version/lib/__mocks__/remote-branch-exists.js
+++ b/commands/version/lib/__mocks__/remote-branch-exists.js
@@ -1,0 +1,4 @@
+"use strict";
+
+// to mock user modules, you _must_ call `jest.mock('./path/to/module')`
+module.exports = jest.fn(() => true);

--- a/commands/version/lib/remote-branch-exists.js
+++ b/commands/version/lib/remote-branch-exists.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const log = require("npmlog");
+const childProcess = require("@lerna/child-process");
+
+module.exports = remoteBranchExists;
+
+function remoteBranchExists(gitRemote, branch, opts) {
+  log.silly("remoteBranchExists");
+
+  const remoteBranch = `${gitRemote}/${branch}`;
+
+  try {
+    childProcess.execSync("git", ["show-ref", "--verify", `refs/remotes/${remoteBranch}`], opts);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Fix for a cryptic error that `lerna version` currently throws when the branch is missing in the remote. 

## Description
If the current branch doesn't exist in the remote, lerna throws the following error:

```
lerna ERR! Error: Command failed: git rev-list --left-right --count origin/xyz...xyz
lerna ERR! fatal: ambiguous argument 'origin/xyz...xyz': unknown revision or path not in the working tree.
lerna ERR! Use '--' to separate paths from revisions, like this:
lerna ERR! 'git <command> [<revision>...] -- [<file>...]'
...
``` 
This PR adds a check when `lerna version` is ran, so that it is verified first that the remote branch exists. If it doesn't exist, a new ValidationError (EMISSREMOTEBRANCH) will be thrown, i.e.:
`Branch 'foo' doesn't exist in remote 'origin'. If this is a new branch, please make sure you push it to the remote first. 
`
## Motivation and Context
The existing error thrown when the remote branch doesn't exist is misleading and doesn't make sense in the context of `lerna version`.

## How Has This Been Tested?
Added unit tests and integration tests. I've also tested it manually, environment:
MacBook Pro macOS High Sierra
node v9.8.0
git 2.15.2

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
