### PR TITLE
fix(bootstrap): Run lifecycle scripts in topological queue instead of batches

### DIFF
--- a/commands/bootstrap/package.json
+++ b/commands/bootstrap/package.json
@@ -36,7 +36,6 @@
     "populate--": true
   },
   "dependencies": {
-    "@lerna/batch-packages": "file:../../utils/batch-packages",
     "@lerna/command": "file:../../core/command",
     "@lerna/filter-options": "file:../../core/filter-options",
     "@lerna/has-npm-version": "file:../../utils/has-npm-version",
@@ -45,7 +44,7 @@
     "@lerna/pulse-till-done": "file:../../utils/pulse-till-done",
     "@lerna/rimraf-dir": "file:../../utils/rimraf-dir",
     "@lerna/run-lifecycle": "file:../../utils/run-lifecycle",
-    "@lerna/run-parallel-batches": "file:../../utils/run-parallel-batches",
+    "@lerna/run-topologically": "file:../../utils/run-topologically",
     "@lerna/symlink-binary": "file:../../utils/symlink-binary",
     "@lerna/symlink-dependencies": "file:../../utils/symlink-dependencies",
     "@lerna/validation-error": "file:../../core/validation-error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -777,17 +777,9 @@
         "semver": "^6.2.0"
       }
     },
-    "@lerna/batch-packages": {
-      "version": "file:utils/batch-packages",
-      "requires": {
-        "@lerna/package-graph": "file:core/package-graph",
-        "npmlog": "^4.1.2"
-      }
-    },
     "@lerna/bootstrap": {
       "version": "file:commands/bootstrap",
       "requires": {
-        "@lerna/batch-packages": "file:utils/batch-packages",
         "@lerna/command": "file:core/command",
         "@lerna/filter-options": "file:core/filter-options",
         "@lerna/has-npm-version": "file:utils/has-npm-version",
@@ -796,7 +788,7 @@
         "@lerna/pulse-till-done": "file:utils/pulse-till-done",
         "@lerna/rimraf-dir": "file:utils/rimraf-dir",
         "@lerna/run-lifecycle": "file:utils/run-lifecycle",
-        "@lerna/run-parallel-batches": "file:utils/run-parallel-batches",
+        "@lerna/run-topologically": "file:utils/run-topologically",
         "@lerna/symlink-binary": "file:utils/symlink-binary",
         "@lerna/symlink-dependencies": "file:utils/symlink-dependencies",
         "@lerna/validation-error": "file:core/validation-error",
@@ -1296,13 +1288,6 @@
         "figgy-pudding": "^3.5.1",
         "npm-lifecycle": "^3.1.2",
         "npmlog": "^4.1.2"
-      }
-    },
-    "@lerna/run-parallel-batches": {
-      "version": "file:utils/run-parallel-batches",
-      "requires": {
-        "p-map": "^2.1.0",
-        "p-map-series": "^1.0.0"
       }
     },
     "@lerna/run-topologically": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates `@lerna/bootstrap` so that it used `runTopologically` instead of the old `batchPackages`

`@lerna/batch-packages` and `@lerna/run-parallel-batches` aren't used anymore by any other package of the monorepo, but I don't know which is the process needed to remove them.

## Motivation and Context

While updating lerna in the Babel repo, I noticed that the old cycles warnings (which should have been disappeared after https://github.com/lerna/lerna/pull/2185) were still there.
After investigating a bit, I realized that the old `partitionCycles` method was still used by `@lerna/batch-packages`.

## How Has This Been Tested?
Only using the tests in this repo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
