### PR TITLE
fix(publish): Ignore non-release tags when detecting `from-git`

### DIFF
--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -209,7 +209,7 @@ class PublishCommand extends Command {
       }
 
       if (this.project.isIndependent()) {
-        return taggedPackageNames.map(name => this.packageGraph.get(name));
+        return taggedPackageNames.map(name => this.packageGraph.get(name)).filter(name => name !== undefined);
       }
 
       return getTaggedPackages(this.packageGraph, this.project.rootPath, this.execOpts);

--- a/integration/lerna-publish-custom-tag.test.js
+++ b/integration/lerna-publish-custom-tag.test.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const path = require("path");
+
+const cliRunner = require("@lerna-test/cli-runner");
+const gitTag = require("@lerna-test/git-tag");
+const cloneFixture = require("@lerna-test/clone-fixture")(
+  path.resolve(__dirname, "../commands/publish/__tests__")
+);
+
+// stabilize changelog commit SHA and datestamp
+expect.addSnapshotSerializer(require("@lerna-test/serialize-changelog"));
+
+const env = {
+  // never actually upload when calling `npm publish`
+  npm_config_dry_run: true,
+  // skip npm package validation, none of the stubs are real
+  LERNA_INTEGRATION: "SKIP",
+};
+
+test("lerna publish from-git handles custom tags", async () => {
+  const { cwd } = await cloneFixture("independent");
+
+  await gitTag(cwd, "some-unrelated-tag");
+
+  const args = ["publish", "--yes", "from-git"];
+
+  const { stdout } = await cliRunner(cwd, env)(...args);
+  expect(stdout).toMatchInlineSnapshot("", ``);
+});


### PR DESCRIPTION
Filter out tags that are not distribution tags generated by lerna when
running publish --from-git

<!--- Provide a general summary of your changes in the Title above -->

## Description

Our repository has an extra (unrelated) tag, and lerna fails with:

```
lerna notice cli v3.4.3
lerna info versioning independent
lerna info Verifying npm credentials
lerna http fetch GET 200 https://artifactory.in.here.com/artifactory/api/npm/verity-npm-sandbox/-/whoami 95ms
lerna ERR! TypeError: Cannot destructure property `pkg` of 'undefined' or 'null'.
lerna ERR!     at updates.map (/root/.npm/_npx/55/lib/node_modules/lerna/node_modules/@lerna/publish/index.js:219:43)
lerna ERR!     at Array.map (<anonymous>)
lerna ERR!     at chain.then.updates (/root/.npm/_npx/55/lib/node_modules/lerna/node_modules/@lerna/publish/index.js:219:39)
lerna ERR! lerna Cannot destructure property `pkg` of 'undefined' or 'null'.
```

reason is that `taggedPackageNames` contains an `undefined` value since no package matches the (unrelated) tag.

<!--- Describe your changes in detail -->

## Motivation and Context

Fixes a crash in lerna

## How Has This Been Tested?

Do a `lerna version patch`, then `git tag foo`, then try `lerna publish from-git` => crash.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
