### PR TITLE
feat(import): Add --preserve-commit

### DIFF
--- a/commands/import/README.md
+++ b/commands/import/README.md
@@ -52,3 +52,13 @@ When importing repositories, you can specify the destination directory by the di
 ```
 $ lerna import ~/Product --dest=utilities
 ```
+
+### `--preserve-commit`
+
+Each git commit has an **author** and a **committer** (with a separate date for each). Usually they're the same person (and date), but since `lerna import` re-creates each commit from the external repository, the **committer** becomes the current git user (and date). This is *technically* correct, but may be undesireable, for example, on Github, which displays both the **author** and **committer** if they're different people, leading to potentially confusing history/blames on imported commits.
+
+Enabling this option preserves the original **committer** (and commit date) to avoid such issues.
+
+```
+$ lerna import ~/Product --preserve-commit
+```

--- a/commands/import/command.js
+++ b/commands/import/command.js
@@ -21,6 +21,11 @@ exports.builder = yargs =>
         describe: "Import destination directory for the external git repository",
         type: "string",
       },
+      "preserve-commit": {
+        group: "Command Options:",
+        describe: "Preserve original committer in addition to original author",
+        type: "boolean",
+      },
       y: {
         group: "Command Options:",
         describe: "Skip all confirmation prompts",

--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -94,6 +94,12 @@ class ImportCommand extends Command {
       throw new ValidationError("NOCOMMITS", `No git commits to import at "${inputPath}"`);
     }
 
+    if (this.options.preserveCommit) {
+      // Back these up since they'll change for each commit
+      this.origGitEmail = this.execSync("git", ["config", "user.email"]);
+      this.origGitName = this.execSync("git", ["config", "user.name"]);
+    }
+
     // Stash the repo's pre-import head away in case something goes wrong.
     this.preImportHead = this.getCurrentSHA();
 
@@ -131,6 +137,10 @@ class ImportCommand extends Command {
 
   getWorkspaceRoot() {
     return ChildProcessUtilities.execSync("git", ["rev-parse", "--show-toplevel"], this.execOpts);
+  }
+
+  execSync(cmd, args) {
+    return ChildProcessUtilities.execSync(cmd, args, this.execOpts);
   }
 
   externalExecSync(cmd, args) {
@@ -186,6 +196,18 @@ class ImportCommand extends Command {
       .replace(/^(rename (from|to)) /gm, `$1 ${formattedTarget}/`);
   }
 
+  getGitUserFromSha(sha) {
+    return {
+      email: this.externalExecSync("git", ["show", "-s", "--format='%ae'", sha]),
+      name: this.externalExecSync("git", ["show", "-s", "--format='%an'", sha]),
+    };
+  }
+
+  configureGitUser({ email, name }) {
+    this.execSync("git", ["config", "user.email", `"${email}"`]);
+    this.execSync("git", ["config", "user.name", `"${name}"`]);
+  }
+
   execute() {
     this.enableProgressBar();
 
@@ -194,13 +216,19 @@ class ImportCommand extends Command {
       tracker.info(sha);
 
       const patch = this.createPatchForCommit(sha);
+      const procArgs = ["am", "-3", "--keep-non-patch"];
+
+      if (this.options.preserveCommit) {
+        this.configureGitUser(this.getGitUserFromSha(sha));
+        procArgs.push("--committer-date-is-author-date");
+      }
 
       // Apply the modified patch to the current lerna repository, preserving
       // original commit date, author and message.
       //
       // Fall back to three-way merge, which can help with duplicate commits
       // due to merge history.
-      const proc = ChildProcessUtilities.exec("git", ["am", "-3", "--keep-non-patch"], this.execOpts);
+      const proc = ChildProcessUtilities.exec("git", procArgs, this.execOpts);
 
       proc.stdin.end(patch);
 
@@ -227,10 +255,24 @@ class ImportCommand extends Command {
       .then(() => {
         tracker.finish();
 
+        if (this.options.preserveCommit) {
+          this.configureGitUser({
+            email: this.origGitEmail,
+            name: this.origGitName,
+          });
+        }
+
         this.logger.success("import", "finished");
       })
       .catch(err => {
         tracker.finish();
+
+        if (this.options.preserveCommit) {
+          this.configureGitUser({
+            email: this.origGitEmail,
+            name: this.origGitName,
+          });
+        }
 
         this.logger.error("import", `Rolling back to previous HEAD (commit ${this.preImportHead})`);
 

--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -103,7 +103,7 @@ class ImportCommand extends Command {
     // Stash the repo's pre-import head away in case something goes wrong.
     this.preImportHead = this.getCurrentSHA();
 
-    if (ChildProcessUtilities.execSync("git", ["diff-index", "HEAD"], this.execOpts)) {
+    if (this.execSync("git", ["diff-index", "HEAD"])) {
       throw new ValidationError("ECHANGES", "Local repository has un-committed changes");
     }
 
@@ -132,11 +132,11 @@ class ImportCommand extends Command {
   }
 
   getCurrentSHA() {
-    return ChildProcessUtilities.execSync("git", ["rev-parse", "HEAD"], this.execOpts);
+    return this.execSync("git", ["rev-parse", "HEAD"]);
   }
 
   getWorkspaceRoot() {
-    return ChildProcessUtilities.execSync("git", ["rev-parse", "--show-toplevel"], this.execOpts);
+    return this.execSync("git", ["rev-parse", "--show-toplevel"]);
   }
 
   execSync(cmd, args) {
@@ -277,8 +277,8 @@ class ImportCommand extends Command {
         this.logger.error("import", `Rolling back to previous HEAD (commit ${this.preImportHead})`);
 
         // Abort the failed `git am` and roll back to previous HEAD.
-        ChildProcessUtilities.execSync("git", ["am", "--abort"], this.execOpts);
-        ChildProcessUtilities.execSync("git", ["reset", "--hard", this.preImportHead], this.execOpts);
+        this.execSync("git", ["am", "--abort"]);
+        this.execSync("git", ["reset", "--hard", this.preImportHead]);
 
         throw new ValidationError(
           "EIMPORT",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hopefully this helps to digest the diff:

- [main change](https://github.com/lerna/lerna/pull/2079/commits/d70be0fd93059932b384040ff074d1144b1c1019)
- [tests](https://github.com/lerna/lerna/pull/2079/commits/b92ee16d5d301695f7a4247ae76ddb63e7af4b8b)
- [cleanup since I added a util](https://github.com/lerna/lerna/pull/2079/commits/4524624bb445bc00df7814ebeaae75e059b83479)

## Description, Motivation, and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Direct quote from my update to the README:

> Each git commit has an **author** and a **committer** (with a separate date for each). Usually they're the same person (and date), but since `lerna import` re-creates each commit from the external repository, the **committer** becomes the current git user (and date). This is *technically* correct, but may be undesireable, for example, on Github, which displays both the **author** and **committer** if they're different people, leading to potentially confusing history/blames on imported commits.
> 
> Enabling this option preserves the original **committer** (and commit date) to avoid such issues.

The way it achieves this is by:

1. configuring to the original git `user.name` and `user.email` before applying each commit, and
2. passing `--committer-date-is-author-date` into `git am`

EDIT: a bit more context — I recently was combining 30+ repos into a new monorepo, which ended up being over 4,000 commits. Upon pushing to github, this would have exploded my github activity and included me in the blame for the entire history of all the repos, which was undesirable for obvious reasons. I ended up hacking this change in my node_modules to get the imports I wanted, but figured I'd contribute it upstream in case anyone else found it valuable.

## How Has This Been Tested?
Added tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
