### PR TITLE
feat(bootstrap): Add `--strict` option to enable throwing when `--hoist` warns

### DIFF
--- a/commands/bootstrap/README.md
+++ b/commands/bootstrap/README.md
@@ -56,6 +56,14 @@ For background on `--hoist`, see the [hoist documentation](https://github.com/le
 Note: If packages depend on different _versions_ of an external dependency,
 the most commonly used version will be hoisted, and a warning will be emitted.
 
+### --strict
+
+When used in conjunction with hoist will throw an error and stop bootstrapping after emitting the version warnings. Has no effect if you aren't hoisting, or if there are no version warnings.
+
+```sh
+$ lerna bootstrap --hoist --strict
+```
+
 ### --nohoist [glob]
 
 Do _not_ install external dependencies matching `glob` at the repo root. This

--- a/commands/bootstrap/__tests__/bootstrap-command.test.js
+++ b/commands/bootstrap/__tests__/bootstrap-command.test.js
@@ -208,6 +208,20 @@ describe("BootstrapCommand", () => {
     });
   });
 
+  describe("with --hoist and --strict", () => {
+    it("should throw if there's a hoist warning", async () => {
+      expect.assertions(1);
+
+      const testDir = await initFixture("basic");
+
+      try {
+        await lernaBootstrap(testDir)("--hoist", "--strict");
+      } catch (err) {
+        expect(err.message).toMatch("Package version inconsistencies found");
+      }
+    });
+  });
+
   describe("with --ci", () => {
     it("should call npmInstall with ci subCommand if on npm 5.7.0 or later", async () => {
       const testDir = await initFixture("ci");

--- a/commands/bootstrap/command.js
+++ b/commands/bootstrap/command.js
@@ -53,6 +53,11 @@ exports.builder = yargs => {
         type: "string",
         requiresArg: true,
       },
+      strict: {
+        group: "Command Options:",
+        describe: "Don't allow warnings when hoisting as it causes longer bootstrap times and other issues.",
+        type: "boolean",
+      },
     });
 
   return filterable(yargs);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an option that will throw an error after printing out the hoist warnings (if there were any) to allow the bootstrap process to stop if there are version conflicts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #2139 (and #667 although that was closed long ago).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added a unit test, and tried it out in our project (after spending a decent chunk of time dealing with trying to get linking working...), seemed to work just great.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please let me know if I did something that I shouldn't have or things to adjust :)