### PR TITLE
docs: note some disadvantages with hoisting

### DIFF
--- a/doc/hoist.md
+++ b/doc/hoist.md
@@ -32,7 +32,9 @@ When the `--hoist` flag is used:
   scripts continue to work unmodified.
 * Well-behaved Node-based software should continue to work unmodified.
 
-## Module resolution
+## Disadvantages with hoisting
+
+### Module resolution
 
 The [Node module resolution algorithm](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders)
 is recursive: When looking for package `A`, it looks in a local
@@ -49,3 +51,23 @@ this, it is possible to symlink packages from their hoisted top-level
 location, to individual package `node_modules` directory. Lerna does
 not yet do this automatically, and it is recommended instead to work
 with tool maintainers to migrate to more compatible patterns.
+
+### Forgetting dependencies
+
+Lerna will hoist dependencies which are used in multiple projects,
+even if they are not used in all projects.
+
+As a result, your packages will be able to import or require any of
+the dependencies that have been hoisted, even if you _forgot to
+specify that dependency_ in your package's `package.json` file.
+
+Tests will pass fine, and you may not realise until later, when you
+try to use this package outside of the monorepo, that some of its
+dependencies are missing.
+
+(This problem is not specific to lerna.  It can also occur as a result
+of [`npm`'s flattening](https://medium.com/pnpm/pnpms-strictness-helps-to-avoid-silly-bugs-9a15fb306308).)
+
+To avoid this problem, when using `require()` or `import` on an
+external module, always check that the dependency is specified in
+`package.json`.

--- a/doc/hoist.md
+++ b/doc/hoist.md
@@ -65,9 +65,12 @@ Tests will pass fine, and you may not realise until later, when you
 try to use this package outside of the monorepo, that some of its
 dependencies are missing.
 
-(This problem is not specific to lerna.  It can also occur as a result
+(This problem is not specific to lerna. It can also occur as a result
 of [`npm`'s flattening](https://medium.com/pnpm/pnpms-strictness-helps-to-avoid-silly-bugs-9a15fb306308).)
 
-To avoid this problem, when using `require()` or `import` on an
-external module, always check that the dependency is specified in
+To avoid this problem, we can use the [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import)
+package, which has a rule `no-extraneous-dependencies` that can warn
+when an import is made from an unspecified package. It is enabled by
+default in the 'recommended' config. Otherwise, we should check by
+hand that all new imports come from packages specified in
 `package.json`.


### PR DESCRIPTION
## Motivation and Context
Before enabling an option, I want to know what are the advantages and disadvantages of doing so.

## Description
Documented one possible disadvantage of hoisting:

- Accidentally require-ing a common dependency without adding it to `package.json`

## How Has This Been Tested?
I created three packages, two with a common dependency, and one without.

The third without was still able to require the common dependency, although it had not specified it in its `package.json`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Additional
If there are any disadvantages which are not documented here, please let me know. I may be able to add them.