### PR TITLE
fix(conventional-commits): trim extra whitespace

### DIFF
--- a/core/conventional-commits/__tests__/__snapshots__/conventional-commits.test.js.snap
+++ b/core/conventional-commits/__tests__/__snapshots__/conventional-commits.test.js.snap
@@ -43,10 +43,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * A second commit for our CHANGELOG ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/SHA))
 
-
-
-
-
 <a name="1.0.0"></a>
 
 # 1.0.0 (YYYY-MM-DD)
@@ -69,10 +65,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Bug Fixes
 
 * A second commit for our CHANGELOG ([SHA](https://github.com/lerna/conventional-commits-fixed/commit/SHA))
-
-
-
-
 
 <a name="1.0.0"></a>
 

--- a/core/conventional-commits/lib/update-changelog.js
+++ b/core/conventional-commits/lib/update-changelog.js
@@ -54,7 +54,7 @@ function updateChangelog(pkg, type, { changelogPreset, rootPath, tagPrefix, vers
     ]).then(([newEntry, [changelogFileLoc, changelogContents]]) => {
       log.silly(type, "writing new entry: %j", newEntry);
 
-      const content = [CHANGELOG_HEADER, newEntry, changelogContents].join(BLANK_LINE);
+      const content = [CHANGELOG_HEADER, newEntry.trim(), changelogContents.trim()].join(BLANK_LINE);
 
       return fs.writeFile(changelogFileLoc, content.trim() + EOL).then(() => {
         log.verbose(type, "wrote", changelogFileLoc);

--- a/integration/lerna-publish-conventional-fixed-prerelease.test.js
+++ b/integration/lerna-publish-conventional-fixed-prerelease.test.js
@@ -161,17 +161,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **package-2:** And another thing ([SHA](COMMIT_URL))
 
-
-
-
-
 ## [2.0.1](/compare/v2.0.1-alpha.0...v2.0.1) (YYYY-MM-DD)
 
 **Note:** Version bump only for package normal
-
-
-
-
 
 ## [2.0.1-alpha.0](/compare/v2.0.0...v2.0.1-alpha.0) (YYYY-MM-DD)
 
@@ -180,20 +172,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **package-4:** And another thing ([SHA](COMMIT_URL))
 
-
-
-
-
 # [2.0.0](/compare/v2.0.0-alpha.1...v2.0.0) (YYYY-MM-DD)
 
 
 ### Features
 
 * **package-1:** Add baz ([SHA](COMMIT_URL))
-
-
-
-
 
 # [2.0.0-alpha.1](/compare/v2.0.0-alpha.0...v2.0.0-alpha.1) (YYYY-MM-DD)
 
@@ -206,10 +190,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * **package-2:** Add baz ([SHA](COMMIT_URL))
-
-
-
-
 
 # [2.0.0-alpha.0](/compare/v1.0.0...v2.0.0-alpha.0) (YYYY-MM-DD)
 
@@ -247,20 +227,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **package-1:** Add baz ([SHA](COMMIT_URL))
 
-
-
-
-
 # [2.0.0-alpha.1](/compare/v2.0.0-alpha.0...v2.0.0-alpha.1) (YYYY-MM-DD)
 
 
 ### Bug Fixes
 
 * **package-1:** Fix foo ([SHA](COMMIT_URL))
-
-
-
-
 
 # [2.0.0-alpha.0](/compare/v1.0.0...v2.0.0-alpha.0) (YYYY-MM-DD)
 
@@ -287,17 +259,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **package-2:** And another thing ([SHA](COMMIT_URL))
 
-
-
-
-
 # [2.0.0](/compare/v2.0.0-alpha.1...v2.0.0) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-2
-
-
-
-
 
 # [2.0.0-alpha.1](/compare/v2.0.0-alpha.0...v2.0.0-alpha.1) (YYYY-MM-DD)
 
@@ -305,10 +269,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * **package-2:** Add baz ([SHA](COMMIT_URL))
-
-
-
-
 
 # [2.0.0-alpha.0](/compare/v1.0.0...v2.0.0-alpha.0) (YYYY-MM-DD)
 
@@ -332,25 +292,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package package-3
 
-
-
-
-
 # [2.0.0](/compare/v2.0.0-alpha.1...v2.0.0) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-3
 
-
-
-
-
 # [2.0.0-alpha.1](/compare/v2.0.0-alpha.0...v2.0.0-alpha.1) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-3
-
-
-
-
 
 # [2.0.0-alpha.0](/compare/v1.0.0...v2.0.0-alpha.0) (YYYY-MM-DD)
 
@@ -379,10 +327,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package package-4
 
-
-
-
-
 ## [2.0.1-alpha.0](/compare/v2.0.0...v2.0.1-alpha.0) (YYYY-MM-DD)
 
 
@@ -405,25 +349,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package package-5
 
-
-
-
-
 # [2.0.0](/compare/v2.0.0-alpha.1...v2.0.0) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-5
 
-
-
-
-
 # [2.0.0-alpha.1](/compare/v2.0.0-alpha.0...v2.0.0-alpha.1) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-5
-
-
-
-
 
 # [2.0.0-alpha.0](/compare/v1.0.0...v2.0.0-alpha.0) (YYYY-MM-DD)
 

--- a/integration/lerna-publish-conventional-fixed.test.js
+++ b/integration/lerna-publish-conventional-fixed.test.js
@@ -86,10 +86,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **package-2:** And another thing ([SHA](COMMIT_URL))
 
-
-
-
-
 # 2.0.0 (YYYY-MM-DD)
 
 
@@ -152,10 +148,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **package-2:** And another thing ([SHA](COMMIT_URL))
 
-
-
-
-
 # 2.0.0 (YYYY-MM-DD)
 
 
@@ -182,10 +174,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.0.1](/compare/v2.0.0...v2.0.1) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-3
-
-
-
-
 
 # 2.0.0 (YYYY-MM-DD)
 
@@ -232,10 +220,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.0.1](/compare/v2.0.0...v2.0.1) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-5
-
-
-
-
 
 # 2.0.0 (YYYY-MM-DD)
 

--- a/integration/lerna-publish-conventional-independent-prerelease.test.js
+++ b/integration/lerna-publish-conventional-independent-prerelease.test.js
@@ -173,20 +173,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package package-1
 
-
-
-
-
 # [1.2.0-alpha.0](/compare/package-1@1.1.2-alpha.0...package-1@1.2.0-alpha.0) (YYYY-MM-DD)
 
 
 ### Features
 
 * **package-1:** Add baz ([SHA](COMMIT_URL))
-
-
-
-
 
 ## [1.1.2-alpha.0](/compare/package-1@1.1.1...package-1@1.1.2-alpha.0) (YYYY-MM-DD)
 
@@ -195,20 +187,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **package-1:** Unfix foo ([SHA](COMMIT_URL))
 
-
-
-
-
 ## [1.1.1](/compare/package-1@1.1.0...package-1@1.1.1) (YYYY-MM-DD)
 
 
 ### Bug Fixes
 
 * **package-1:** Fix foo ([SHA](COMMIT_URL))
-
-
-
-
 
 # 1.1.0 (YYYY-MM-DD)
 
@@ -236,25 +220,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package package-2
 
-
-
-
-
 # [2.1.0](/compare/package-2@2.1.0-alpha.1...package-2@2.1.0) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-2
 
-
-
-
-
 # [2.1.0-alpha.1](/compare/package-2@2.1.0-alpha.0...package-2@2.1.0-alpha.1) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-2
-
-
-
-
 
 # [2.1.0-alpha.0](/compare/package-2@2.0.1-alpha.0...package-2@2.1.0-alpha.0) (YYYY-MM-DD)
 
@@ -262,10 +234,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * **package-2:** Add baz ([SHA](COMMIT_URL))
-
-
-
-
 
 ## 2.0.1-alpha.0 (YYYY-MM-DD)
 
@@ -293,33 +261,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package package-3
 
-
-
-
-
 # [4.0.0-alpha.3](/compare/package-3@4.0.0-alpha.2...package-3@4.0.0-alpha.3) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-3
-
-
-
-
 
 # [4.0.0-alpha.2](/compare/package-3@4.0.0-alpha.1...package-3@4.0.0-alpha.2) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-3
 
-
-
-
-
 # [4.0.0-alpha.1](/compare/package-3@4.0.0-alpha.0...package-3@4.0.0-alpha.1) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-3
-
-
-
-
 
 # 4.0.0-alpha.0 (YYYY-MM-DD)
 
@@ -352,33 +304,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package package-5
 
-
-
-
-
 ## [5.0.1-alpha.3](/compare/package-5@5.0.1-alpha.2...package-5@5.0.1-alpha.3) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-5
-
-
-
-
 
 ## [5.0.1-alpha.2](/compare/package-5@5.0.1-alpha.1...package-5@5.0.1-alpha.2) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-5
 
-
-
-
-
 ## [5.0.1-alpha.1](/compare/package-5@5.0.1-alpha.0...package-5@5.0.1-alpha.1) (YYYY-MM-DD)
 
 **Note:** Version bump only for package package-5
-
-
-
-
 
 ## 5.0.1-alpha.0 (YYYY-MM-DD)
 


### PR DESCRIPTION
fix #2116

## Description
As #2116 explains, there are a few extra newlines after each entry that this PR trims off.

## Motivation and Context
#2116 

## How Has This Been Tested?
I made these changes in my local installation of lerna and it worked great!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
