### PR TITLE
Add [ci skip] to all publish commit messages.

### DIFF
--- a/commands/version/__tests__/__snapshots__/version-bump-prerelease.test.js.snap
+++ b/commands/version/__tests__/__snapshots__/version-bump-prerelease.test.js.snap
@@ -3,6 +3,8 @@
 exports[`version patch with previous prerelease also graduates prereleased 1`] = `
 v1.0.1
 
+[ci skip]
+
 HEAD -> master, tag: v1.0.1
 
 diff --git a/lerna.json b/lerna.json
@@ -41,6 +43,8 @@ index SHA..SHA 100644
 exports[`version prerelease with immediate graduation 1`] = `
 v1.0.1-beta.4
 
+[ci skip]
+
 HEAD -> master, tag: v1.0.1-beta.4
 
 diff --git a/lerna.json b/lerna.json
@@ -68,6 +72,8 @@ index SHA..SHA 100644
 
 exports[`version prerelease with immediate graduation 2`] = `
 v1.0.1
+
+[ci skip]
 
 HEAD -> master, tag: v1.0.1
 
@@ -130,6 +136,8 @@ index SHA..SHA 100644
 exports[`version prerelease with previous prerelease bumps changed only 1`] = `
 v1.0.1-beta.4
 
+[ci skip]
+
 HEAD -> master, tag: v1.0.1-beta.4
 
 diff --git a/lerna.json b/lerna.json
@@ -150,6 +158,8 @@ index SHA..SHA 100644
 
 exports[`version prerelease with previous prerelease supersedes --conventional-commits 1`] = `
 v1.0.1-beta.4
+
+[ci skip]
 
 HEAD -> master, tag: v1.0.1-beta.4
 

--- a/commands/version/__tests__/__snapshots__/version-bump.test.js.snap
+++ b/commands/version/__tests__/__snapshots__/version-bump.test.js.snap
@@ -9,6 +9,8 @@ exports[`version bump prerelease increments version with custom --preid 1`] = `
  - package-4@4.0.1-foo.0
  - package-5@5.0.1-foo.0
 
+[ci skip]
+
 HEAD -> master, tag: package-5@5.0.1-foo.0, tag: package-4@4.0.1-foo.0, tag: package-3@3.0.1-foo.0, tag: package-2@2.0.1-foo.0, tag: package-1@1.0.1-foo.0
 
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
@@ -65,6 +67,8 @@ exports[`version bump prerelease increments version with default --preid 1`] = `
  - package-3@3.0.1-alpha.0
  - package-4@4.0.1-alpha.0
  - package-5@5.0.1-alpha.0
+
+[ci skip]
 
 HEAD -> master, tag: package-5@5.0.1-alpha.0, tag: package-4@4.0.1-alpha.0, tag: package-3@3.0.1-alpha.0, tag: package-2@2.0.1-alpha.0, tag: package-1@1.0.1-alpha.0
 

--- a/commands/version/__tests__/__snapshots__/version-command.test.js.snap
+++ b/commands/version/__tests__/__snapshots__/version-command.test.js.snap
@@ -3,6 +3,8 @@
 exports[`VersionCommand --exact updates existing exact versions 1`] = `
 "v1.0.1
 
+[ci skip]
+
 HEAD -> master, tag: v1.0.1
 
 diff --git a/lerna.json b/lerna.json
@@ -60,6 +62,8 @@ index SHA..SHA 100644
 
 exports[`VersionCommand --exact updates matching local dependencies of published packages with exact versions 1`] = `
 "v1.0.1
+
+[ci skip]
 
 HEAD -> master, tag: v1.0.1
 
@@ -129,6 +133,8 @@ Object {
 exports[`VersionCommand --no-push versions changed packages without git push 1`] = `
 "v1.0.1
 
+[ci skip]
+
 HEAD -> master, tag: v1.0.1
 
 diff --git a/lerna.json b/lerna.json
@@ -195,6 +201,8 @@ exports[`VersionCommand independent mode versions changed packages: commit 1`] =
  - package-3@4.0.0
  - package-4@4.1.0
  - package-5@5.0.1
+
+[ci skip]
 
 HEAD -> master, tag: package-5@5.0.1, tag: package-4@4.1.0, tag: package-3@4.0.0, tag: package-2@2.1.0, tag: package-1@1.0.1
 
@@ -265,6 +273,8 @@ Object {
 exports[`VersionCommand normal mode bumps all packages when major version selected 1`] = `
 "v2.0.0
 
+[ci skip]
+
 HEAD -> master, tag: v2.0.0
 
 diff --git a/lerna.json b/lerna.json
@@ -325,6 +335,8 @@ index SHA..SHA 100644
 
 exports[`VersionCommand normal mode only bumps changed packages when non-major version selected 1`] = `
 "v1.1.0
+
+[ci skip]
 
 HEAD -> master, tag: v1.1.0
 
@@ -469,6 +481,8 @@ Array [
 
 exports[`VersionCommand versions all transitive dependents after change 1`] = `
 "v2.0.0
+
+[ci skip]
 
 HEAD -> master, tag: v2.0.0
 

--- a/commands/version/__tests__/__snapshots__/version-ignore-changes.test.js.snap
+++ b/commands/version/__tests__/__snapshots__/version-ignore-changes.test.js.snap
@@ -3,6 +3,8 @@
 exports[`version --ignore-changes does not version packages with ignored changes 1`] = `
 "v1.0.1
 
+[ci skip]
+
 HEAD -> master, tag: v1.0.1
 
 lerna.json
@@ -11,6 +13,8 @@ packages/package-4/package.json"
 
 exports[`version --ignore-changes is mapped from deprecated --ignore 1`] = `
 "v1.0.1
+
+[ci skip]
 
 HEAD -> master, tag: v1.0.1
 

--- a/commands/version/__tests__/version-bump-prerelease.test.js
+++ b/commands/version/__tests__/version-bump-prerelease.test.js
@@ -96,7 +96,7 @@ test("version prerelease with existing preid bumps with the preid provide as arg
   await lernaVersion(testDir)("prerelease", "--preid", "rc");
 
   const message = await getCommitMessage(testDir);
-  expect(message).toBe("v1.0.1-rc.0");
+  expect(message).toBe("v1.0.1-rc.0\n\n[ci skip]");
 });
 
 test("version prerelease with immediate graduation", async () => {

--- a/commands/version/__tests__/version-bump.test.js
+++ b/commands/version/__tests__/version-bump.test.js
@@ -30,7 +30,7 @@ describe("version bump", () => {
     expect(PromptUtilities.select).not.toHaveBeenCalled();
 
     const message = await getCommitMessage(testDir);
-    expect(message).toBe("v1.0.1-beta.25");
+    expect(message).toBe("v1.0.1-beta.25\n\n[ci skip]");
   });
 
   it("receives --repo-version <value> as explicit [bump]", async () => {
@@ -38,7 +38,7 @@ describe("version bump", () => {
     await lernaVersion(testDir)("--repo-version", "1.0.1-beta.25");
 
     const message = await getCommitMessage(testDir);
-    expect(message).toBe("v1.0.1-beta.25");
+    expect(message).toBe("v1.0.1-beta.25\n\n[ci skip]");
   });
 
   it("errors when --repo-version and [bump] positional passed", async () => {
@@ -58,7 +58,7 @@ describe("version bump", () => {
     await lernaVersion(testDir)("v1.2.0-beta.1+deadbeef");
 
     const message = await getCommitMessage(testDir);
-    expect(message).toBe("v1.2.0-beta.1");
+    expect(message).toBe("v1.2.0-beta.1\n\n[ci skip]");
   });
 
   it("accepts semver keywords", async () => {
@@ -68,7 +68,7 @@ describe("version bump", () => {
     expect(PromptUtilities.select).not.toHaveBeenCalled();
 
     const message = await getCommitMessage(testDir);
-    expect(message).toBe("v1.1.0");
+    expect(message).toBe("v1.1.0\n\n[ci skip]");
   });
 
   it("receives --cd-version <bump>", async () => {
@@ -76,7 +76,7 @@ describe("version bump", () => {
     await lernaVersion(testDir)("--cd-version", "premajor");
 
     const message = await getCommitMessage(testDir);
-    expect(message).toBe("v2.0.0-alpha.0");
+    expect(message).toBe("v2.0.0-alpha.0\n\n[ci skip]");
   });
 
   it("errors when --cd-version and [bump] positional passed", async () => {

--- a/commands/version/__tests__/version-command.test.js
+++ b/commands/version/__tests__/version-command.test.js
@@ -194,7 +194,7 @@ describe("VersionCommand", () => {
       await lernaVersion(cwd)("--no-commit-hooks");
 
       const message = await getCommitMessage(cwd);
-      expect(message).toBe("v1.0.1");
+      expect(message).toBe("v1.0.1\n\n[ci skip]");
     });
 
     it("consumes configuration from lerna.json", async () => {
@@ -212,7 +212,7 @@ describe("VersionCommand", () => {
       await lernaVersion(cwd)();
 
       const message = await getCommitMessage(cwd);
-      expect(message).toBe("v1.0.1");
+      expect(message).toBe("v1.0.1\n\n[ci skip]");
     });
   });
 
@@ -368,7 +368,7 @@ describe("VersionCommand", () => {
       expect(PromptUtilities.confirm).not.toHaveBeenCalled();
 
       const message = await getCommitMessage(testDir);
-      expect(message).toBe("v1.0.1");
+      expect(message).toBe("v1.0.1\n\n[ci skip]");
     });
   });
 
@@ -609,7 +609,7 @@ describe("VersionCommand", () => {
       expect(PromptUtilities.confirm).not.toHaveBeenCalled();
 
       const message = await getCommitMessage(testDir);
-      expect(message).toBe("v1.0.1");
+      expect(message).toBe("v1.0.1\n\n[ci skip]");
     });
   });
 });

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -561,7 +561,9 @@ class VersionCommand extends Command {
   gitCommitAndTagVersionForUpdates() {
     const tags = this.packagesToVersion.map(pkg => `${pkg.name}@${this.updatesVersions.get(pkg.name)}`);
     const subject = this.options.message || "Publish";
-    const message = tags.reduce((msg, tag) => `${msg}${os.EOL} - ${tag}`, `${subject}${os.EOL}`);
+    let message = tags.reduce((msg, tag) => `${msg}${os.EOL} - ${tag}`, `${subject}${os.EOL}`);
+
+    message += "\n\n[ci skip]";
 
     return Promise.resolve()
       .then(() => gitCommit(message, this.gitOpts, this.execOpts))
@@ -572,9 +574,11 @@ class VersionCommand extends Command {
   gitCommitAndTagVersion() {
     const version = this.globalVersion;
     const tag = `${this.tagPrefix}${version}`;
-    const message = this.options.message
+    let message = this.options.message
       ? this.options.message.replace(/%s/g, tag).replace(/%v/g, version)
       : tag;
+
+    message += "\n\n[ci skip]";
 
     return Promise.resolve()
       .then(() => gitCommit(message, this.gitOpts, this.execOpts))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When lerna is used for automatic releases in a CI using `--yes`, the publish commit triggers another auto-release (which is bad). This adds a `[ci skip]` to all publish commit messages to avoid it.

## Motivation and Context

Avoid unnecessary releases.

## How Has This Been Tested?

Just unit tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
