### PR TITLE
feat(publish): add `--registry-scope` option to override registry urls set with scope

### DIFF
--- a/commands/publish/command.js
+++ b/commands/publish/command.js
@@ -51,6 +51,11 @@ exports.builder = yargs => {
       type: "string",
       requiresArg: true,
     },
+    "registry-scope": {
+      describe: "Use the specified registry for all npm client operations.",
+      type: "string",
+      requiresArg: true,
+    },
     "require-scripts": {
       describe: "Execute ./scripts/prepublish.js and ./scripts/postpublish.js, relative to package root.",
       type: "boolean",

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -101,6 +101,20 @@ class PublishCommand extends Command {
       registry: this.options.registry,
     });
 
+    if (this.options["registry-scope"]) {
+      const registryScope = Array.isArray(this.options["registry-scope"])
+        ? this.options["registry-scope"]
+        : [this.options["registry-scope"]];
+
+      registryScope.forEach(scope => {
+        const registryScopeParts = scope.split(/(^@.*?):/);
+
+        if (registryScopeParts && registryScopeParts.length === 3) {
+          this.conf.set(`${registryScopeParts[1]}:registry`, registryScopeParts[2], "cli");
+        }
+      });
+    }
+
     this.conf.set("user-agent", userAgent, "cli");
 
     if (this.conf.get("registry") === "https://registry.yarnpkg.com") {


### PR DESCRIPTION
## Description

Allow overriding of scoped registry urls.

For example if you have a `.npmrc` file like this:
```
@scope:registry=https://npm.pkg.github.com/
```
And you execute a publish like this:
```
yarn lerna publish from-git --yes --registry https://custom.registry.com/
```
Lerna will currently always try to publish too `https://npm.pkg.github.com/`.

## Motivation and Context

It is currently not possible to override scoped registry urls from a `.npmrc` file in the CLI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested manually with linking this package in to the project where we needed the ability to override scoped registries.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
