### PR TITLE
feat(publish): display uncommitted changes in check-working-tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -736,6 +736,7 @@
     "@lerna/check-working-tree": {
       "version": "file:utils/check-working-tree",
       "requires": {
+        "@lerna/collect-uncommitted": "file:utils/collect-uncommitted",
         "@lerna/describe-ref": "file:utils/describe-ref",
         "@lerna/validation-error": "file:core/validation-error"
       }
@@ -768,6 +769,13 @@
         "dedent": "^0.7.0",
         "npmlog": "^4.1.2",
         "yargs": "^12.0.1"
+      }
+    },
+    "@lerna/collect-uncommitted": {
+      "version": "file:utils/collect-uncommitted",
+      "requires": {
+        "@lerna/child-process": "file:core/child-process",
+        "chalk": "^2.3.1"
       }
     },
     "@lerna/collect-updates": {
@@ -1252,14 +1260,29 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@octokit/endpoint": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-4.1.1.tgz",
-      "integrity": "sha512-lfphGC9hglBDiIOU84f1xDUzjWE5j3jGkO3Ng/IpDDVARw760A+/x408JOEpdV20ZUj2GRWdDBC0+HPu5qA5gQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-4.2.2.tgz",
+      "integrity": "sha512-5IZjkUNhx5q0IRN7Juwf5A+Lu2qAso7ULST7C1P2mbGHePuCOk936Stcl/5GdJpB3ovD8M6/Lv3xra6Mn0IKNQ==",
       "requires": {
         "deepmerge": "3.2.0",
-        "is-plain-object": "^2.0.4",
+        "is-plain-object": "^3.0.0",
         "universal-user-agent": "^2.0.1",
         "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        }
       }
     },
     "@octokit/plugin-enterprise-rest": {
@@ -1268,24 +1291,39 @@
       "integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw=="
     },
     "@octokit/request": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-3.0.0.tgz",
-      "integrity": "sha512-DZqmbm66tq+a9FtcKrn0sjrUpi0UaZ9QPUCxxyk/4CJ2rseTMpAWRf6gCwOSUCzZcx/4XVIsDk+kz5BVdaeenA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-aH61OVkMKMofGW/go2x4mJ44X4U/JF8xsiFFictwkZYtz0psE8OPKpsP2TZBZaJoCg2wmeTyEgqGfY+veg0hGQ==",
       "requires": {
         "@octokit/endpoint": "^4.0.0",
         "deprecation": "^1.0.1",
-        "is-plain-object": "^2.0.4",
+        "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
         "universal-user-agent": "^2.0.1"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        }
       }
     },
     "@octokit/rest": {
-      "version": "16.25.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.25.0.tgz",
-      "integrity": "sha512-QKIzP0gNYjyIGmY3Gpm3beof0WFwxFR+HhRZ+Wi0fYYhkEUvkJiXqKF56Pf5glzzfhEwOrggfluEld5F/ZxsKw==",
+      "version": "16.25.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.25.1.tgz",
+      "integrity": "sha512-a1Byzjj07OMQNUQDP5Ng/rChaI7aq6TNMY1ZFf8+zCVEEtYzCgcmrFG9BDerFbLPPKGQ5TAeRRFyLujUUN1HIg==",
       "requires": {
-        "@octokit/request": "3.0.0",
+        "@octokit/request": "3.0.1",
         "atob-lite": "^2.0.0",
         "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
@@ -6489,9 +6527,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
     },
     "node-fetch-npm": {
       "version": "2.0.2",

--- a/utils/check-working-tree/CHANGELOG.md
+++ b/utils/check-working-tree/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unpublished
+
+### Features
+
+* Display uncommitted changes in error message when working tree is dirty.
+
 ## [3.13.3](https://github.com/lerna/lerna/compare/v3.13.2...v3.13.3) (2019-04-17)
 
 **Note:** Version bump only for package @lerna/check-working-tree

--- a/utils/check-working-tree/__tests__/check-working-tree.test.js
+++ b/utils/check-working-tree/__tests__/check-working-tree.test.js
@@ -1,8 +1,10 @@
 "use strict";
 
 jest.mock("@lerna/describe-ref");
+jest.mock("@lerna/collect-uncommitted");
 
 const describeRef = require("@lerna/describe-ref");
+const collectUncommitted = require("@lerna/collect-uncommitted");
 const checkWorkingTree = require("../lib/check-working-tree");
 
 describe("check-working-tree", () => {
@@ -29,13 +31,25 @@ describe("check-working-tree", () => {
 
   it("rejects when working tree has uncommitted changes", async () => {
     describeRef.mockResolvedValueOnce({ isDirty: true });
+    collectUncommitted.mockResolvedValueOnce(["AD file"]);
 
     try {
       await checkWorkingTree();
     } catch (err) {
       expect(err.message).toMatch("Working tree has uncommitted changes");
+      expect(err.message).toMatch("\nAD file");
     }
 
+    expect.assertions(2);
+  });
+
+  it("passes cwd to collectUncommitted when working tree has uncommitted changes", async () => {
+    describeRef.mockResolvedValueOnce({ isDirty: true });
+    try {
+      await checkWorkingTree({ cwd: "foo" });
+    } catch (err) {
+      expect(collectUncommitted).toHaveBeenLastCalledWith({ cwd: "foo" });
+    }
     expect.assertions(1);
   });
 });

--- a/utils/collect-uncommitted/CHANGELOG.md
+++ b/utils/collect-uncommitted/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## Unpublished
+
+### Features
+
+* Create `[@lerna](https://github.com/lerna)/collect-uncommitted`

--- a/utils/collect-uncommitted/README.md
+++ b/utils/collect-uncommitted/README.md
@@ -1,0 +1,25 @@
+# `@lerna/collect-uncommitted`
+
+> Check git working tree status and collect uncommitted changes for display
+
+## Usage
+
+```js
+const collectUncommitted = require("@lerna/collect-uncommitted");
+
+// values listed here are their defaults
+const options = {
+  cwd: process.cwd(),
+};
+
+(async () => {
+  try {
+    const results = await collectUncommitted(options);
+    console.log(`Uncommitted changes on CWD ${options.cwd}: ${results.join("\n")}`);
+  } catch (err) {
+    console.error(err.message);
+  }
+})();
+```
+
+Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` CLI.

--- a/utils/collect-uncommitted/__tests__/collect-uncommitted.js
+++ b/utils/collect-uncommitted/__tests__/collect-uncommitted.js
@@ -1,0 +1,78 @@
+"use strict";
+
+jest.mock("@lerna/child-process");
+
+const chalk = require("chalk");
+const childProcess = require("@lerna/child-process");
+const collectUncommitted = require("../lib/collect-uncommitted");
+
+const stats = `AD file1
+ D file2
+ M path/to/file3
+AM path/file4
+MM path/file5
+M  file6
+D  file7
+UU file8
+?? file9`;
+
+const GREEN_A = chalk.green("A");
+const GREEN_M = chalk.green("M");
+const GREEN_D = chalk.green("D");
+const RED_D = chalk.red("D");
+const RED_M = chalk.red("M");
+const RED_UU = chalk.red("UU");
+const RED_QQ = chalk.red("??");
+
+const colorizedAry = [
+  `${GREEN_A}${RED_D} file1`,
+  ` ${RED_D} file2`,
+  ` ${RED_M} path/to/file3`,
+  `${GREEN_A}${RED_M} path/file4`,
+  `${GREEN_M}${RED_M} path/file5`,
+  `${GREEN_M}  file6`,
+  `${GREEN_D}  file7`,
+  `${RED_UU} file8`,
+  `${RED_QQ} file9`,
+];
+
+childProcess.exec.mockResolvedValue(stats);
+childProcess.execSync.mockReturnValue(stats);
+
+describe("collectUncommitted()", () => {
+  it("resolves an array of uncommitted changes", async () => {
+    const result = await collectUncommitted();
+    expect(childProcess.exec).toHaveBeenLastCalledWith("git", "status -s", {});
+    expect(result).toEqual(colorizedAry);
+  });
+
+  it("empty array on clean repo", async () => {
+    childProcess.exec.mockResolvedValueOnce("");
+    const result = await collectUncommitted();
+    expect(childProcess.exec).toHaveBeenLastCalledWith("git", "status -s", {});
+    expect(result).toEqual([]);
+  });
+
+  it("accepts options.cwd", async () => {
+    const options = { cwd: "foo" };
+    await collectUncommitted(options);
+
+    expect(childProcess.exec).toHaveBeenLastCalledWith("git", "status -s", options);
+  });
+
+  describe("collectUncommitted.sync()", () => {
+    it("returns an array of uncommitted changes", async () => {
+      const result = collectUncommitted.sync();
+
+      expect(childProcess.execSync).toHaveBeenLastCalledWith("git", "status -s", {});
+      expect(result).toEqual(colorizedAry);
+    });
+
+    it("accepts options.cwd", async () => {
+      const options = { cwd: "foo" };
+      collectUncommitted.sync(options);
+
+      expect(childProcess.execSync).toHaveBeenLastCalledWith("git", "status -s", options);
+    });
+  });
+});

--- a/utils/collect-uncommitted/lib/collect-uncommitted.js
+++ b/utils/collect-uncommitted/lib/collect-uncommitted.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const chalk = require("chalk");
+const { exec, execSync } = require("@lerna/child-process");
+
+module.exports = collectUncommitted;
+module.exports.sync = sync;
+
+const maybeColorize = colorize => s => (s !== " " ? colorize(s) : s);
+const cRed = maybeColorize(chalk.red);
+const cGreen = maybeColorize(chalk.green);
+
+const replaceStatus = (_, maybeGreen, maybeRed) => `${cGreen(maybeGreen)}${cRed(maybeRed)}`;
+
+const colorizeStats = stats =>
+  stats.replace(/^([^U]| )([A-Z]| )/gm, replaceStatus).replace(/^\?{2}|U{2}/gm, cRed("$&"));
+
+const splitOnNewLine = (string = "") => string.split("\n");
+
+const filterEmpty = (strings = []) => strings.filter(s => s.length !== 0);
+
+const o = (l, r) => x => l(r(x));
+
+const transformOutput = o(filterEmpty, o(splitOnNewLine, colorizeStats));
+
+function collectUncommitted(options = {}) {
+  return exec("git", "status -s", options).then(transformOutput);
+}
+
+function sync(options = {}) {
+  const stdout = execSync("git", "status -s", options);
+  return transformOutput(stdout);
+}

--- a/utils/collect-uncommitted/package.json
+++ b/utils/collect-uncommitted/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@lerna/check-working-tree",
+  "name": "@lerna/collect-uncommitted",
   "version": "3.13.3",
-  "description": "Check git working tree status and error appropriately",
+  "description": "Collect uncommitted changes to working tree for display in error messages",
   "keywords": [
     "lerna",
     "utils",
@@ -9,9 +9,12 @@
     "tree"
   ],
   "author": "Daniel Stockman <daniel.stockman@gmail.com>",
-  "homepage": "https://github.com/lerna/lerna/tree/master/utils/check-working-tree#readme",
+  "contributors": [
+    "Pedro De Ona <p.deona001@gmail.com>"
+  ],
+  "homepage": "https://github.com/lerna/lerna/tree/master/utils/collect-uncommitted#readme",
   "license": "MIT",
-  "main": "lib/check-working-tree.js",
+  "main": "lib/collect-uncommitted.js",
   "files": [
     "lib"
   ],
@@ -24,14 +27,13 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lerna/lerna.git",
-    "directory": "utils/check-working-tree"
+    "directory": "utils/collect-uncommitted"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@lerna/describe-ref": "file:../describe-ref",
-    "@lerna/validation-error": "file:../../core/validation-error",
-    "@lerna/collect-uncommitted": "file:../collect-uncommitted"
+    "@lerna/child-process": "file:../../core/child-process",
+    "chalk": "^2.3.1"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR attempts to remedy (#1860) by adding a `utils/collect-uncommitted` that will resolve an array of uncommitted changes, for use in the error message in `utils/check-working-tree`, and anywhere else it may come in handy.

I am not 100% on the formatting for the error message and would love input on the best way to display the uncommitted changes to the user.

<!--- Describe your changes in detail -->
- adds `utils/collect-uncommitted` with tests
- require `collectUncommitted` in check-working-tree, when tree is dirty `collectUncommitted` changes for display to user in error message.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See (#1680)
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Add tests in `utils/collect-uncommitted`, modify existing test in `utils/check-working-tree`, run `npx jest`, `npm run integration`. All tests pass in CI.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
