### PR TITLE
docs(import): Add a note for importing on fresh repos

### DIFF
--- a/commands/import/README.md
+++ b/commands/import/README.md
@@ -17,6 +17,22 @@ repo. Each commit is modified to make changes relative to the package
 directory. So, for example, the commit that added `package.json` will
 instead add `packages/<directory-name>/package.json`.
 
+*Note*: If you're importing an external repository on a new lerna repository, then do remember to have at least one commit.
+
+```bash
+# Getting started with Lerna
+$ npm install --global lerna
+$ git init lerna-repo && cd lerna-repo
+$ lerna init
+
+# Adding a commit
+$ git add .
+$ git commit -m "Initial lerna commit" # Without a commit, import command would fail
+
+# Importing other repository
+$ lerna import <path-to-external-repository>
+```
+
 ## Options
 
 ### `--flatten`

--- a/commands/import/README.md
+++ b/commands/import/README.md
@@ -21,16 +21,16 @@ instead add `packages/<directory-name>/package.json`.
 
 ```bash
 # Getting started with Lerna
-$ npm install --global lerna
 $ git init lerna-repo && cd lerna-repo
-$ lerna init
+$ npx lerna init
+$ npm install
 
 # Adding a commit
 $ git add .
 $ git commit -m "Initial lerna commit" # Without a commit, import command would fail
 
 # Importing other repository
-$ lerna import <path-to-external-repository>
+$ npx lerna import <path-to-external-repository>
 ```
 
 ## Options


### PR DESCRIPTION
I was facing this issue and found the solution on 3rd google search result. Thought it would be nice to have it in the docs itself.

