### PR TITLE
fix(publish): Add `--graph-type` option to control packages included in topological sort

### DIFF
--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -49,6 +49,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 - [`--contents <dir>`](#--contents-dir)
 - [`--dist-tag <tag>`](#--dist-tag-tag)
 - [`--git-head <sha>`](#--git-head-sha)
+- [`--graph-type <all|dependencies>`](#--graph-type)
 - [`--no-git-reset`](#--no-git-reset)
 - [`--no-verify-access`](#--no-verify-access)
 - [`--otp`](#--otp)
@@ -126,6 +127,10 @@ lerna publish from-package --git-head ${CODEBUILD_RESOLVED_SOURCE_VERSION}
 ```
 
 Under all other circumstances, this value is derived from a local `git` command.
+
+### `--graph-type <all|dependencies>`
+
+Set which set of dependencies to use when building a package graph. The default value is `dependencies`, whereby only packages listed in the `dependencies` section of your package's `package.json` are included. Pass `all` to include both your `dependencies` and `devDependencies` when constructing the package graph and determining topological order.
 
 ### `--no-git-reset`
 

--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -49,7 +49,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 - [`--contents <dir>`](#--contents-dir)
 - [`--dist-tag <tag>`](#--dist-tag-tag)
 - [`--git-head <sha>`](#--git-head-sha)
-- [`--graph-type <all|dependencies>`](#--graph-type)
+- [`--graph-type <all|dependencies>`](#--graph-type-alldependencies)
 - [`--no-git-reset`](#--no-git-reset)
 - [`--no-verify-access`](#--no-verify-access)
 - [`--otp`](#--otp)
@@ -130,7 +130,25 @@ Under all other circumstances, this value is derived from a local `git` command.
 
 ### `--graph-type <all|dependencies>`
 
-Set which set of dependencies to use when building a package graph. The default value is `dependencies`, whereby only packages listed in the `dependencies` section of your package's `package.json` are included. Pass `all` to include both your `dependencies` and `devDependencies` when constructing the package graph and determining topological order.
+Set which kind of dependencies to use when building a package graph. The default value is `dependencies`, whereby only packages listed in the `dependencies` section of a package's `package.json` are included. Pass `all` to include both `dependencies` _and_ `devDependencies` when constructing the package graph and determining topological order.
+
+When using traditional peer + dev dependency pairs, this option should be configured to `all` so the peers are always published before their dependents.
+
+```sh
+lerna publish --graph-type all
+```
+
+Configured via `lerna.json`:
+
+```json
+{
+  "command": {
+    "publish": {
+      "graphType": "all"
+    }
+  }
+}
+```
 
 ### `--no-git-reset`
 

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -178,6 +178,35 @@ Map {
     });
   });
 
+  describe("--graph-type", () => {
+    it("produces a topological ordering that _includes_ devDependencies when value is 'all'", async () => {
+      const cwd = await initFixture("normal");
+
+      await lernaPublish(cwd)("--graph-type", "all");
+
+      expect(npmPublish.order()).toEqual([
+        "package-1",
+        "package-4",
+        "package-2",
+        // package-3 has a peer/devDependency on package-2
+        "package-3",
+        // package-5 is private
+      ]);
+    });
+
+    it("throws an error when value is _not_ 'all' or 'dependencies'", async () => {
+      const testDir = await initFixture("normal");
+
+      try {
+        await lernaPublish(testDir)("--graph-type", "poopy-pants");
+      } catch (err) {
+        expect(err.message).toMatch("poopy-pants");
+      }
+
+      expect.hasAssertions();
+    });
+  });
+
   describe("--otp", () => {
     otplease.getOneTimePassword.mockImplementation(() => Promise.resolve("654321"));
 

--- a/commands/publish/command.js
+++ b/commands/publish/command.js
@@ -41,6 +41,12 @@ exports.builder = yargs => {
       type: "string",
       requiresArg: true,
     },
+    "graph-type": {
+      describe: "Dependency graphs to use when determining package hierarchy.",
+      type: "string",
+      requiresArg: true,
+      defaultDescription: "dependencies",
+    },
     otp: {
       describe: "Supply a one-time password for publishing with two-factor authentication.",
       type: "string",

--- a/commands/publish/command.js
+++ b/commands/publish/command.js
@@ -42,9 +42,8 @@ exports.builder = yargs => {
       requiresArg: true,
     },
     "graph-type": {
-      describe: "Dependency graphs to use when determining package hierarchy.",
-      type: "string",
-      requiresArg: true,
+      describe: "Type of dependency to use when determining package hierarchy.",
+      choices: ["all", "dependencies"],
       defaultDescription: "dependencies",
     },
     otp: {

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -585,18 +585,15 @@ class PublishCommand extends Command {
   }
 
   topoMapPackages(mapper) {
-    // Default behavior
-    // Originally, Lerna didn't sort based on devDependencies because that would increase the
-    // chance of dependency cycles, causing less-than-ideal a publishing order.
-    let graphType = "dependencies";
-    if (this.options.graphType && this.options.graphType === "all") {
-      graphType = "allDependencies"; // Use the entire package graph for sorting topologically
-    }
     // we don't respect --no-sort here, sorry
     return runTopologically(this.packagesToPublish, mapper, {
       concurrency: this.concurrency,
       rejectCycles: this.options.rejectCycles,
-      graphType,
+      // By default, do not include devDependencies in the graph because it would
+      // increase the chance of dependency cycles, causing less-than-ideal order.
+      // If the user has opted-in to --graph-type=all (or "graphType": "all" in lerna.json),
+      // devDependencies _will_ be included in the graph construction.
+      graphType: this.options.graphType === "all" ? "allDependencies" : "dependencies",
     });
   }
 

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -585,14 +585,18 @@ class PublishCommand extends Command {
   }
 
   topoMapPackages(mapper) {
+    // Default behavior
+    // Originally, Lerna didn't sort based on devDependencies because that would increase the
+    // chance of dependency cycles, causing less-than-ideal a publishing order.
+    let graphType = "dependencies";
+    if (this.options.graphType && this.options.graphType === "all") {
+      graphType = "allDependencies"; // Use the entire package graph for sorting topologically
+    }
     // we don't respect --no-sort here, sorry
     return runTopologically(this.packagesToPublish, mapper, {
       concurrency: this.concurrency,
       rejectCycles: this.options.rejectCycles,
-      // Don't sort based on devDependencies because that
-      // would increase the chance of dependency cycles
-      // causing less-than-ideal a publishing order.
-      graphType: "dependencies",
+      graphType,
     });
   }
 


### PR DESCRIPTION
Allow for configuration of a specific graphType, so that users can opt-in to using devDependencies when building a package graph during publish.

Closes #1437.

## Description
Added a new option, graph-type, to the publish command. The default value for this option does not change any existing behaviour.

Not sure what tests I should add for this change though. 

## Motivation and Context
See #1437.

## How Has This Been Tested?
Ran the existing test suite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
