### PR TITLE
Support 2FA for npm via --otp

### DIFF
--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -51,6 +51,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 - [`--git-head <sha>`](#--git-head-sha)
 - [`--no-git-reset`](#--no-git-reset)
 - [`--no-verify-access`](#--no-verify-access)
+- [`--otp`](#--otp)
 - [`--preid`](#--preid)
 - [`--registry <url>`](#--registry-url)
 - [`--temp-tag`](#--temp-tag)
@@ -139,6 +140,16 @@ By default, `lerna` will verify the logged-in npm user's access to the packages 
 If you are using a third-party registry that does not support `npm access ls-packages`, you will need to pass this flag (or set `command.publish.verifyAccess` to `false` in lerna.json).
 
 > Please use with caution
+
+### `--otp`
+
+When publishing to a registry that requires two-factor authentication, you can specify a "one-time password" using `--otp`:
+
+```sh
+lerna publish --otp 123456
+```
+
+> Please keep in mind that one-time passwords often expire within a few minutes of their generation. Please ensure adequate time for the publish process to complete.
 
 ### `--preid`
 

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -257,4 +257,17 @@ Map {
       }
     });
   });
+
+  describe("--otp", () => {
+    it("passes one-time password to npm commands", async () => {
+      const testDir = await initFixture("normal");
+      const otp = "123456";
+      await lernaPublish(testDir)("--otp", otp);
+      expect(npmPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "package-1" }),
+        "/TEMP_DIR/package-1-MOCKED.tgz",
+        expect.objectContaining({ otp })
+      );
+    });
+  });
 });

--- a/commands/publish/command.js
+++ b/commands/publish/command.js
@@ -77,6 +77,11 @@ exports.builder = yargs => {
     //   alias: "yes",
     //   type: "boolean",
     // },
+    otp: {
+      describe: "Supply a one-time password for publishing with two-factor authentication.",
+      type: "string",
+      requiresArg: true,
+    },
   };
 
   composeVersionOptions(yargs);

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -96,6 +96,7 @@ class PublishCommand extends Command {
       npmSession,
       npmVersion: userAgent,
       registry: this.options.registry,
+      otp: this.options.otp,
     });
 
     this.conf.set("user-agent", userAgent, "cli");


### PR DESCRIPTION
## Description
This adds an `--otp` CLI argument to `lerna publish` to support publishing to NPM registries that require two-factor authentication.

## Motivation and Context
It is currently possible to publish using 2FA *without* the `--otp` argument, however this requires setting an environment variable *prior* to calling `lerna publish`, and the process of setting an environment variable differs in different shells (i.e. bash, cmd, PowerShell, etc.). Providing this via an option simplifies the process and documents the capability.

## How Has This Been Tested?
I've added tests to verify the `--otp` option is passed to `npmPublish` as a configuration option and have also verified that the `--otp` option works by publishing a monorepo to NPM using an account that requires 2FA to publish.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (NOTE: There are tests that currently fail *without* this change when run on Windows).

Fixes #1091