### PR TITLE
docs(readme): add config option to lerna.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Run `lerna --help` to see all available commands and options.
   "npmClient": "npm",
   "command": {
     "publish": {
-      "ignoreChanges": ["ignored-file", "*.md"]
+      "ignoreChanges": ["ignored-file", "*.md"],
+      "message": "chore(release): publish"
     },
     "bootstrap": {
       "ignore": "component-*",
@@ -156,6 +157,7 @@ Run `lerna --help` to see all available commands and options.
 - `version`: the current version of the repository.
 - `npmClient`: an option to specify a specific client to run commands with (this can also be specified on a per command basis). Change to `"yarn"` to run all commands with yarn. Defaults to "npm".
 - `command.publish.ignoreChanges`: an array of globs that won't be included in `lerna changed/publish`. Use this to prevent publishing a new version unnecessarily for changes, such as fixing a `README.md` typo.
+- `command.publish.message`: a custom commit message when performing version updates for publication. See [@lerna/version](commands/version#--message-msg) for more details. 
 - `command.bootstrap.ignore`: an array of globs that won't be bootstrapped when running the `lerna bootstrap` command.
 - `command.bootstrap.npmClientArgs`: array of strings that will be passed as arguments directly to `npm install` during the `lerna bootstrap` command.
 - `command.bootstrap.scope`: an array of globs that restricts which packages will be bootstrapped when running the `lerna bootstrap` command.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add command.publish.message to lerna.json with a link back to its documentation

## Motivation and Context

I was looking for a way to configure custom messages in lerna.json, but couldn't find it, until I came across it in `@lerna/version`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
