### PR TITLE
Add gitlab releases to version

### DIFF
--- a/commands/__mocks__/@lerna/gitlab-client.js
+++ b/commands/__mocks__/@lerna/gitlab-client.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const client = {
+  repos: {
+    createRelease: jest.fn(),
+  },
+};
+
+module.exports = () => client;

--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -51,7 +51,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
 - [`--exact`](#--exact)
 - [`--force-publish`](#--force-publish)
 - [`--git-remote`](#--git-remote-name)
-- [`--github-release`](#--github-release)
+- [`--create-release`](#--create-release-type)
 - [`--ignore-changes`](#--ignore-changes)
 - [`--include-merged-tags`](#--include-merged-tags)
 - [`--message`](#--message-msg)
@@ -194,19 +194,25 @@ lerna version --git-remote upstream
 
 When run with this flag, `lerna version` will push the git changes to the specified remote instead of `origin`.
 
-### `--github-release`
+### `--create-release <type>`
 
 ```sh
-lerna version --github-release --conventional-commits
+lerna version --conventional-commits --create-release github
+lerna version --conventional-commits --create-release gitlab
 ```
 
-When run with this flag, `lerna version` will create an official GitHub release based on the changed packages. Requires `--conventional-commits` to be passed so that changelogs can be generated.
+When run with this flag, `lerna version` will create an official GitHub or GitLab release based on the changed packages. Requires `--conventional-commits` to be passed so that changelogs can be generated.
 
 To authenticate with GitHub, the following environment variables can be defined.
 
 - `GH_TOKEN` (required) - Your GitHub authentication token (under Settings > Developer settings > Personal access tokens).
 - `GHE_API_URL` - When using GitHub Enterprise, an absolute URL to the API.
 - `GHE_VERSION` - When using GitHub Enterprise, the currently installed GHE version. [Supports the following versions](https://github.com/octokit/plugin-enterprise-rest.js).
+-
+To authenticate with GitLab, the following environment variables can be defined.
+
+- `GL_TOKEN` (required) - Your GitLab authentication token (under User Settings > Access Tokens).
+- `GL_API_URL` - An absolute URL to the API, including the version. (Default: https://gitlab.com/api/v4)
 
 > NOTE: When using this option, you cannot pass [`--no-changelog`](#--no-changelog).
 
@@ -288,7 +294,7 @@ lerna version --conventional-commits --no-changelog
 
 When using `conventional-commits`, do not generate any `CHANGELOG.md` files.
 
-> NOTE: When using this option, you cannot pass [`--github-release`](#--github-release).
+> NOTE: When using this option, you cannot pass [`--create-release`](#--create-release-type).
 
 ### `--no-commit-hooks`
 

--- a/commands/version/__tests__/version-gitlab-release.test.js
+++ b/commands/version/__tests__/version-gitlab-release.test.js
@@ -10,7 +10,7 @@ jest.mock("../lib/is-behind-upstream");
 jest.mock("../lib/remote-branch-exists");
 
 // mocked modules
-const { client } = require("@lerna/github-client");
+const client = require("@lerna/gitlab-client")();
 const { recommendVersion } = require("@lerna/conventional-commits");
 
 // helpers
@@ -19,19 +19,19 @@ const initFixture = require("@lerna-test/init-fixture")(__dirname);
 // test command
 const lernaVersion = require("@lerna-test/command-runner")(require("../command"));
 
-test("--github-release does not create a release if --no-push is passed", async () => {
+test("--create-release=gitlab does not create a release if --no-push is passed", async () => {
   const cwd = await initFixture("independent");
 
-  await lernaVersion(cwd)("--github-release", "--conventional-commits", "--no-push");
+  await lernaVersion(cwd)("--create-release=gitlab", "--conventional-commits", "--no-push");
 
   expect(client.repos.createRelease).not.toHaveBeenCalled();
 });
 
-test("--github-release throws an error if --conventional-commits is not passed", async () => {
+test("--create-release=gitlab throws an error if --conventional-commits is not passed", async () => {
   const cwd = await initFixture("independent");
 
   try {
-    await lernaVersion(cwd)("--github-release");
+    await lernaVersion(cwd)("--create-release=gitlab");
   } catch (err) {
     expect(err.message).toBe("To create a release, you must enable --conventional-commits");
     expect(client.repos.createRelease).not.toHaveBeenCalled();
@@ -40,11 +40,11 @@ test("--github-release throws an error if --conventional-commits is not passed",
   expect.hasAssertions();
 });
 
-test("--github-release throws an error if --no-changelog also passed", async () => {
+test("--create-release=gitlab throws an error if --no-changelog also passed", async () => {
   const cwd = await initFixture("independent");
 
   try {
-    await lernaVersion(cwd)("--github-release", "--conventional-commits", "--no-changelog");
+    await lernaVersion(cwd)("--create-release=gitlab", "--conventional-commits", "--no-changelog");
   } catch (err) {
     expect(err.message).toBe("To create a release, you cannot pass --no-changelog");
     expect(client.repos.createRelease).not.toHaveBeenCalled();
@@ -53,12 +53,12 @@ test("--github-release throws an error if --no-changelog also passed", async () 
   expect.hasAssertions();
 });
 
-test("--github-release marks a version as a pre-release if it contains a valid part", async () => {
+test("--create-release=gitlab marks a version as a pre-release if it contains a valid part", async () => {
   const cwd = await initFixture("normal");
 
   recommendVersion.mockResolvedValueOnce("2.0.0-alpha.1");
 
-  await lernaVersion(cwd)("--github-release", "--conventional-commits");
+  await lernaVersion(cwd)("--create-release=gitlab", "--conventional-commits");
 
   expect(client.repos.createRelease).toHaveBeenCalledTimes(1);
   expect(client.repos.createRelease).toHaveBeenCalledWith({
@@ -72,7 +72,7 @@ test("--github-release marks a version as a pre-release if it contains a valid p
   });
 });
 
-test("--github-release creates a release for every independent version", async () => {
+test("--create-release=gitlab creates a release for every independent version", async () => {
   const cwd = await initFixture("independent");
   const versionBumps = new Map([
     ["package-1", "1.0.1"],
@@ -84,7 +84,7 @@ test("--github-release creates a release for every independent version", async (
 
   versionBumps.forEach(bump => recommendVersion.mockResolvedValueOnce(bump));
 
-  await lernaVersion(cwd)("--github-release", "--conventional-commits");
+  await lernaVersion(cwd)("--create-release=gitlab", "--conventional-commits");
 
   expect(client.repos.createRelease).toHaveBeenCalledTimes(5);
   versionBumps.forEach((version, name) => {
@@ -100,12 +100,12 @@ test("--github-release creates a release for every independent version", async (
   });
 });
 
-test("--github-release creates a single fixed release", async () => {
+test("--create-release=gitlab creates a single fixed release", async () => {
   const cwd = await initFixture("normal");
 
   recommendVersion.mockResolvedValueOnce("1.1.0");
 
-  await lernaVersion(cwd)("--github-release", "--conventional-commits");
+  await lernaVersion(cwd)("--create-release=gitlab", "--conventional-commits");
 
   expect(client.repos.createRelease).toHaveBeenCalledTimes(1);
   expect(client.repos.createRelease).toHaveBeenCalledWith({

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -40,9 +40,10 @@ exports.builder = (yargs, composed) => {
       requiresArg: true,
       defaultDescription: "origin",
     },
-    "github-release": {
-      describe: "Create an official GitHub release for every version.",
-      type: "boolean",
+    "create-release": {
+      describe: "Create an official GitHub or GitLab release for every version.",
+      type: "string",
+      choices: ["gitlab", "github"],
     },
     "ignore-changes": {
       describe: [
@@ -171,6 +172,11 @@ exports.builder = (yargs, composed) => {
       hidden: true,
       type: "boolean",
     })
+    .option("github-release", {
+      // TODO: remove in next major release
+      hidden: true,
+      type: "boolean",
+    })
     .check(argv => {
       /* eslint-disable no-param-reassign */
       if (argv.ignore) {
@@ -200,6 +206,12 @@ exports.builder = (yargs, composed) => {
         delete argv.skipGit;
         delete argv["skip-git"];
         log.warn("deprecated", "--skip-git has been replaced by --no-git-tag-version --no-push");
+      }
+
+      if (argv.githubRelease) {
+        argv.createRelease = "github";
+        delete argv.githubRelease;
+        log.warn("deprecated", "--release has been replaced by --create-release=github");
       }
       /* eslint-enable no-param-reassign */
 

--- a/commands/version/lib/create-release.js
+++ b/commands/version/lib/create-release.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const semver = require("semver");
+
+const createGitLabClient = require("@lerna/gitlab-client");
+const { createGitHubClient, parseGitRepo } = require("@lerna/github-client");
+const ValidationError = require("@lerna/validation-error");
+
+module.exports = createRelease;
+
+function createClient(type) {
+  switch (type) {
+    case "gitlab":
+      return createGitLabClient();
+    case "github":
+      return createGitHubClient();
+    default:
+      throw new ValidationError("ERELEASE", "Invalid release client type");
+  }
+}
+
+function createRelease(type, { tags, releaseNotes }, { gitRemote, execOpts }) {
+  const repo = parseGitRepo(gitRemote, execOpts);
+  const client = createClient(type);
+
+  return Promise.all(
+    releaseNotes.map(({ notes, name }) => {
+      const tag = name === "fixed" ? tags[0] : tags.find(t => t.startsWith(`${name}@`));
+
+      /* istanbul ignore if */
+      if (!tag) {
+        return Promise.resolve();
+      }
+
+      const prereleaseParts = semver.prerelease(tag.replace(`${name}@`, "")) || [];
+
+      return client.repos.createRelease({
+        owner: repo.owner,
+        repo: repo.name,
+        tag_name: tag,
+        name: tag,
+        body: notes,
+        draft: false,
+        prerelease: prereleaseParts.length > 0,
+      });
+    })
+  );
+}

--- a/commands/version/package.json
+++ b/commands/version/package.json
@@ -40,6 +40,7 @@
     "@lerna/command": "file:../../core/command",
     "@lerna/conventional-commits": "file:../../core/conventional-commits",
     "@lerna/github-client": "file:../../utils/github-client",
+    "@lerna/gitlab-client": "file:../../utils/gitlab-client",
     "@lerna/output": "file:../../utils/output",
     "@lerna/prerelease-id-from-version": "file:../../utils/prerelease-id-from-version",
     "@lerna/prompt": "file:../../core/prompt",

--- a/core/project/__fixtures__/extends-deprecated/lerna.json
+++ b/core/project/__fixtures__/extends-deprecated/lerna.json
@@ -3,6 +3,9 @@
   "commands": {
     "bootstrap": {
       "hoist": true
+    },
+    "version": {
+      "githubRelease": true
     }
   },
   "npmTag": "next",

--- a/core/project/__tests__/project.test.js
+++ b/core/project/__tests__/project.test.js
@@ -140,7 +140,7 @@ describe("Project", () => {
       });
     });
 
-    it("renames deprecated config recursively", async () => {
+    it("updates deprecated config recursively", async () => {
       const cwd = await initFixture("extends-deprecated");
       const project = new Project(cwd);
 
@@ -157,6 +157,9 @@ Object {
         "ignored-file",
       ],
       "loglevel": "success",
+    },
+    "version": Object {
+      "createRelease": "github",
     },
   },
   "packages": Array [

--- a/core/project/lib/deprecate-config.js
+++ b/core/project/lib/deprecate-config.js
@@ -6,6 +6,10 @@ const path = require("path");
 
 module.exports = compose(
   // add new predicates HERE
+  remap("command.version.githubRelease", "command.version.createRelease", {
+    alsoRoot: true,
+    toValue: value => value && "github",
+  }),
   remap("command.publish.npmTag", "command.publish.distTag", { alsoRoot: true }),
   remap("command.publish.cdVersion", "command.publish.bump", { alsoRoot: true }),
   remap("command.publish.ignore", "command.publish.ignoreChanges"),
@@ -21,9 +25,10 @@ module.exports = compose(
  * @param {String} target Path of renamed option
  * @param {Object} opts Optional configuration object
  * @param {Boolean} opts.alsoRoot Whether to check root config as well
+ * @param {Function} opts.toValue Return the new config value given the current value
  * @return {Function} predicate accepting (config, filepath)
  */
-function remap(search, target, { alsoRoot } = {}) {
+function remap(search, target, { alsoRoot, toValue } = {}) {
   const pathsToSearch = [search];
 
   if (alsoRoot) {
@@ -34,20 +39,49 @@ function remap(search, target, { alsoRoot } = {}) {
   return obj => {
     for (const searchPath of pathsToSearch) {
       if (dotProp.has(obj.config, searchPath)) {
-        const localPath = path.relative(".", obj.filepath);
+        const fromVal = dotProp.get(obj.config, searchPath);
+        const toVal = toValue ? toValue(fromVal) : fromVal;
 
-        log.warn(
-          "project",
-          `Deprecated key "${searchPath}" found in ${localPath}\nPlease rename "${searchPath}" => "${target}"`
-        );
+        log.warn("project", deprecationMessage(obj, target, searchPath, fromVal, toVal));
 
-        dotProp.set(obj.config, target, dotProp.get(obj.config, searchPath));
+        dotProp.set(obj.config, target, toVal);
         dotProp.delete(obj.config, searchPath);
       }
     }
 
     return obj;
   };
+}
+
+/**
+ * Builds a deprecation message string that specifies
+ * a deprecated config option and suggests a correction.
+ *
+ * @param {Object} obj A config object
+ * @param {String} target Path of renamed option
+ * @param {String} searchSearch Path to deprecated option
+ * @param {Any} fromVal Current value of deprecated option
+ * @param {Any} toVal Corrected value of deprecated option
+ * @return {String} deprecation message
+ */
+function deprecationMessage(obj, target, searchPath, fromVal, toVal) {
+  const localPath = path.relative(".", obj.filepath);
+
+  let from;
+  let to;
+  if (toVal === fromVal) {
+    from = `"${searchPath}"`;
+    to = `"${target}"`;
+  } else {
+    from = stringify({ [searchPath]: fromVal });
+    to = stringify({ [target]: toVal });
+  }
+
+  return `Deprecated key "${searchPath}" found in ${localPath}\nPlease update ${from} => ${to}`;
+}
+
+function stringify(obj) {
+  return JSON.stringify(obj).slice(1, -1);
 }
 
 function compose(...funcs) {

--- a/integration/lerna-init.test.js
+++ b/integration/lerna-init.test.js
@@ -17,32 +17,32 @@ describe("lerna init", () => {
 
     const { stderr } = await cliRunner(cwd)("init");
     expect(stderr).toMatchInlineSnapshot(`
-lerna notice cli __TEST_VERSION__
-lerna info Initializing Git repository
-lerna info Creating package.json
-lerna info Creating lerna.json
-lerna info Creating packages directory
-lerna success Initialized Lerna files
-`);
+      lerna notice cli __TEST_VERSION__
+      lerna info Initializing Git repository
+      lerna info Creating package.json
+      lerna info Creating lerna.json
+      lerna info Creating packages directory
+      lerna success Initialized Lerna files
+    `);
 
     const [packageJson, lernaJson] = await loadMetaData(cwd);
     expect(packageJson).toMatchInlineSnapshot(`
-Object {
-  "devDependencies": Object {
-    "lerna": "^__TEST_VERSION__",
-  },
-  "name": "root",
-  "private": true,
-}
-`);
+      Object {
+        "devDependencies": Object {
+          "lerna": "^__TEST_VERSION__",
+        },
+        "name": "root",
+        "private": true,
+      }
+    `);
     expect(lernaJson).toMatchInlineSnapshot(`
-Object {
-  "packages": Array [
-    "packages/*",
-  ],
-  "version": "0.0.0",
-}
-`);
+      Object {
+        "packages": Array [
+          "packages/*",
+        ],
+        "version": "0.0.0",
+      }
+    `);
   });
 
   test("updates existing metadata", async () => {
@@ -50,39 +50,39 @@ Object {
 
     const { stderr } = await cliRunner(cwd)("init", "--exact");
     expect(stderr).toMatchInlineSnapshot(`
-lerna notice cli __TEST_VERSION__
-lerna WARN project Deprecated key "commands" found in lerna.json
-lerna WARN project Please rename "commands" => "command"
-lerna info Updating package.json
-lerna info Updating lerna.json
-lerna info Creating packages directory
-lerna success Initialized Lerna files
-`);
+      lerna notice cli __TEST_VERSION__
+      lerna WARN project Deprecated key "commands" found in lerna.json
+      lerna WARN project Please update "commands" => "command"
+      lerna info Updating package.json
+      lerna info Updating lerna.json
+      lerna info Creating packages directory
+      lerna success Initialized Lerna files
+    `);
 
     const [packageJson, lernaJson] = await loadMetaData(cwd);
     expect(packageJson).toMatchInlineSnapshot(`
-Object {
-  "devDependencies": Object {
-    "lerna": "__TEST_VERSION__",
-  },
-  "name": "updates",
-}
-`);
+      Object {
+        "devDependencies": Object {
+          "lerna": "__TEST_VERSION__",
+        },
+        "name": "updates",
+      }
+    `);
     expect(lernaJson).toMatchInlineSnapshot(`
-Object {
-  "command": Object {
-    "bootstrap": Object {
-      "hoist": true,
-    },
-    "init": Object {
-      "exact": true,
-    },
-  },
-  "packages": Array [
-    "packages/*",
-  ],
-  "version": "1.0.0",
-}
-`);
+      Object {
+        "command": Object {
+          "bootstrap": Object {
+            "hoist": true,
+          },
+          "init": Object {
+            "exact": true,
+          },
+        },
+        "packages": Array [
+          "packages/*",
+        ],
+        "version": "1.0.0",
+      }
+    `);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -919,6 +919,14 @@
         "npmlog": "^4.1.2"
       }
     },
+    "@lerna/gitlab-client": {
+      "version": "file:utils/gitlab-client",
+      "requires": {
+        "node-fetch": "^2.5.0",
+        "npmlog": "^4.1.2",
+        "whatwg-url": "^7.0.0"
+      }
+    },
     "@lerna/global-options": {
       "version": "file:core/global-options"
     },
@@ -1253,6 +1261,7 @@
         "@lerna/command": "file:core/command",
         "@lerna/conventional-commits": "file:core/conventional-commits",
         "@lerna/github-client": "file:utils/github-client",
+        "@lerna/gitlab-client": "file:utils/gitlab-client",
         "@lerna/output": "file:utils/output",
         "@lerna/prerelease-id-from-version": "file:utils/prerelease-id-from-version",
         "@lerna/prompt": "file:core/prompt",

--- a/utils/gitlab-client/CHANGELOG.md
+++ b/utils/gitlab-client/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/utils/gitlab-client/README.md
+++ b/utils/gitlab-client/README.md
@@ -1,0 +1,9 @@
+# `@lerna/gitlab-client`
+
+> An internal Lerna tool
+
+## Usage
+
+You probably shouldn't, at least directly.
+
+Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` CLI.

--- a/utils/gitlab-client/__tests__/GitLabClient.test.js
+++ b/utils/gitlab-client/__tests__/GitLabClient.test.js
@@ -1,0 +1,56 @@
+"use strict";
+
+jest.mock("node-fetch");
+
+const fetch = require("node-fetch");
+
+const GitLabClient = require("../lib/GitLabClient");
+
+describe("GitLabClient", () => {
+  describe("constructor", () => {
+    it("sets `baseUrl` and `token`", () => {
+      const client = new GitLabClient("http://some/host", "TOKEN");
+
+      expect(client.baseUrl).toEqual("http://some/host");
+      expect(client.token).toEqual("TOKEN");
+    });
+  });
+
+  describe("releasesUrl", () => {
+    it("returns a GitLab releases API URL", () => {
+      const client = new GitLabClient("http://some/host", "TOKEN");
+      const url = client.releasesUrl("the-namespace", "the-project");
+
+      expect(url).toEqual("http://some/host/projects/the-namespace%2Fthe-project/releases");
+    });
+  });
+
+  describe("createRelease", () => {
+    it("requests releases api with release", () => {
+      const client = new GitLabClient("http://some/host", "TOKEN");
+      fetch.mockResolvedValue({ ok: true });
+      const release = {
+        owner: "the-owner",
+        repo: "the-repo",
+        name: "the-name",
+        tag_name: "the-tag_name",
+        body: "the-body",
+      };
+
+      client.createRelease(release);
+
+      expect(fetch).toHaveBeenCalledWith("http://some/host/projects/the-owner%2Fthe-repo/releases", {
+        method: "post",
+        body: JSON.stringify({
+          name: "the-name",
+          tag_name: "the-tag_name",
+          description: "the-body",
+        }),
+        headers: {
+          "PRIVATE-TOKEN": "TOKEN",
+          "Content-Type": "application/json",
+        },
+      });
+    });
+  });
+});

--- a/utils/gitlab-client/__tests__/gitlab-client.test.js
+++ b/utils/gitlab-client/__tests__/gitlab-client.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+jest.mock("../lib/GitLabClient");
+
+const GitLabClient = require("../lib/GitLabClient");
+const createGitLabClient = require("../index");
+
+describe("createGitLabClient", () => {
+  const oldEnv = Object.assign({}, process.env);
+
+  afterEach(() => {
+    process.env = oldEnv;
+  });
+
+  it("errors if no GL_TOKEN env var", () => {
+    expect(() => {
+      createGitLabClient();
+    }).toThrow("A GL_TOKEN environment variable is required.");
+  });
+
+  it("doesnt error if GL_TOKEN env var is set", () => {
+    process.env.GL_TOKEN = "TOKEN";
+
+    expect(() => {
+      createGitLabClient();
+    }).not.toThrow();
+  });
+
+  it("sets client `baseUrl` when GL_API_URL is set", () => {
+    process.env.GL_TOKEN = "TOKEN";
+    process.env.GL_API_URL = "http://some/host";
+
+    createGitLabClient();
+
+    expect(GitLabClient).toHaveBeenCalledWith("http://some/host", "TOKEN");
+  });
+
+  it("has a createRelease method like ocktokit", () => {
+    expect(createGitLabClient().repos.createRelease).toBeInstanceOf(Function);
+  });
+});

--- a/utils/gitlab-client/index.js
+++ b/utils/gitlab-client/index.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const log = require("npmlog");
+
+const GitLabClient = require("./lib/GitLabClient");
+
+module.exports = createGitLabClient;
+
+function OcktokitAdapter(client) {
+  return { repos: { createRelease: client.createRelease.bind(client) } };
+}
+
+function createGitLabClient() {
+  const { GL_API_URL, GL_TOKEN } = process.env;
+
+  log.silly("Creating a GitLab client...");
+
+  if (!GL_TOKEN) {
+    throw new Error("A GL_TOKEN environment variable is required.");
+  }
+
+  const client = new GitLabClient(GL_API_URL, GL_TOKEN);
+
+  return OcktokitAdapter(client);
+}

--- a/utils/gitlab-client/lib/GitLabClient.js
+++ b/utils/gitlab-client/lib/GitLabClient.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const path = require("path");
+
+const { URL } = require("whatwg-url");
+const log = require("npmlog");
+const fetch = require("node-fetch");
+
+class GitLabClient {
+  constructor(baseUrl = "https://gitlab.com/api/v4", token) {
+    this.baseUrl = baseUrl;
+    this.token = token;
+  }
+
+  createRelease({ owner, repo, name, tag_name: tagName, body }) {
+    const releasesUrl = this.releasesUrl(owner, repo, "releases");
+
+    log.silly("Requesting GitLab releases", releasesUrl);
+
+    return fetch(releasesUrl, {
+      method: "post",
+      body: JSON.stringify({ name, tag_name: tagName, description: body }),
+      headers: {
+        "PRIVATE-TOKEN": this.token,
+        "Content-Type": "application/json",
+      },
+    }).then(({ ok, status, statusText }) => {
+      if (!ok) {
+        log.error("gitlab", `Failed to create release\nRequest returned ${status} ${statusText}`);
+      } else {
+        log.silly("gitlab", "Created release successfully.");
+      }
+    });
+  }
+
+  releasesUrl(namespace, project) {
+    return new URL(
+      `${this.baseUrl}/${path.join("projects", encodeURIComponent(`${namespace}/${project}`), "releases")}`
+    ).toString();
+  }
+}
+
+module.exports = GitLabClient;

--- a/utils/gitlab-client/package.json
+++ b/utils/gitlab-client/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@lerna/gitlab-client",
+  "version": "3.13.3",
+  "description": "An internal Lerna tool",
+  "keywords": [
+    "lerna",
+    "utils"
+  ],
+  "homepage": "https://github.com/lerna/lerna/tree/master/utils/gitlab-client#readme",
+  "license": "MIT",
+  "author": {
+    "name": "Luke Bennett",
+    "url": "https://gitlab.com/lbennett"
+  },
+  "files": [
+    "lib"
+  ],
+  "main": "index.js",
+  "engines": {
+    "node": ">= 6.9.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://gitlab.com/lerna/lerna.git",
+    "directory": "utils/gitlab-client"
+  },
+  "scripts": {
+    "test": "echo \"Run tests from root\" && exit 1"
+  },
+  "dependencies": {
+    "node-fetch": "^2.5.0",
+    "npmlog": "^4.1.2",
+    "whatwg-url": "^7.0.0"
+  }
+}


### PR DESCRIPTION
* Deprecate `version --github-release` in favour of `version --create-release=[gitlab|github]`.
* Add `GitLabClient` w/ `createReleases` method to create releases using GitLab API. 
* Add `createRelease` function to DRY GitLab and GitHub releases.

## Description

I think it's pretty much all there. Let me know if you need any more info.

### Links

https://docs.gitlab.com/ee/user/project/releases/index.html
https://docs.gitlab.com/ee/api/releases/index.html

### Screenshot

<img width="967" alt="Screenshot 2019-05-06 at 04 11 37" src="https://user-images.githubusercontent.com/5678671/57205242-1d215c00-6fb5-11e9-9377-018ea91fd3a0.png">

## Motivation and Context

I use https://gitlab.com and self-hosted GitLab instances to host my favouritestest repos. I would like the releases feature to work for them.

## How Has This Been Tested?

There are tests for deprecation, `GitLabClient` and `--create-release=gitlab`. _(`--create-release=github` is tested in existing `--github-release` tests)_

Tested locally with:

```
$ GL_TOKEN=[TOKEN] npx lerna version --create-release=gitlab --conventional-commits
# AND
$ GL_TOKEN=[TOKEN] GL_API_URL="https://gitlab.selfhosted.io/api/v4" npx lerna version --create-release=gitlab --conventional-commits
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

**Note:** `--github-release` has been appropriately deprecated.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
