### PR TITLE
docs: Update README.md to use `lerna --help` instead of just `lerna`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Lerna will log to a `lerna-debug.log` file (same as `npm-debug.log`) when it enc
 
 Lerna also has support for [scoped packages](https://docs.npmjs.com/misc/scope).
 
-Running `lerna` without arguments will show all commands/options.
+Run `lerna --help` to see all available commands and options.
 
 ### lerna.json
 


### PR DESCRIPTION
## Description
I just recently downloaded and ran `lerna`, and attempted to follow the README by running `lerna`, but it returned the following error:
```
ERR! lerna A command is required. Pass --help to see all available commands and options.
```
This PR updates the README to reflect this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
