### PR TITLE
fix(publish): use package.json from --contents

### DIFF
--- a/core/project/index.js
+++ b/core/project/index.js
@@ -166,11 +166,13 @@ class Project {
     return finder;
   }
 
-  getPackages() {
-    const mapper = packageConfigPath =>
-      loadJsonFile(packageConfigPath).then(
-        packageJson => new Package(packageJson, path.dirname(packageConfigPath), this.rootPath)
+  getPackages(redirect = arg => arg) {
+    const mapper = packageJsonPath => {
+      const redirectedPath = redirect(packageJsonPath);
+      return loadJsonFile(redirectedPath).then(
+        packageJson => new Package(packageJson, path.dirname(redirectedPath), this.rootPath)
       );
+    };
 
     return this.fileFinder("package.json", filePaths => pMap(filePaths, mapper, { concurrency: 50 }));
   }


### PR DESCRIPTION
## Description

This PR lets any `Command` subclass intercept the `Package` loader by defining a `redirectPackages` method on itself. The `publish` command uses this to ensure `--contents` is respected when re-serializing  any `package.json` modules before calling `npm publish`.

## Motivation and Context
See here: https://github.com/lerna/lerna/issues/2113#issuecomment-498042638

## How Has This Been Tested?
I tested this manually on the monorepo for `react-spring`. 

I don't have time to write any tests, currently.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
