### PR TITLE
fix(publish): --canary doesn't upgrade private packages

### DIFF
--- a/commands/publish/__tests__/publish-canary-no-git-reset.test.js
+++ b/commands/publish/__tests__/publish-canary-no-git-reset.test.js
@@ -91,6 +91,7 @@ Object {
   "package-2": 1.0.1-alpha.0+SHA,
   "package-3": 1.0.1-alpha.0+SHA,
   "package-4": 1.0.1-alpha.0+SHA,
+  "package-5": 1.0.1-alpha.0+SHA,
 }
 `);
   expect(gitCheckout).toHaveBeenCalledTimes(0);

--- a/commands/publish/__tests__/publish-canary.test.js
+++ b/commands/publish/__tests__/publish-canary.test.js
@@ -92,6 +92,7 @@ Object {
   "package-2": 1.0.1-alpha.0+SHA,
   "package-3": 1.0.1-alpha.0+SHA,
   "package-4": 1.0.1-alpha.0+SHA,
+  "package-5": 1.0.1-alpha.0+SHA,
 }
 `);
 });
@@ -107,6 +108,7 @@ Object {
   "package-1": 1.0.1-beta.0+SHA,
   "package-2": 1.0.1-beta.0+SHA,
   "package-3": 1.0.1-beta.0+SHA,
+  "package-5": 1.0.1-beta.0+SHA,
 }
 `);
 });
@@ -123,6 +125,7 @@ Object {
   "package-1": 1.0.1-alpha.0+SHA,
   "package-2": 1.0.1-alpha.0+SHA,
   "package-3": 1.0.1-alpha.0+SHA,
+  "package-5": 1.0.1-alpha.0+SHA,
 }
 `);
 });
@@ -138,6 +141,7 @@ Object {
   "package-1": 1.1.0-alpha.0+SHA,
   "package-2": 2.1.0-alpha.0+SHA,
   "package-3": 3.1.0-alpha.0+SHA,
+  "package-5": 5.1.0-alpha.0+SHA,
 }
 `);
 });
@@ -311,6 +315,7 @@ Object {
   "package-2": 1.0.1-alpha.0+SHA,
   "package-3": 1.0.1-alpha.0+SHA,
   "package-4": 1.0.1-alpha.0+SHA,
+  "package-5": 1.0.1-alpha.0+SHA,
 }
 `);
 });
@@ -333,6 +338,7 @@ test("publish --canary --force-publish <arg> on tagged release avoids early exit
 Object {
   "package-2": 2.0.1-alpha.0+SHA,
   "package-3": 3.0.1-alpha.0+SHA,
+  "package-5": 5.0.2-alpha.0+SHA,
 }
 `);
 });

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -492,9 +492,7 @@ class PublishCommand extends Command {
   }
 
   updateCanaryVersions() {
-    const publishableUpdates = this.updates.filter(node => !node.pkg.private);
-
-    return pMap(publishableUpdates, ({ pkg, localDependencies }) => {
+    return pMap(this.updates, ({ pkg, localDependencies }) => {
       pkg.version = this.updatesVersions.get(pkg.name);
 
       for (const [depName, resolved] of localDependencies) {
@@ -552,7 +550,7 @@ class PublishCommand extends Command {
   }
 
   serializeChanges() {
-    return pMap(this.packagesToPublish, pkg => pkg.serialize());
+    return pMap(this.updates, ({ pkg }) => pkg.serialize());
   }
 
   resetChanges() {
@@ -560,7 +558,7 @@ class PublishCommand extends Command {
     // and we should always __attempt_ to leave the working tree clean
     const { cwd } = this.execOpts;
     const dirtyManifests = [this.project.manifest]
-      .concat(this.packagesToPublish)
+      .concat(this.updates.map(({ pkg }) => pkg))
       .map(pkg => path.relative(cwd, pkg.manifestLocation));
 
     return gitCheckout(dirtyManifests, this.execOpts).catch(err => {

--- a/integration/lerna-publish-canary.test.js
+++ b/integration/lerna-publish-canary.test.js
@@ -76,6 +76,7 @@ Changes not staged for commit:
 	modified:   packages/package-1/package.json
 	modified:   packages/package-2/package.json
 	modified:   packages/package-3/package.json
+	modified:   packages/package-5/package.json
 
 no changes added to commit (use "git add" and/or "git commit -a")
 `);


### PR DESCRIPTION
Fixes #2206 

## Description
`lerna --canary --no-git-reset` should upgrade a package version if some of its dependent packages changed. Now it doesn't work if the package is private.

## Motivation and Context
Fixes #2206

## How Has This Been Tested?
Create a monorepo with packages: `app` (private), `lib` (public). Make `app` depend on `lib`.
Then `lerna publish --canary --no-git-reset --force-publish` should upgrade both packages and publish `lib`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
