### PR TITLE
docs(add): Highlight single-argument limitation

### DIFF
--- a/commands/add/README.md
+++ b/commands/add/README.md
@@ -10,7 +10,7 @@ Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` C
 $ lerna add <package>[@version] [--dev] [--exact]
 ```
 
-Add local or remote `package` as dependency to packages in the current Lerna repo.
+Add local or remote `package` as dependency to packages in the current Lerna repo. Note that only a single package can be added at a time compared to `yarn add` or `npm install`.
 
 When run, this command will:
 


### PR DESCRIPTION
Addition to docs

## Description
lerna add only supports adding one package at a time, compared to yarn or NPM.  Makes sense to note this in the docs

## Motivation and Context
It's a common mistake from developers to run code like:
```
lerna add --scope=axy express webpack
```
and then see it fail.  The docs can now show that only 1 package can be added at a time

## How Has This Been Tested?
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
