### PR TITLE
feat: alias add command with install

### DIFF
--- a/commands/add/README.md
+++ b/commands/add/README.md
@@ -10,6 +10,8 @@ Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` C
 $ lerna add <package>[@version] [--dev] [--exact]
 ```
 
+The `add` command is aliased to `install` as well to mirror `npm` semantics, ie. `lerna install <package>[@version] [--dev] [--exact]`
+
 Add local or remote `package` as dependency to packages in the current Lerna repo.
 
 When run, this command will:

--- a/commands/add/command.js
+++ b/commands/add/command.js
@@ -7,6 +7,8 @@ const filterable = require("@lerna/filter-options");
  */
 exports.command = "add <pkg> [globs..]";
 
+exports.aliases = ["install"];
+
 exports.describe = "Add a single dependency to matched packages";
 
 exports.builder = yargs => {
@@ -57,7 +59,8 @@ exports.builder = yargs => {
     .example("$0 add module-1 --scope=module-2 --dev", "Install module-1 to module-2 in devDependencies")
     .example("$0 add module-1", "Install module-1 in all modules except module-1")
     .example("$0 add module-1 --no-bootstrap", "Skip automatic `lerna bootstrap`")
-    .example("$0 add babel-core", "Install babel-core in all modules");
+    .example("$0 add babel-core", "Install babel-core in all modules")
+    .example("$0 install babel-core", "Install babel-core in all modules");
 
   return filterable(yargs);
 };


### PR DESCRIPTION
Thanks for Lerna ❤️!

EDIT: typo and wording

## Summary
This PR simply adds an alias to the `lerna add` command. `lerna install` will operate exactly the same as `lerna add`. This was _incredibly_ simple to add due to `lerna`'s use of `yargs` command modules 👍 

## Reasoning
Correct me if I am wrong in any of these assumptions. It seems that `lerna` originally leaned more towards `yarn` as the default underlying package manager, based on `lerna`'s cli, the ease of yarn workspaces, and some GitHub issues that I have read over in the repo.

Due to some unintuitive/opinionated moves by `yarn`, as well as the yarn community not reaching across the aisle to help build/maintain `npm`, `lerna` switched to leaning more towards `npm`; after all the default `npmClient` _is_ `npm` now. However, `lerna`'s api for adding a dep still aligns with `yarn add`, not `npm install`.

I think it kosher that `lerna`, now electing `npm` as the default `npmClient` in `lerna.json` should also mirror `npm`'s arguably most commonly used command, `install`.

I think a separate discussion (or perhaps here?) could be had around updating the documentation to be `install` centric and not `add` centric, but that would be a little weird, given the name of the package 😅.

Let me know what else is needed and thanks again! 🙏 

## Types of changes
- New feature (non-breaking change which adds functionality) this only aliases `lerna add` with `lerna install`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
