### PR TITLE
fix(version): Resolve prerelease for version without bump

### DIFF
--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -278,10 +278,9 @@ class VersionCommand extends Command {
     const { bump, conventionalCommits, preid } = this.options;
     const repoVersion = bump ? semver.clean(bump) : "";
     const increment = bump && !semver.valid(bump) ? bump : "";
-    const isPrerelease = increment.startsWith("pre");
 
     const getExistingPreId = version => (semver.prerelease(version) || []).shift();
-    const resolvePrereleaseId = existingPreid => preid || (isPrerelease && existingPreid) || "alpha";
+    const resolvePrereleaseId = existingPreid => preid || existingPreid || "alpha";
 
     const makeGlobalVersionPredicate = nextVersion => {
       this.globalVersion = nextVersion;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #2025

## Description
<!--- Describe your changes in detail -->
This PR modifies the `resolvePrereleaseId` function to use the package's prerelease identifier as the default identifier when it exists, not only when when the `bump` CLI arg is an increment keyword.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the existing prerelease identifier is only used when `lerna version` is provided an increment bump. This means that if the current version is `1.0.0-beta.2`, the "Custom Prerelease" prompt's default value is `alpha`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran the existing tests, but haven't added any new ones yet. I was looking at the tests in [`prompt-version.test.js`](https://github.com/lerna/lerna/blob/c599c64b11f06afe2fa16ed2c448b16de7da147a/commands/version/__tests__/prompt-version.test.js), but those use a custom `resolvePrereleaseId` function. I'd be happy to add a test, but I'm not sure what the best way to test the `resolvePrereleaseId` function created in `getVersionsForUpdates` is.

I'm not actually sure why the `isPrerelease` check exists, so I'm not sure if removing it will break anything. I didn't have any luck tracing the code's history (it was introduced in #1522) to see why it was originally added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
