### PR TITLE
feat(global-options): Default concurrency to logical CPU count

### DIFF
--- a/core/command/__tests__/command.test.js
+++ b/core/command/__tests__/command.test.js
@@ -9,6 +9,10 @@ const tempy = require("tempy");
 
 // partially mocked
 const ChildProcessUtilities = require("@lerna/child-process");
+const os = require("os");
+
+// normalize concurrency across different environments (localhost, CI, etc)
+jest.spyOn(os, "cpus").mockImplementation(() => new Array(42));
 
 // helpers
 const initFixture = require("@lerna-test/init-fixture")(__dirname);
@@ -70,14 +74,14 @@ describe("core-command", () => {
       const command = testFactory({ concurrency: "bla" });
       await command;
 
-      expect(command.concurrency).toBe(4);
+      expect(command.concurrency).toBe(42);
     });
 
     it("should fall back to default if concurrency given is 0", async () => {
       const command = testFactory({ concurrency: 0 });
       await command;
 
-      expect(command.concurrency).toBe(4);
+      expect(command.concurrency).toBe(42);
     });
 
     it("should fall back to 1 if concurrency given is smaller than 1", async () => {

--- a/core/command/index.js
+++ b/core/command/index.js
@@ -4,6 +4,7 @@ const _ = require("lodash");
 const dedent = require("dedent");
 const execa = require("execa");
 const log = require("npmlog");
+const os = require("os");
 
 const PackageGraph = require("@lerna/package-graph");
 const Project = require("@lerna/project");
@@ -14,7 +15,7 @@ const cleanStack = require("./lib/clean-stack");
 const logPackageError = require("./lib/log-package-error");
 const warnIfHanging = require("./lib/warn-if-hanging");
 
-const DEFAULT_CONCURRENCY = 4;
+const DEFAULT_CONCURRENCY = os.cpus().length;
 
 class Command {
   constructor(argv) {

--- a/core/global-options/README.md
+++ b/core/global-options/README.md
@@ -6,7 +6,7 @@
 
 ### `--concurrency`
 
-How many threads to use when Lerna parallelizes the tasks (defaults to `4`)
+How many threads to use when Lerna parallelizes the tasks (defaults to count of logical CPU cores)
 
 ```sh
 $ lerna publish --concurrency 1

--- a/core/global-options/index.js
+++ b/core/global-options/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const os = require("os");
+
 module.exports = globalOptions;
 
 function globalOptions(yargs) {
@@ -11,7 +13,7 @@ function globalOptions(yargs) {
       type: "string",
     },
     concurrency: {
-      defaultDescription: "4",
+      defaultDescription: `count of logical CPU cores (${os.cpus().length})`,
       describe: "How many processes to use when lerna parallelizes tasks.",
       type: "number",
       requiresArg: true,

--- a/core/global-options/index.js
+++ b/core/global-options/index.js
@@ -13,7 +13,7 @@ function globalOptions(yargs) {
       type: "string",
     },
     concurrency: {
-      defaultDescription: `count of logical CPU cores (${os.cpus().length})`,
+      defaultDescription: os.cpus().length,
       describe: "How many processes to use when lerna parallelizes tasks.",
       type: "number",
       requiresArg: true,


### PR DESCRIPTION
## Description
The PR makes little changes to set concurrency option to count of logical CPU cores by default.

## Motivation and Context
`--concurrency` option is set to `4` by default what can be not the best value with different count of CPUs.
Setting the option to specific number isn't good options cause the same script can be run on different servers.

Fixes #1929 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unfortunately, my computer have 4 logical CPU what was the value before my changes, so for now I didn't test what is effected. I'm going to run lerna tests in virtual environments with different count of CPU cores.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
