### PR TITLE
feat(bootstrap): Allow to specify custom folder for packages symlinks

### DIFF
--- a/core/package/index.js
+++ b/core/package/index.js
@@ -53,6 +53,9 @@ class Package {
       rootPath: {
         value: rootPath,
       },
+      symLinkDir: {
+        value: pkg.symLinkDir,
+      },
       // internal state is "private"
       [PKG]: {
         configurable: true,

--- a/utils/symlink-dependencies/symlink-dependencies.js
+++ b/utils/symlink-dependencies/symlink-dependencies.js
@@ -77,7 +77,10 @@ function symlinkDependencies(packages, packageGraph, tracker) {
         });
 
         // create package symlink
-        chain = chain.then(() => createSymlink(dependencyNode.location, targetDirectory, "junction"));
+        const dependencyLocation = dependencyNode.pkg.symLinkDir
+          ? path.resolve(dependencyNode.location, dependencyNode.pkg.symLinkDir)
+          : dependencyNode.location;
+        chain = chain.then(() => createSymlink(dependencyLocation, targetDirectory, "junction"));
 
         // TODO: pass PackageGraphNodes directly instead of Packages
         chain = chain.then(() => symlinkBinary(dependencyNode.pkg, currentNode.pkg));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This allows to specify a `symLinkDir` in a package `package.json` to create the symbolic link from a specific folder of the package.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was motivated by the need to access to the folder structure of the transpiled source of one of our packages, thus we needed that only the `dist` folder was used in the symbolic link.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We added a `"symLinkDir": "dist"` field in one of our packages `package.json`, we ran `lerna bootstrap` and used another package which depends on the first one. Only the `dist` folder was used for the symbolic link, allowing us to access to the whole folder structure of the `dist` folder using
```js
import '@repo/child-package/directory/subdirectory/feature';
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
