### PR TITLE
feat(version): implement --no-changelog flag

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -41,6 +41,7 @@ If you have any packages with a prerelease version number (e.g. `2.0.0-beta.3`) 
 - [`--commit-hooks`](#--commit-hooks)
 - [`--conventional-commits`](#--conventional-commits)
 - [`--changelog-preset`](#--changelog-preset)
+- [`--no-changelog`](#--no-changelog)
 - [`--exact`](#--exact)
 - [`--force-publish`](#--force-publish)
 - [`--ignore-changes`](#--ignore-changes)
@@ -132,6 +133,14 @@ In some cases you might want to change either use a another preset or a custom o
 Presets are names of built-in or installable configuration for conventional changelog.
 Presets may be passed as the full name of the package, or the auto-expanded suffix
 (e.g., `angular` is expanded to `conventional-changelog-angular`).
+
+### `--no-changelog`
+
+```sh
+lerna version --conventional-commits --no-changelog
+```
+
+When using `conventional-commits`, do not generate any `CHANGELOG.md` files.
 
 ### `--exact`
 

--- a/commands/version/__tests__/version-conventional-commits.test.js
+++ b/commands/version/__tests__/version-conventional-commits.test.js
@@ -74,6 +74,13 @@ describe("--conventional-commits", () => {
         changelogOpts
       );
     });
+
+    it("should not update changelogs with --no-changelog option", async () => {
+      const cwd = await initFixture("independent");
+      await lernaVersion(cwd)("--conventional-commits", "--no-changelog");
+
+      expect(ConventionalCommitUtilities.updateChangelog).not.toHaveBeenCalled();
+    });
   });
 
   describe("fixed mode", () => {
@@ -141,6 +148,13 @@ describe("--conventional-commits", () => {
         "fixed",
         changelogOpts
       );
+    });
+
+    it("should not update changelogs with --no-changelog option", async () => {
+      const cwd = await initFixture("normal");
+      await lernaVersion(cwd)("--conventional-commits", "--no-changelog");
+
+      expect(ConventionalCommitUtilities.updateChangelog).not.toHaveBeenCalled();
     });
   });
 

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -33,6 +33,11 @@ exports.builder = (yargs, composed) => {
       describe: "Use another conventional-changelog preset rather than angular.",
       type: "string",
     },
+    changelog: {
+      describe: "When using conventional-commits, generate CHANGELOG.md files.",
+      type: "boolean",
+      defaultDescription: "true",
+    },
     exact: {
       describe: "Specify cross-dependency version numbers exactly rather than with a caret (^).",
       type: "boolean",

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -396,7 +396,7 @@ class VersionCommand extends Command {
   }
 
   updatePackageVersions() {
-    const { conventionalCommits, changelogPreset } = this.options;
+    const { conventionalCommits, changelogPreset, changelog = true } = this.options;
     const independentVersions = this.project.isIndependent();
     const rootPath = this.project.manifest.location;
     const changedFiles = new Set();
@@ -440,7 +440,7 @@ class VersionCommand extends Command {
       pkg => this.runPackageLifecycle(pkg, "version").then(() => pkg),
     ];
 
-    if (conventionalCommits) {
+    if (conventionalCommits && changelog) {
       // we can now generate the Changelog, based on the
       // the updated version that we're about to release.
       const type = independentVersions ? "independent" : "fixed";
@@ -468,7 +468,7 @@ class VersionCommand extends Command {
       )
     );
 
-    if (!independentVersions) {
+    if (!independentVersions && changelog) {
       this.project.version = this.globalVersion;
 
       if (conventionalCommits) {


### PR DESCRIPTION

## Description
Introduces a new `--no-changelog` flag that skips changelog generation when using conventional commits.

## Motivation and Context

Closes #1852

## How Has This Been Tested?
Unit tests added for `fixed` and `independent` modes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

