### PR TITLE
fix(exec): Handle node string error codes before setting process.exitCode

### DIFF
--- a/integration/lerna-exec.test.js
+++ b/integration/lerna-exec.test.js
@@ -175,4 +175,17 @@ success!
 
     expect.hasAssertions();
   });
+
+  test("string node error code is not swallowed", async () => {
+    const cwd = await initFixture("lerna-exec");
+    const args = ["exec", "--no-bail", "--concurrency=1", "--", "thing-that-is-missing"];
+
+    try {
+      await cliRunner(cwd)(...args);
+    } catch (err) {
+      expect(err.code).toBeGreaterThan(0);
+    }
+
+    expect.hasAssertions();
+  });
 });


### PR DESCRIPTION
Thanks for the awesome project!

<!--- Provide a general summary of your changes in the Title above -->
Handle node string error codes before setting process.exitCode in implementation of `lerna exec` command.
## Description
<!--- Describe your changes in detail -->
Added a switch statement based on the result exit code type that does the following:
- in case of a number exit code simply returns it
- in case of a string error code looks it up in `os.constants.errno` and returns a number from there
- in case of another type throws a `TypeError`

Also added a unit test, but since it can only fail under windows, and lerna does not seem to run tests under windows, I'm not sure how useful that test will be.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Yesterday I ran into a problem with `lerna exec` under windows 10 (this does not seem to happen under linux). I do the following:

```bat
lerna exec --concurrency=1 --no-bail -- custom-command
```

Where `custom-command` could potentially fail with an `ENOENT`. The commands fail, but `lerna exec` reports success and `NaN` exit code:
![GH SS](https://user-images.githubusercontent.com/10573234/55960439-737cd280-5c75-11e9-82e0-d4c8b87ac636.png)


The exit code gets swallowed and some tools, like git hooks, successfully pass, when that shouldn't be the case.

Some investigation into your `child-process` module and `execa` led me to the observation that a certain code path returns such a `result` whose `result.code` property can be a node error string like `ENOENT`, `EEXIST` and so on.

I'm not a 100% sure that my way is the best way to address this, moving this logic to `child-process` might be better.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Added a unit test which fails under windows without my changes and passes when they're applied. Also gave it a spin on my linux machine.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
