### PR TITLE
docs(readme): Fix incorrect statement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Lerna will log to a `lerna-debug.log` file (same as `npm-debug.log`) when it enc
 
 Lerna also has support for [scoped packages](https://docs.npmjs.com/misc/scope).
 
-Running `lerna` without arguments will show all commands/options.
+Running `lerna --help` will show all commands/options.
 
 ### lerna.json
 


### PR DESCRIPTION
## Description

Updates a single line in the readme.

## Motivation and Context

The readme currently says:

> Running `lerna` without arguments will show all commands/options.

But this isn't true. With the latest lerna, I get this:

```sh
> lerna
ERR! lerna A command is required. Pass --help to see all available commands and options.
```

## How Has This Been Tested?
Manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
