### PR TITLE
fix(publish) Pass only the project scope to libnpmpublish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -760,6 +760,7 @@
         "figgy-pudding": "^3.5.1",
         "fs-extra": "^7.0.0",
         "libnpmpublish": "^1.1.1",
+        "npm-package-arg": "^6.1.0",
         "npmlog": "^4.1.2",
         "pify": "^3.0.0",
         "read-package-json": "^2.0.13"

--- a/utils/npm-publish/__tests__/npm-publish.test.js
+++ b/utils/npm-publish/__tests__/npm-publish.test.js
@@ -32,7 +32,7 @@ describe("npm-publish", () => {
   const tarFilePath = "/tmp/test-1.10.100.tgz";
   const rootPath = path.normalize("/test");
   const pkg = new Package(
-    { name: "test", version: "1.10.100" },
+    { name: "@scope/test", version: "1.10.100" },
     path.join(rootPath, "npmPublish/test"),
     rootPath
   );
@@ -49,8 +49,8 @@ describe("npm-publish", () => {
       mockTarData,
       expect.figgyPudding({
         dryRun: false,
-        projectScope: "test",
         tag: "published-tag",
+        projectScope: "@scope",
       })
     );
   });
@@ -127,7 +127,7 @@ describe("npm-publish", () => {
 
   it("calls publish lifecycles", async () => {
     const aFiggyPudding = expect.figgyPudding({
-      projectScope: "test",
+      projectScope: "@scope",
     });
 
     await npmPublish(pkg, tarFilePath);

--- a/utils/npm-publish/npm-publish.js
+++ b/utils/npm-publish/npm-publish.js
@@ -7,6 +7,7 @@ const pify = require("pify");
 const readJSON = require("read-package-json");
 const figgyPudding = require("figgy-pudding");
 const runLifecycle = require("@lerna/run-lifecycle");
+const npa = require("npm-package-arg");
 
 module.exports = npmPublish;
 
@@ -30,11 +31,13 @@ const PublishConfig = figgyPudding(
 );
 
 function npmPublish(pkg, tarFilePath, _opts) {
+  const { scope, name } = npa(pkg.name);
+  // pass only the package scope to libnpmpublish
   const opts = PublishConfig(_opts, {
-    projectScope: pkg.name,
+    projectScope: scope,
   });
 
-  opts.log.verbose("publish", pkg.name);
+  opts.log.verbose("publish", name);
 
   let chain = Promise.resolve();
 

--- a/utils/npm-publish/npm-publish.js
+++ b/utils/npm-publish/npm-publish.js
@@ -31,13 +31,13 @@ const PublishConfig = figgyPudding(
 );
 
 function npmPublish(pkg, tarFilePath, _opts) {
-  const { scope, name } = npa(pkg.name);
+  const { scope } = npa(pkg.name);
   // pass only the package scope to libnpmpublish
   const opts = PublishConfig(_opts, {
     projectScope: scope,
   });
 
-  opts.log.verbose("publish", name);
+  opts.log.verbose("publish", pkg.name);
 
   let chain = Promise.resolve();
 

--- a/utils/npm-publish/package.json
+++ b/utils/npm-publish/package.json
@@ -35,6 +35,7 @@
     "figgy-pudding": "^3.5.1",
     "fs-extra": "^7.0.0",
     "libnpmpublish": "^1.1.1",
+    "npm-package-arg": "^6.1.0",
     "npmlog": "^4.1.2",
     "pify": "^3.0.0",
     "read-package-json": "^2.0.13"

--- a/utils/npm-publish/package.json
+++ b/utils/npm-publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lerna/npm-publish",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "An internal Lerna tool",
   "keywords": [
     "lerna",


### PR DESCRIPTION
## Description
Parse the `@scope` from the full package name using `npm-package-arg` and set `projectScope`. 

The `projectScope` parameter is used by `libnpmpublish` to set the `HTTP_NPM_SCOPE` header.

## Motivation and Context
When publishing scoped packages with Lerna, the `projectScope` used by `libnpmpublish` was being set using the full package name (`@scope/name`). 

This behavior caused some third-party registries to fail when verifying the `HTTP_NPM_SCOPE` header which was expected to match the package `@scope`.

## How Has This Been Tested?
These changes have been tested against the official npm registry and third-party registries to ensure that only the `@scope` parameter will go through `libnpmpublish` as the `projectScope`. 

Updated tests in `npm-publish.test` to include `@scope`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Related issue
Fixes #1968 