### PR TITLE
docs(version): Add cases in which --ignore-changes does not ignore a package

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -177,6 +177,10 @@ This option is best specified as root `lerna.json` configuration, both to avoid 
 
 Pass `--no-ignore-changes` to disable any existing durable configuration.
 
+> In the following cases, a package will always be published, regardless of this option:
+> 1. The latest release of the package is a `prerelease` version (i.e. `1.0.0-alpha`, `1.0.0–0.3.7`, etc.).
+> 2. One or more linked dependencies of the package have changed.
+
 ### `--git-remote <name>`
 
 ```sh


### PR DESCRIPTION
## Description
There are certain cases when a package will always be published, even if it's ignored using the `--ignore-changes` option:

1. The latest release of the package is a `prerelease` version, as seen here: https://github.com/lerna/lerna/blob/v3.4.3/utils/collect-updates/collect-updates.js#L62

2. One or more linked dependencies of the package have changed, as seen here: https://github.com/lerna/lerna/blob/v3.4.3/utils/collect-updates/collect-updates.js#L72

This PR updates the documentation for `version` to include this information.

## Motivation and Context
I had some issues publishing a package because my `--ignore-changes` options were not being honored. After some searching, I found a comment on an issue which mentions that packages with dependents that have changes will always be published: https://github.com/lerna/lerna/issues/1586#issuecomment-414392535

It would be very helpful for developers if this information is in the documentation, near the `--ignore-changes` option.

## How Has This Been Tested?
NA

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
