### PR TITLE
fix(import): Avoid "unrecognized input" error from colors when using `--flatten`

### DIFF
--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -151,6 +151,7 @@ class ImportCommand extends Command {
         "--stat",
         "--binary",
         "-1",
+        "--color=never",
         sha,
         // custom git prefixes for accurate parsing of filepaths (#1655)
         `--src-prefix=COMPARE_A/`,


### PR DESCRIPTION
Resolves issue when color in the output would create invalid output

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Resolves the same or similar problem described here:
https://github.com/lerna/lerna/issues/1644

Basically, calling `git log` would contain colorized output that leads to problems when calling `git am ...`

Note: It resolves only when the `--flatten` parameter is set!

Kudos to random StackOverflow dude who pointed me in the direction of the right fix:
https://stackoverflow.com/a/53191568/747678

## How Has This Been Tested?
I checked out the lerna repos locally, made the change, used `npm link` and ran `lerna import --flatten some-dir` that way to see the import worked successfully.  Also ran integration test `npm run integration -- lerna-import`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
