### PR TITLE
provide a way to list lerna deps as an adjacency matrix

### DIFF
--- a/commands/list/README.md
+++ b/commands/list/README.md
@@ -32,6 +32,7 @@ In any case, you can always pass `--loglevel silent` to create pristine chains o
 - [`-l`, `--long`](#--long)
 - [`-p`, `--parseable`](#--parseable)
 - [`--toposort`](#--toposort)
+- [`--graph`](#--graph)
 
 `lerna ls` also respects all available [Filter Flags](https://www.npmjs.com/package/@lerna/filter-options).
 
@@ -142,4 +143,18 @@ $ json dependencies <packages/pkg-1/package.json
 $ lerna ls --toposort
 package-2
 package-1
+```
+
+### `--graph`
+
+Prints packages with an array of dependencies for each one as a JSON.
+
+```sh
+$ lerna ls --graph
+{
+  "pkg-1": [
+    "pkg-2"
+  ],
+  "pkg-2": []
+}
 ```

--- a/utils/listable/__tests__/listable-format.test.js
+++ b/utils/listable/__tests__/listable-format.test.js
@@ -72,6 +72,15 @@ pkg-2 MISSING pkgs/pkg-2
 `);
     });
 
+    test("json (graph) output", () => {
+      const { count, text } = formatWithOptions({ graph: true });
+
+      expect(count).toBe(2);
+      expect(text).toMatch(`
+      {"pkg-1":["pkg-2"],"pkg-2":[]}
+`);
+    });
+
     test("all long output", () => {
       const { text } = formatWithOptions({ long: true, all: true });
 

--- a/utils/listable/__tests__/listable-format.test.js
+++ b/utils/listable/__tests__/listable-format.test.js
@@ -76,8 +76,13 @@ pkg-2 MISSING pkgs/pkg-2
       const { count, text } = formatWithOptions({ graph: true });
 
       expect(count).toBe(2);
-      expect(text).toMatch(`
-      {"pkg-1":["pkg-2"],"pkg-2":[]}
+      expect(text).toMatchInlineSnapshot(`
+{
+  "pkg-1": [
+    "pkg-2"
+  ],
+  "pkg-2": []
+}
 `);
     });
 

--- a/utils/listable/__tests__/listable-options.test.js
+++ b/utils/listable/__tests__/listable-options.test.js
@@ -41,4 +41,8 @@ describe("listable.options()", () => {
   it("provides --toposort", () => {
     expect(parsed("--toposort")).toHaveProperty("toposort", true);
   });
+
+  it("provides --graph", () => {
+    expect(parsed("--graph")).toHaveProperty("graph", true);
+  });
 });

--- a/utils/listable/lib/listable-format.js
+++ b/utils/listable/lib/listable-format.js
@@ -20,6 +20,8 @@ function listableFormat(pkgList, options) {
     text = formatNDJSON(resultList);
   } else if (viewOptions.showParseable) {
     text = formatParseable(resultList, viewOptions);
+  } else if (viewOptions.showGraph) {
+    text = formatJsonGraph(resultList, viewOptions);
   } else {
     text = formatColumns(resultList, viewOptions);
   }
@@ -37,6 +39,7 @@ function parseViewOptions(options) {
     showNDJSON: options.ndjson,
     showParseable: options.parseable,
     isTopological: options.toposort,
+    showGraph: options.graph,
   };
 }
 
@@ -69,6 +72,14 @@ function toJSONList(resultList) {
 
 function formatJSON(resultList) {
   return JSON.stringify(toJSONList(resultList), null, 2);
+}
+
+function formatJsonGraph(resultList) {
+  const graph = {};
+  for (const pkg of resultList) {
+    graph[pkg.name] = Object.keys(pkg.dependencies || []);
+  }
+  return JSON.stringify(graph);
 }
 
 function formatNDJSON(resultList) {

--- a/utils/listable/lib/listable-format.js
+++ b/utils/listable/lib/listable-format.js
@@ -79,7 +79,7 @@ function formatJsonGraph(resultList) {
   for (const pkg of resultList) {
     graph[pkg.name] = Object.keys(pkg.dependencies || []);
   }
-  return JSON.stringify(graph);
+  return JSON.stringify(graph, null, 2);
 }
 
 function formatNDJSON(resultList) {

--- a/utils/listable/lib/listable-options.js
+++ b/utils/listable/lib/listable-options.js
@@ -37,5 +37,10 @@ function listableOptions(yargs) {
       describe: "Sort packages in topological order instead of lexical by directory",
       type: "boolean",
     },
+    graph: {
+      group: "Command Options:",
+      describe: "Shows dependency graph in an adjacency matrix form (Json)",
+      type: "boolean",
+    },
   });
 }


### PR DESCRIPTION
## Description
For large monorepo there is a need to show packages dependencies , i added a 'graph' option to lerna 'list' command in order to print out a json showing dependencies for each package.

Dependency graph could then be rendered using a nice tool such as https://www.npmjs.com/package/dependo

## Types of changes
- [ x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
