### PR TITLE
Add Unchanged option to interactive version prompt

### DIFF
--- a/commands/version/__tests__/__snapshots__/version-command.test.js.snap
+++ b/commands/version/__tests__/__snapshots__/version-command.test.js.snap
@@ -461,6 +461,10 @@ Array [
           "name": "Custom Version",
           "value": "CUSTOM",
         },
+        Object {
+          "name": "Unchanged",
+          "value": "1.0.0",
+        },
       ],
     },
   ],

--- a/commands/version/lib/prompt-version.js
+++ b/commands/version/lib/prompt-version.js
@@ -38,6 +38,7 @@ function promptVersion(currentVersion, name, prereleaseId) {
       { value: premajor, name: `Premajor (${premajor})` },
       { value: "PRERELEASE", name: "Custom Prerelease" },
       { value: "CUSTOM", name: "Custom Version" },
+      { value: currentVersion, name: "Unchanged" },
     ],
   }).then(choice => {
     if (choice === "CUSTOM") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When using the interactive version prompt from `lerna version` (in independent mode), add an option to leave the version the unchanged.

Fixes #1963 

## Description
<!--- Describe your changes in detail -->
When the `Unchanged` option is selected, the returned version `value` is the current version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A small quality of life change for projects that do partial releases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The snapshot test has been updated to include the `Unchanged` option.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
