### PR TITLE
Add OTP prompt during publish

### DIFF
--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -176,7 +176,8 @@ Map {
       expect(npmPublish).toHaveBeenCalledWith(
         expect.objectContaining({ name: "package-1" }),
         "/TEMP_DIR/package-1-MOCKED.tgz",
-        expect.objectContaining({ registry })
+        expect.objectContaining({ registry }),
+        expect.objectContaining({ otp: undefined })
       );
     });
 
@@ -189,7 +190,8 @@ Map {
       expect(npmPublish).toHaveBeenCalledWith(
         expect.objectContaining({ name: "package-1" }),
         "/TEMP_DIR/package-1-MOCKED.tgz",
-        expect.objectContaining({ registry: "https://registry.npmjs.org/" })
+        expect.objectContaining({ registry: "https://registry.npmjs.org/" }),
+        expect.objectContaining({ otp: undefined })
       );
 
       const logMessages = loggingOutput("warn");

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -92,6 +92,8 @@ class PublishCommand extends Command {
     this.logger.verbose("session", npmSession);
     this.logger.verbose("user-agent", userAgent);
 
+    // cache to hold a one-time-password across publishes
+    this.otpCache = { otp: undefined };
     this.conf = npmConf({
       lernaCommand: "publish",
       npmSession,
@@ -647,7 +649,8 @@ class PublishCommand extends Command {
           const preDistTag = this.getPreDistTag(pkg);
           const tag = !this.options.tempTag && preDistTag ? preDistTag : opts.tag;
           const pkgOpts = Object.assign({}, opts, { tag });
-          return pulseTillDone(npmPublish(pkg, pkg.packed.tarFilePath, pkgOpts)).then(() => {
+
+          return pulseTillDone(npmPublish(pkg, pkg.packed.tarFilePath, pkgOpts, this.otpCache)).then(() => {
             tracker.success("published", pkg.name, pkg.version);
             tracker.completeWork(1);
 

--- a/core/otplease/README.md
+++ b/core/otplease/README.md
@@ -1,0 +1,7 @@
+# `@lerna/otplease`
+
+> Prompt for OTP when wrapped Promise fails
+
+## Usage
+
+This is an internal lerna library, you probably shouldn't use it directly.

--- a/core/otplease/__tests__/otplease.test.js
+++ b/core/otplease/__tests__/otplease.test.js
@@ -1,0 +1,118 @@
+jest.mock("@lerna/prompt");
+const otplease = require("..")
+const prompt = require("@lerna/prompt");
+
+describe("@lerna/otplease", () => {
+    let savedIsTTY;
+    beforeAll(() => {
+        savedIsTTY = [process.stdin.isTTY, process.stdout.isTTY];
+        process.stdin.isTTY = true;
+        process.stdout.isTTY = true;
+    })
+    afterAll(() => {
+        process.stdin.isTTY = savedIsTTY[0];
+        process.stdout.isTTY = savedIsTTY[1];
+    });
+
+    it("no error", () => {
+        const obj = {};
+        const fn = jest.fn(() => obj);
+        prompt.input.mockResolvedValue("123456");
+        return otplease(fn, {}).then(result => {
+            expect(fn).toBeCalled();
+            expect(prompt.input).not.toBeCalled();
+            expect(result).toBe(obj);
+        });
+    });
+    it("request otp", () => {
+        const obj = {};
+        const fn = jest.fn(makeTestCallback("123456", obj));
+        prompt.input.mockResolvedValue("123456");
+        return otplease(fn, {}).then(result => {
+            expect(fn).toBeCalledTimes(2);
+            expect(prompt.input).toBeCalled();
+            expect(result).toBe(obj);
+        });
+    });
+    it("request otp updates cache", () => {
+        const otpCache = { otp: undefined };
+        const obj = {};
+        const fn = jest.fn(makeTestCallback("123456", obj));
+        prompt.input.mockResolvedValue("123456");
+        return otplease(fn, {}, otpCache).then(result => {
+            expect(fn).toBeCalledTimes(2);
+            expect(prompt.input).toBeCalled();
+            expect(result).toBe(obj);
+            expect(otpCache.otp).toBe("123456");
+        });
+    });
+    it("uses cache if opts does not have own otp", () => {
+        const otpCache = { otp: "654321" };
+        const obj = {};
+        const fn = jest.fn(makeTestCallback("654321", obj));
+        prompt.input.mockResolvedValue("123456");
+        return otplease(fn, {}, otpCache).then(result => {
+            expect(fn).toBeCalledTimes(1);
+            expect(prompt.input).not.toBeCalled();
+            expect(result).toBe(obj);
+            expect(otpCache.otp).toBe("654321");
+        });
+    });
+    it("uses explicit otp regardless of cache value", () => {
+        const otpCache = { otp: "654321" };
+        const obj = {};
+        const fn = jest.fn(makeTestCallback("987654", obj));
+        prompt.input.mockResolvedValue("123456");
+        return otplease(fn, { otp: "987654" }, otpCache).then(result => {
+            expect(fn).toBeCalledTimes(1);
+            expect(prompt.input).not.toBeCalled();
+            expect(result).toBe(obj);
+            expect(otpCache.otp).toBe("654321"); // do not replace cache
+        });
+    });
+    it("using cache updated in a different task", () => {
+        const otpCache = { otp: undefined };
+        const obj = {};
+        const fn = jest.fn(makeTestCallback("654321", obj));
+        prompt.input.mockResolvedValue("123456");
+
+        // enqueue a promise resolution to update the otp at the start of the next turn.
+        Promise.resolve().then(() => { otpCache.otp = "654321"; });
+
+        // start intial otplease call, 'catch' will happen in next turn *after* the cache is set.
+        return otplease(fn, {}, otpCache).then(result => {
+            expect(fn).toBeCalledTimes(2);
+            expect(prompt.input).not.toBeCalled();
+            expect(result).toBe(obj);
+        });
+    });
+    it("semaphore prevents overlapping requests for OTP", () => {
+        const otpCache = { otp: undefined };
+        prompt.input.mockResolvedValue("123456");
+
+        // overlapped calls to otplease that share an otpCache should
+        // result in the user only being prompted *once* for an OTP.
+        const obj1 = {};
+        const fn1 = jest.fn(makeTestCallback("123456", obj1));
+        const p1 = otplease(fn1, {}, otpCache);
+
+        const obj2 = {};
+        const fn2 = jest.fn(makeTestCallback("123456", obj2));
+        const p2 = otplease(fn2, {}, otpCache);
+
+        return Promise.all([p1, p2]).then(res => {
+            expect(fn1).toBeCalledTimes(2);
+            expect(fn2).toBeCalledTimes(2);
+            expect(prompt.input).toBeCalledTimes(1); // only called once for the two concurrent requests
+            expect(res[0]).toBe(obj1);
+            expect(res[1]).toBe(obj2);
+        });
+    });
+})
+
+function makeTestCallback(otp, result) {
+    return opts => {
+        if (opts.otp !== otp) throw { code: "EOTP" };
+        return result;
+    };
+}

--- a/core/otplease/otplease.js
+++ b/core/otplease/otplease.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const figgyPudding = require('figgy-pudding')
+const prompt = require('@lerna/prompt')
+
+const OtpPleaseConfig = figgyPudding({
+  otp: {}
+})
+
+// basic single-entry semaphore
+const semaphore = {
+  wait() {
+    return new Promise(resolve => {
+      if (!this._promise) {
+        // not waiting, block other callers until 'release' is called.
+        this._promise = new Promise(resolve => this._resolve = resolve);
+        resolve();
+      } else {
+        // wait for 'release' to be called and try to lock the semaphore again.
+        resolve(this._promise.then(() => this.wait()));
+      }
+    });
+  },
+  release() {
+    const resolve = this._resolve;
+    if (resolve) {
+      this._resolve = undefined;
+      this._promise = undefined;
+      // notify waiters that the semaphore has been released.
+      resolve();
+    }
+  }
+};
+
+module.exports = otplease
+function otplease(fn, _opts, otpCache) {
+  // NOTE: do not use 'otpCache' as a figgy-pudding provider directly as the
+  // otp value could change between async wait points.
+  const opts = OtpPleaseConfig(Object.assign({}, otpCache), _opts)
+  return attempt(fn, opts, otpCache);
+}
+
+
+function attempt(fn, opts, otpCache) {
+  return new Promise(resolve => {
+    resolve(fn(opts))
+  }).catch(err => {
+    if (err.code !== 'EOTP' && !(err.code === 'E401' && /one-time pass/.test(err.body))) {
+      throw err
+    } else if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      throw err
+    } else {
+      // check the cache in case a concurrent caller has already updated the otp.
+      if (otpCache != null && otpCache.otp != null && otpCache.otp !== opts.otp) {
+        return attempt(fn, opts.concat(otpCache), otpCache)
+      }
+      // only allow one getOneTimePassword attempt at a time to reuse the value
+      // from the preceeding prompt
+      return semaphore.wait().then(() => {
+        // check the cache again in case a previous waiter already updated it.
+        if (otpCache != null && otpCache.otp != null && otpCache.otp !== opts.otp) {
+          semaphore.release();
+          return attempt(fn, opts.concat({ otp: otpCache.otp }), otpCache)
+        } else {
+          return getOneTimePassword().then(otp => {
+            // update the otp and release the lock so that waiting
+            // callers can see the updated otp.
+            if (otpCache != null) otpCache.otp = otp;
+            semaphore.release();
+            return otp;
+          }, err => {
+            // release the lock and reject the promise.
+            semaphore.release();
+            return Promise.reject(err);
+          }).then(otp => {
+            return fn(opts.concat({ otp }));
+          });
+        }
+      })
+    }
+  })
+}
+
+function getOneTimePassword() {
+  // Logic taken from npm internals: https://git.io/fNoMe
+  return prompt.input('This operation requires a one-time password:', {
+    filter: otp => otp.replace(/\s+/g, ""),
+    validate: otp =>
+      (otp && /^[\d ]+$|^[A-Fa-f0-9]{64,64}$/.test(otp)) ||
+      "Must be a valid one-time-password. " +
+        "See https://docs.npmjs.com/getting-started/using-two-factor-authentication",
+  });
+}

--- a/core/otplease/otplease.js
+++ b/core/otplease/otplease.js
@@ -1,11 +1,11 @@
-'use strict'
+"use strict";
 
-const figgyPudding = require('figgy-pudding')
-const prompt = require('@lerna/prompt')
+const figgyPudding = require("figgy-pudding");
+const prompt = require("@lerna/prompt");
 
 const OtpPleaseConfig = figgyPudding({
-  otp: {}
-})
+  otp: {},
+});
 
 // basic single-entry semaphore
 const semaphore = {
@@ -13,7 +13,9 @@ const semaphore = {
     return new Promise(resolve => {
       if (!this._promise) {
         // not waiting, block other callers until 'release' is called.
-        this._promise = new Promise(resolve => this._resolve = resolve);
+        this._promise = new Promise(release => {
+          this._resolve = release;
+        });
         resolve();
       } else {
         // wait for 'release' to be called and try to lock the semaphore again.
@@ -23,36 +25,37 @@ const semaphore = {
   },
   release() {
     const resolve = this._resolve;
+    // istanbul ignore else
     if (resolve) {
       this._resolve = undefined;
       this._promise = undefined;
       // notify waiters that the semaphore has been released.
       resolve();
     }
-  }
+  },
 };
 
-module.exports = otplease
+module.exports = otplease;
+
 function otplease(fn, _opts, otpCache) {
   // NOTE: do not use 'otpCache' as a figgy-pudding provider directly as the
   // otp value could change between async wait points.
-  const opts = OtpPleaseConfig(Object.assign({}, otpCache), _opts)
+  const opts = OtpPleaseConfig(Object.assign({}, otpCache), _opts);
   return attempt(fn, opts, otpCache);
 }
 
-
 function attempt(fn, opts, otpCache) {
   return new Promise(resolve => {
-    resolve(fn(opts))
+    resolve(fn(opts));
   }).catch(err => {
-    if (err.code !== 'EOTP' && !(err.code === 'E401' && /one-time pass/.test(err.body))) {
-      throw err
+    if (err.code !== "EOTP" && !(err.code === "E401" && /one-time pass/.test(err.body))) {
+      throw err;
     } else if (!process.stdin.isTTY || !process.stdout.isTTY) {
-      throw err
+      throw err;
     } else {
       // check the cache in case a concurrent caller has already updated the otp.
       if (otpCache != null && otpCache.otp != null && otpCache.otp !== opts.otp) {
-        return attempt(fn, opts.concat(otpCache), otpCache)
+        return attempt(fn, opts.concat(otpCache), otpCache);
       }
       // only allow one getOneTimePassword attempt at a time to reuse the value
       // from the preceeding prompt
@@ -60,30 +63,37 @@ function attempt(fn, opts, otpCache) {
         // check the cache again in case a previous waiter already updated it.
         if (otpCache != null && otpCache.otp != null && otpCache.otp !== opts.otp) {
           semaphore.release();
-          return attempt(fn, opts.concat({ otp: otpCache.otp }), otpCache)
-        } else {
-          return getOneTimePassword().then(otp => {
-            // update the otp and release the lock so that waiting
-            // callers can see the updated otp.
-            if (otpCache != null) otpCache.otp = otp;
-            semaphore.release();
-            return otp;
-          }, err => {
-            // release the lock and reject the promise.
-            semaphore.release();
-            return Promise.reject(err);
-          }).then(otp => {
+          return attempt(fn, opts.concat({ otp: otpCache.otp }), otpCache);
+        }
+        return getOneTimePassword()
+          .then(
+            otp => {
+              // update the otp and release the lock so that waiting
+              // callers can see the updated otp.
+              if (otpCache != null) {
+                // eslint-disable-next-line no-param-reassign
+                otpCache.otp = otp;
+              }
+              semaphore.release();
+              return otp;
+            },
+            promptError => {
+              // release the lock and reject the promise.
+              semaphore.release();
+              return Promise.reject(promptError);
+            }
+          )
+          .then(otp => {
             return fn(opts.concat({ otp }));
           });
-        }
-      })
+      });
     }
-  })
+  });
 }
 
 function getOneTimePassword() {
   // Logic taken from npm internals: https://git.io/fNoMe
-  return prompt.input('This operation requires a one-time password:', {
+  return prompt.input("This operation requires a one-time password:", {
     filter: otp => otp.replace(/\s+/g, ""),
     validate: otp =>
       (otp && /^[\d ]+$|^[A-Fa-f0-9]{64,64}$/.test(otp)) ||

--- a/core/otplease/package.json
+++ b/core/otplease/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@lerna/otplease",
+    "version": "3.13.0",
+    "description": "Prompt for OTP when wrapped Promise fails",
+    "keywords": [
+      "lerna",
+      "utils"
+    ],
+    "homepage": "https://github.com/lerna/lerna/tree/master/core/otplease#readme",
+    "license": "MIT",
+    "author": {
+      "name": "Daniel Stockman",
+      "url": "https://github.com/evocateur"
+    },
+    "files": [
+      "otplease.js"
+    ],
+    "main": "otplease.js",
+    "engines": {
+      "node": ">= 6.9.0"
+    },
+    "publishConfig": {
+      "access": "public"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/lerna/lerna.git",
+      "directory": "utils/output"
+    },
+    "scripts": {
+      "test": "echo \"Run tests from root\" && exit 1"
+    },
+    "dependencies": {
+      "@lerna/prompt": "file:../prompt",
+      "figgy-pudding": "^3.5.1"
+    }
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,6 +1017,7 @@
     "@lerna/npm-publish": {
       "version": "file:utils/npm-publish",
       "requires": {
+        "@lerna/otplease": "file:core/otplease",
         "@lerna/run-lifecycle": "file:utils/run-lifecycle",
         "figgy-pudding": "^3.5.1",
         "fs-extra": "^7.0.0",
@@ -1033,6 +1034,13 @@
         "@lerna/child-process": "file:core/child-process",
         "@lerna/get-npm-exec-opts": "file:utils/get-npm-exec-opts",
         "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/otplease": {
+      "version": "file:core/otplease",
+      "requires": {
+        "@lerna/prompt": "file:core/prompt",
+        "figgy-pudding": "^3.5.1"
       }
     },
     "@lerna/output": {

--- a/utils/npm-publish/__tests__/npm-publish.test.js
+++ b/utils/npm-publish/__tests__/npm-publish.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 jest.mock("@lerna/run-lifecycle");
+jest.mock("@lerna/otplease");
 jest.mock("read-package-json");
 jest.mock("libnpmpublish");
 jest.mock("fs-extra");
@@ -10,6 +11,7 @@ const fs = require("fs-extra");
 const { publish } = require("libnpmpublish");
 const readJSON = require("read-package-json");
 const runLifecycle = require("@lerna/run-lifecycle");
+const otplease = require("@lerna/otplease");
 
 // helpers
 const path = require("path");
@@ -28,6 +30,7 @@ describe("npm-publish", () => {
   publish.mockName("libnpmpublish").mockResolvedValue();
   readJSON.mockName("read-package-json").mockImplementation((file, cb) => cb(null, mockManifest));
   runLifecycle.mockName("@lerna/run-lifecycle").mockResolvedValue();
+  otplease.mockName("@lerna/otplease").mockImplementation((cb, opts) => Promise.resolve(cb(opts)));
 
   const tarFilePath = "/tmp/test-1.10.100.tgz";
   const rootPath = path.normalize("/test");

--- a/utils/npm-publish/npm-publish.js
+++ b/utils/npm-publish/npm-publish.js
@@ -8,6 +8,7 @@ const readJSON = require("read-package-json");
 const figgyPudding = require("figgy-pudding");
 const runLifecycle = require("@lerna/run-lifecycle");
 const npa = require("npm-package-arg");
+const otplease = require("@lerna/otplease");
 
 module.exports = npmPublish;
 
@@ -30,7 +31,7 @@ const PublishConfig = figgyPudding(
   }
 );
 
-function npmPublish(pkg, tarFilePath, _opts) {
+function npmPublish(pkg, tarFilePath, _opts, otpCache) {
   const { scope } = npa(pkg.name);
   // pass only the package scope to libnpmpublish
   const opts = PublishConfig(_opts, {
@@ -56,7 +57,7 @@ function npmPublish(pkg, tarFilePath, _opts) {
         manifest.publishConfig.tag = opts.tag;
       }
 
-      return publish(manifest, tarData, opts).catch(err => {
+      return otplease(opts => publish(manifest, tarData, opts), opts, otpCache).catch(err => {
         opts.log.silly("", err);
         opts.log.error(err.code, (err.body && err.body.error) || err.message);
 

--- a/utils/npm-publish/npm-publish.js
+++ b/utils/npm-publish/npm-publish.js
@@ -57,7 +57,7 @@ function npmPublish(pkg, tarFilePath, _opts, otpCache) {
         manifest.publishConfig.tag = opts.tag;
       }
 
-      return otplease(opts => publish(manifest, tarData, opts), opts, otpCache).catch(err => {
+      return otplease(innerOpts => publish(manifest, tarData, innerOpts), opts, otpCache).catch(err => {
         opts.log.silly("", err);
         opts.log.error(err.code, (err.body && err.body.error) || err.message);
 

--- a/utils/npm-publish/package.json
+++ b/utils/npm-publish/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@lerna/run-lifecycle": "file:../run-lifecycle",
+    "@lerna/otplease": "file:../../core/otplease",
     "figgy-pudding": "^3.5.1",
     "fs-extra": "^7.0.0",
     "libnpmpublish": "^1.1.1",


### PR DESCRIPTION
## Description
Adds a prompt for a one-time-password (OTP) when requested from registries that use two-factor authentication (2FA).

## Motivation and Context
It is currently marginally possible to publish using 2FA without this prompt, however this requires setting an environment variable prior to calling `lerna publish`, which could expire during the process of publishing packages.

## How Has This Been Tested?
I've added tests for `@lerna/otplease` and have tested publishing a monorepo for an account that requires a one-time password.

Fixes: #1091

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
