### PR TITLE
fix(import): Ensure compatibility with root-level package globs

### DIFF
--- a/commands/import/__tests__/__fixtures__/root-packages/lerna.json
+++ b/commands/import/__tests__/__fixtures__/root-packages/lerna.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "packages": ["mycompany-*"]
+}

--- a/commands/import/__tests__/__fixtures__/root-packages/package.json
+++ b/commands/import/__tests__/__fixtures__/root-packages/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "mycompany-root"
+}

--- a/commands/import/__tests__/import-command.test.js
+++ b/commands/import/__tests__/import-command.test.js
@@ -11,6 +11,7 @@ const pathExists = require("path-exists");
 const PromptUtilities = require("@lerna/prompt");
 
 // helpers
+const initNamedFixture = require("@lerna-test/init-named-fixture")(__dirname);
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
 const gitAdd = require("@lerna-test/git-add");
 const gitCommit = require("@lerna-test/git-commit");
@@ -76,6 +77,19 @@ describe("ImportCommand", () => {
 
       expect(await lastCommitInDir(testDir)).toBe("Branch merged");
       expect(await pathExists(newFilePath)).toBe(true);
+    });
+
+    it("imports a repo into the root directory when packages are located there", async () => {
+      const [testDir, externalDir] = await Promise.all([
+        initFixture("root-packages"),
+        initNamedFixture("myapp-foo", "external", "myapp-foo init commit"),
+      ]);
+
+      await lernaImport(testDir)(externalDir);
+
+      expect(await lastCommitInDir(testDir)).toBe("myapp-foo init commit");
+      expect(await pathExists(path.join(testDir, "myapp-foo/old-file"))).toBe(true);
+      expect(await pathExists(path.join(testDir, "myapp-foo/package.json"))).toBe(true);
     });
 
     it("supports moved files within the external repo", async () => {

--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -114,7 +114,7 @@ class ImportCommand extends Command {
   }
 
   getPackageDirectories() {
-    return this.project.packageConfigs.filter(p => path.basename(p) === "*").map(p => path.dirname(p));
+    return this.project.packageConfigs.filter(p => p.endsWith("*")).map(p => path.dirname(p));
   }
 
   getTargetBase() {

--- a/helpers/init-named-fixture/index.js
+++ b/helpers/init-named-fixture/index.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const path = require("path");
+const fs = require("fs-extra");
+const tempy = require("tempy");
+const copyFixture = require("@lerna-test/copy-fixture");
+const gitAdd = require("@lerna-test/git-add");
+const gitCommit = require("@lerna-test/git-commit");
+const gitInit = require("@lerna-test/git-init");
+
+module.exports = initNamedFixture;
+
+function initNamedFixture(startDir) {
+  return (dirName, fixtureName, commitMessage = "Init commit") => {
+    const cwd = path.join(tempy.directory(), dirName);
+    let chain = Promise.resolve();
+
+    chain = chain.then(() => fs.ensureDir(cwd));
+    chain = chain.then(() => process.chdir(cwd));
+    chain = chain.then(() => copyFixture(cwd, fixtureName, startDir));
+    chain = chain.then(() => gitInit(cwd, "."));
+
+    if (commitMessage) {
+      chain = chain.then(() => gitAdd(cwd, "-A"));
+      chain = chain.then(() => gitCommit(cwd, commitMessage));
+    }
+
+    return chain.then(() => cwd);
+  };
+}

--- a/helpers/init-named-fixture/package.json
+++ b/helpers/init-named-fixture/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@lerna-test/init-named-fixture",
+  "version": "0.0.0-test-only",
+  "description": "A local test helper",
+  "main": "index.js",
+  "private": true,
+  "license": "MIT",
+  "dependencies": {
+    "@lerna-test/copy-fixture": "file:../copy-fixture",
+    "@lerna-test/git-add": "file:../git-add",
+    "@lerna-test/git-commit": "file:../git-commit",
+    "@lerna-test/git-init": "file:../git-init",
+    "tempy": "^0.2.1",
+    "fs-extra": "^7.0.0"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,18 @@
         "tempy": "^0.2.1"
       }
     },
+    "@lerna-test/init-named-fixture": {
+      "version": "file:helpers/init-named-fixture",
+      "dev": true,
+      "requires": {
+        "@lerna-test/copy-fixture": "file:helpers/copy-fixture",
+        "@lerna-test/git-add": "file:helpers/git-add",
+        "@lerna-test/git-commit": "file:helpers/git-commit",
+        "@lerna-test/git-init": "file:helpers/git-init",
+        "fs-extra": "^7.0.0",
+        "tempy": "^0.2.1"
+      }
+    },
     "@lerna-test/load-manifests": {
       "version": "file:helpers/load-manifests",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@lerna-test/git-status": "file:helpers/git-status",
     "@lerna-test/git-tag": "file:helpers/git-tag",
     "@lerna-test/init-fixture": "file:helpers/init-fixture",
+    "@lerna-test/init-named-fixture": "file:helpers/init-named-fixture",
     "@lerna-test/load-manifests": "file:helpers/load-manifests",
     "@lerna-test/logging-output": "file:helpers/logging-output",
     "@lerna-test/multi-line-trim-right": "file:helpers/multi-line-trim-right",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes `lerna import` to work in the case where packages are housed at the root level of a lerna-managed repo and use a configuration like `["myapp-*"]` for the packages configuration.

## Description
<!--- Describe your changes in detail -->

I changed the `getPackageDirectories()` method inside the import command so that any path ending in `*` is considered a package root location instead of just the ones ending in `/*`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes #1872. The change makes it possible to use `lerna import` when your packages are located at the root directory of a lerna-managed repo.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added a new test that covers the exact case failing in the issue I reported. The test makes a new lerna repo with the `myapp-*` config, imports a subpackage, and then verifies the new history and file contents.

I had to add a new testing helper since having a static name for the test repo wasn't supported by the regular fixtures helper function.

I wrote the test before the implementation, verified it failed, wrote the implementation, and verified both manually and through the test code that everything is working correctly.

I ran `npm test` to test the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I would imagine this is just a bug fix, not a breaking change, but I wouldn't know for sure.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I don't think the existing documentation needs to be updated. I expected this to work already based on it.

## Note:

It's possibly outside the scope of this ticket, but the output of this error is hard to read when there are zero package directories since JS stringifies an empty array to empty string:

```js
throw new ValidationError(
  "EDESTDIR",
  `--dest does not match with the package directories: ${this.getPackageDirectories()}`
);
```