### PR TITLE
fix: Do not print duplicate stdio after a streaming command errors

### DIFF
--- a/core/command/__tests__/command.test.js
+++ b/core/command/__tests__/command.test.js
@@ -198,6 +198,33 @@ describe("core-command", () => {
         });
       }
     });
+
+    it("does not log stdout/stderr after streaming ends", async () => {
+      class PkgErrorCommand extends Command {
+        initialize() {
+          return true;
+        }
+
+        execute() {
+          const err = new Error("message");
+
+          err.cmd = "test-pkg-err";
+          err.stdout = "pkg-err-stdout";
+          err.stderr = "pkg-err-stderr";
+          err.pkg = {
+            name: "pkg-err-name",
+          };
+
+          throw err;
+        }
+      }
+
+      try {
+        await new PkgErrorCommand({ cwd: testDir, stream: true });
+      } catch (err) {
+        expect(console.error.mock.calls).toHaveLength(0);
+      }
+    });
   });
 
   describe("loglevel", () => {

--- a/core/command/index.js
+++ b/core/command/index.js
@@ -59,7 +59,7 @@ class Command {
         err => {
           if (err.pkg) {
             // Cleanly log specific package error details
-            logPackageError(err);
+            logPackageError(err, this.options.stream);
           } else if (err.name !== "ValidationError") {
             // npmlog does some funny stuff to the stack by default,
             // so pass it directly to avoid duplication.

--- a/core/command/lib/log-package-error.js
+++ b/core/command/lib/log-package-error.js
@@ -4,8 +4,13 @@ const log = require("libnpm/log");
 
 module.exports = logPackageError;
 
-function logPackageError(err) {
+function logPackageError(err, stream = false) {
   log.error(err.cmd, `exited ${err.code} in '${err.pkg.name}'`);
+
+  if (stream) {
+    // Streaming has already printed all stdout/stderr
+    return;
+  }
 
   if (err.stdout) {
     log.error(err.cmd, "stdout:");


### PR DESCRIPTION
## Description

Omits stdout/stderr output printed after a command fails, if run with `--stream`. 

## Motivation and Context

Since streaming mode prints stdout/stderr as it happens, printing it again after the command completes produces a duplicate copy.

Addresses https://github.com/lerna/lerna/issues/1790.

## How Has This Been Tested?
* Manually tested with a few projects I have, passing `--stream` and not, to ensure that only a single copy of stdout/stderr is produced in each case
* Added a unit test for `Command` to ensure that extra output is not printed when `--stream` is passed. (inverse case is already covered in the unit test above it)
* Checked to make sure that `logPackageError` was not called anywhere except `Command`, and that it would produce the same behavior if it was missing the `stream` argument.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

(this would only be considered a breaking change if people were depending on the double-output, but I suppose they theoretically could be)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
