### PR TITLE
fix numeric bin script names

### DIFF
--- a/core/package/index.js
+++ b/core/package/index.js
@@ -64,12 +64,18 @@ class Package {
       },
       // immutable
       bin: {
+        // name to path, e.g. { "filename": "bin/filename" }
         value:
-          typeof pkg.bin === "string"
+          typeof pkg.bin === "undefined"
+            ? {}
+            : typeof pkg.bin === "string"
             ? {
                 [binSafeName(resolved)]: pkg.bin,
               }
-            : Object.assign({}, pkg.bin),
+            : pkg.bin.reduce((acc, name) => {
+                acc[name.substr(name.lastIndexOf("/") + 1)] = name;
+                return acc;
+              }, {}),
       },
       scripts: {
         value: Object.assign({}, pkg.scripts),


### PR DESCRIPTION
## Description
Original `Object.assign({}, pkg.bin)` returned e.g. { 0: "bin/cmnd" }.
New code guards undefined and returns e.g. { "cmnd": "bin/cmnd" }, as
expected by `symlinkBinary`.

## Motivation and Context
addresses [#1974]

## How Has This Been Tested?
Tested locally on a [purpose-built test repo](https://github.com/ericprud/lerna-repo-tutorial/tree/testing) and on [shex.js modular repo](https://github.com/shexSpec/shex.js/tree/modular).
Running `node ./node_modules/.bin/lerna add @scope1/cli packages/scope1-test` results in `.bin/` scripts like `command1 -> ../../../scope1-cli/bin/command1` instead of `0 -> ../../../scope1-cli/bin/command1`.
I expect there was some change to deal with the other branch in the inline conditional resulting in the initialization of an object from an array.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [?] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
