### PR TITLE
feat(import) Add `--dest` option to explicitly specify import destination

### DIFF
--- a/commands/import/README.md
+++ b/commands/import/README.md
@@ -27,3 +27,10 @@ When importing repositories with merge commits with conflicts, the import comman
 $ lerna import ~/Product --flatten
 ```
 
+### `--dest`
+
+When importing repositories, you can specify the destination directory by the directory listed in lerna.json.
+
+```
+$ lerna import ~/Product --dest=utilities
+```

--- a/commands/import/__tests__/__fixtures__/multi-packages/lerna.json
+++ b/commands/import/__tests__/__fixtures__/multi-packages/lerna.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "packages": [
+    "core/*",
+    "packages/*"
+  ]
+}

--- a/commands/import/__tests__/__fixtures__/multi-packages/package.json
+++ b/commands/import/__tests__/__fixtures__/multi-packages/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "multi-packages"
+}

--- a/commands/import/__tests__/import-command.test.js
+++ b/commands/import/__tests__/import-command.test.js
@@ -270,4 +270,33 @@ describe("ImportCommand", () => {
       expect(await pathExists(packageJson)).toBe(true);
     });
   });
+
+  describe("with multi-packages Lerna dir", () => {
+    it("creates a module in specified package directory", async () => {
+      const [testDir, externalDir] = await Promise.all([
+        initFixture("multi-packages"),
+        initFixture("external", "Init external commit"),
+      ]);
+
+      const packageJson = path.join(testDir, "packages", path.basename(externalDir), "package.json");
+
+      await lernaImport(testDir)(externalDir, "--dest=packages");
+
+      expect(await lastCommitInDir(testDir)).toBe("Init external commit");
+      expect(await pathExists(packageJson)).toBe(true);
+    });
+
+    it("throws error when the package directory does not match with config", async () => {
+      const [testDir, externalDir] = await Promise.all([
+        initFixture("multi-packages"),
+        initFixture("external", "Init external commit"),
+      ]);
+
+      try {
+        await lernaImport(testDir)(externalDir, "--dest=components");
+      } catch (err) {
+        expect(err.message).toBe("--dest does not match with the package directories: core,packages");
+      }
+    });
+  });
 });

--- a/commands/import/command.js
+++ b/commands/import/command.js
@@ -16,6 +16,11 @@ exports.builder = yargs =>
         describe: "Import each merge commit as a single change the merge introduced",
         type: "boolean",
       },
+      dest: {
+        group: "Command Options:",
+        describe: "Import destination directory for the external git repository",
+        type: "string",
+      },
       y: {
         group: "Command Options:",
         describe: "Skip all confirmation prompts",


### PR DESCRIPTION
Add --dest option to import command, to specify import destination

## Motivation and Context
We want to import repository into a specific location in a project that have multiple package directories.
lerna default the import destination to the first directory in the package list.

## How Has This Been Tested?
Unit tested in `__test__/import-command.test.js`.
Command line tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
