### PR TITLE
fix(bootstrap): respect --force-local option

### DIFF
--- a/commands/bootstrap/__tests__/__snapshots__/bootstrap-command.test.js.snap
+++ b/commands/bootstrap/__tests__/__snapshots__/bootstrap-command.test.js.snap
@@ -319,9 +319,6 @@ Object {
     "bar@^2.0.0",
     "foo@^1.0.0",
   ],
-  "packages/package-4": Array [
-    "package-3@^1.0.0",
-  ],
 }
 `;
 
@@ -331,6 +328,21 @@ Array [
     "_src": "packages/package-1",
     "dest": "packages/package-4/node_modules/@test/package-1",
     "type": "junction",
+  },
+  Object {
+    "_src": "packages/package-3",
+    "dest": "packages/package-4/node_modules/package-3",
+    "type": "junction",
+  },
+  Object {
+    "_src": "packages/package-3/cli1.js",
+    "dest": "packages/package-4/node_modules/.bin/package3cli1",
+    "type": "exec",
+  },
+  Object {
+    "_src": "packages/package-3/cli2.js",
+    "dest": "packages/package-4/node_modules/.bin/package3cli2",
+    "type": "exec",
   },
 ]
 `;

--- a/commands/bootstrap/__tests__/bootstrap-command.test.js
+++ b/commands/bootstrap/__tests__/bootstrap-command.test.js
@@ -313,6 +313,24 @@ describe("BootstrapCommand", () => {
       expect(symlinkedDirectories(testDir)).toMatchSnapshot();
     });
 
+    it("should respect --force-local when a single package is in scope", async () => {
+      const testDir = await initFixture("basic");
+
+      await lernaBootstrap(testDir)("--scope", "package-4", "--force-local");
+
+      // no packages were installed from the registry
+      const installed = installedPackagesInDirectories(testDir);
+      expect(installed["packages/package-4"] || []).toEqual([]);
+
+      // package-3 was resolved as a local symlink
+      const symlinked = symlinkedDirectories(testDir);
+      expect(symlinked).toContainEqual({
+        _src: "packages/package-3",
+        dest: "packages/package-4/node_modules/package-3",
+        type: "junction",
+      });
+    });
+
     it("should not update package.json when filtering", async () => {
       const testDir = await initFixture("basic");
 

--- a/commands/bootstrap/index.js
+++ b/commands/bootstrap/index.js
@@ -161,7 +161,7 @@ class BootstrapCommand extends Command {
     chain = chain.then(filteredPackages => {
       this.filteredPackages = filteredPackages;
 
-      if (filteredPackages.length !== this.targetGraph.size) {
+      if (filteredPackages.length !== this.targetGraph.size && !this.options.forceLocal) {
         this.logger.warn("bootstrap", "Installing local packages that do not match filters from registry");
 
         // an explicit --scope, --ignore, or --since should only symlink the targeted packages, no others


### PR DESCRIPTION
## Description

Before this change, `--force-local` option was not respected and monorepo-local packages outside of the defined --scope were still installed from the npm registry.

This commit fixes the code handling `--force-local` logic, so that:
- Local packages are resolved as links within the monorepo, as one would expect.
- The following warning IS NOT printed anymore:  _Installing local packages that do not match filters from registry_

## Motivation and Context

In https://github.com/strongloop/loopback-next, we have a test that runs `lerna bootstrap --scope {pkg}` to bootstrap a single package. I noticed that our test starts to fail when the code in the package depends on changes made elsewhere in the monorepo and those changes were not released to the npm registry yet.

After further digging I found that lerna is installing monorepo-local dependencies from the npm registry, instead of creating symlinks.

Eventually, I found https://github.com/lerna/lerna/commit/71174e4709 which changed the behavior of `lerna bootstrap` command in what I would consider a backwards-incompatible way, but fortunately added `--force-local` flag.

Except `--force-local` does not work right now!

## How Has This Been Tested?

It turns out the existing snapshot-based test for `--force-local` was using snapshot values describing the wrong behavior. I have updated these snapshots to match the desired outcome.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@evocateur You are the author of `--force-local` option, could you please review my pull request? Thanks! 🙏 