### PR TITLE
feat(publish): Use temporary dist-tags by default

### DIFF
--- a/commands/__mocks__/@lerna/npm-dist-tag.js
+++ b/commands/__mocks__/@lerna/npm-dist-tag.js
@@ -1,9 +1,28 @@
 "use strict";
 
-const mockAdd = jest.fn(() => Promise.resolve());
+const addRegistry = new Map();
+
+// by default, act like a spy that populates registry
+const mockAdd = jest.fn((spec, distTag) => {
+  addRegistry.set(spec, distTag);
+
+  return Promise.resolve();
+});
 const mockList = jest.fn(() => Promise.resolve({}));
 const mockRemove = jest.fn(() => Promise.resolve());
 
+// a convenient format for assertions
+function addTagged() {
+  return Array.from(addRegistry.values());
+}
+
+// keep test data isolated
+afterEach(() => {
+  addRegistry.clear();
+});
+
 exports.add = mockAdd;
+module.exports.add.registry = addRegistry;
+module.exports.add.tagged = addTagged;
 exports.list = mockList;
 exports.remove = mockRemove;

--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -55,13 +55,13 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 - [`--ignore-scripts`](#--ignore-scripts)
 - [`--ignore-prepublish`](#--ignore-prepublish)
 - [`--no-git-reset`](#--no-git-reset)
+- [`--no-temp-tag`](#--no-temp-tag)
 - [`--no-verify-access`](#--no-verify-access)
 - [`--otp`](#--otp)
 - [`--preid`](#--preid)
 - [`--pre-dist-tag <tag>`](#--pre-dist-tag-tag)
 - [`--registry <url>`](#--registry-url)
 - [`--tag-version-prefix`](#--tag-version-prefix)
-- [`--temp-tag`](#--temp-tag)
 - [`--yes`](#--yes)
 
 ### `--canary`
@@ -170,6 +170,14 @@ To avoid this, pass `--no-git-reset`. This can be especially useful when used as
 lerna publish --no-git-reset
 ```
 
+### `--no-temp-tag`
+
+By default, `lerna publish` first publishes all changed packages to a temporary dist-tag (`lerna-temp`)
+and then after all are successful moves the new version(s) to the dist-tag configured by [`--dist-tag`](#--dist-tag-tag) (default `latest`).
+This is intended to help avoid "partial" releases (due to network, authentication, or other failure) corrupting consumer installs with conflicting metadata.
+
+If you do not need this insurance, pass `--no-temp-tag` (or set `command.publish.tempTag` to `false` in lerna.json) to disable this behavior.
+
 ### `--no-verify-access`
 
 By default, `lerna` will verify the logged-in npm user's access to the packages about to be published. Passing this flag will disable that check.
@@ -244,15 +252,6 @@ You could also configure this at the root level of lerna.json, applying to both 
   "version": "independent"
 }
 ```
-
-### `--temp-tag`
-
-When passed, this flag will alter the default publish process by first publishing
-all changed packages to a temporary dist-tag (`lerna-temp`) and then moving the
-new version(s) to the dist-tag configured by [`--dist-tag`](#--dist-tag-tag) (default `latest`).
-
-This is not generally necessary, as Lerna will publish packages in topological
-order (all dependencies before dependents) by default.
 
 ### `--yes`
 
@@ -360,4 +359,4 @@ Lerna will run [npm lifecycle scripts](https://docs.npmjs.com/misc/scripts#descr
 9. Run `publish` lifecycle in root
    - To avoid recursive calls, don't use this root lifecycle to run `lerna publish`
 10. Run `postpublish` lifecycle in root
-11. Update temporary dist-tag to latest, if [enabled](#--temp-tag)
+11. Update temporary dist-tag to latest, unless [disabled](#--no-temp-tag)

--- a/commands/publish/__tests__/publish-canary.test.js
+++ b/commands/publish/__tests__/publish-canary.test.js
@@ -15,7 +15,7 @@ const childProcess = require("@lerna/child-process");
 
 // mocked modules
 const writePkg = require("write-pkg");
-const npmPublish = require("@lerna/npm-publish");
+const npmDistTag = require("@lerna/npm-dist-tag");
 const PromptUtilities = require("@lerna/prompt");
 const checkWorkingTree = require("@lerna/check-working-tree");
 
@@ -78,20 +78,12 @@ test("publish --canary", async () => {
   expect(PromptUtilities.confirm).toHaveBeenLastCalledWith(
     "Are you sure you want to publish these packages?"
   );
-  expect(npmPublish.registry).toMatchInlineSnapshot(`
+  expect(npmDistTag.add.registry).toMatchInlineSnapshot(`
 Map {
-  "package-1" => "canary",
-  "package-3" => "canary",
-  "package-4" => "canary",
-  "package-2" => "canary",
-}
-`);
-  expect(writePkg.updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
-  "package-4": 1.0.1-alpha.0+SHA,
+  package-1@1.0.1-alpha.0+SHA => "canary",
+  package-3@1.0.1-alpha.0+SHA => "canary",
+  package-4@1.0.1-alpha.0+SHA => "canary",
+  package-2@1.0.1-alpha.0+SHA => "canary",
 }
 `);
 });

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -111,21 +111,19 @@ Set {
 `);
       expect(npmPublish.registry).toMatchInlineSnapshot(`
 Map {
-  "package-1" => "latest",
-  "package-3" => "latest",
-  "package-4" => "latest",
-  "package-2" => "latest",
+  "package-1" => "lerna-temp",
+  "package-3" => "lerna-temp",
+  "package-4" => "lerna-temp",
+  "package-2" => "lerna-temp",
 }
 `);
-      expect(npmPublish.order()).toEqual([
-        "package-1",
-        "package-3",
-        "package-4",
-        "package-2",
-        // package-5 is private
+      expect(npmDistTag.add.tagged()).toEqual([
+        "latest",
+        "latest",
+        "latest",
+        "latest",
+        // see publish-tagging.test.js for more temp-tag tests
       ]);
-      expect(npmDistTag.remove).not.toHaveBeenCalled();
-      expect(npmDistTag.add).not.toHaveBeenCalled();
 
       expect(getNpmUsername).toHaveBeenCalled();
       expect(getNpmUsername).toHaveBeenLastCalledWith(

--- a/commands/publish/command.js
+++ b/commands/publish/command.js
@@ -82,8 +82,13 @@ exports.builder = yargs => {
       hidden: true,
       type: "boolean",
     },
-    "temp-tag": {
+    "no-temp-tag": {
       describe: "Create a temporary tag while publishing.",
+      type: "boolean",
+    },
+    "temp-tag": {
+      // proxy for --no-temp-tag
+      hidden: true,
       type: "boolean",
     },
     "no-verify-access": {


### PR DESCRIPTION
## Description

The previous default was _not_ to use temporary dist-tags during the `lerna publish` process, and thus a partially successful publish (due to authentication errors and the like) would result in a broken `latest` dist-tag.

Pass `--no-temp-tag` to restore the previous, slightly more dangerous behavior.

## Motivation and Context

#1862 should be merged first.

Refs #1767

## How Has This Been Tested?

moar tests

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
