### PR TITLE
fix(gitignore): make all node_modules ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ composer.lock
 *.swo
 
 # Project Specific
-/node_modules
+node_modules
 *.log
 /lib
 tmp


### PR DESCRIPTION
Gitignore currently does not ignore all packages node_modules.

## Description
Changing `/node_modules` to `node_modules` fixes the problem.

## Motivation and Context
It makes sure that the repo is free of any mistakenly committed node_modules.

## How Has This Been Tested?
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
