### PR TITLE
fix: Update yarn workspaces error prompt link

### DIFF
--- a/core/project/index.js
+++ b/core/project/index.js
@@ -79,7 +79,7 @@ class Project {
           "EWORKSPACES",
           dedent`
             Yarn workspaces need to be defined in the root package.json.
-            See: https://github.com/lerna/lerna#--use-workspaces
+            See: https://github.com/lerna/lerna/blob/master/commands/bootstrap/README.md#--use-workspaces
           `
         );
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When running `lerna bootstrap` without workspaces defined in `package.json` the error prompt links to `https://github.com/lerna/lerna#--use-workspaces` which no longer exists.

## Description

This PR updates the link to `https://github.com/lerna/lerna/blob/master/commands/bootstrap/README.md#--use-workspaces` which is the closest match I could find.

## Motivation and Context
Bad links bad

## How Has This Been Tested?
Visited the correct link in my browser. It didn't seem necessary to add a test for this message.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
