### PR TITLE
feat(import): allow more flexibility

### DIFF
--- a/commands/import/README.md
+++ b/commands/import/README.md
@@ -47,10 +47,17 @@ $ lerna import ~/Product --flatten
 
 ### `--dest`
 
-When importing repositories, you can specify the destination directory by the directory listed in lerna.json.
+When importing repositories, you can specify the destination directory. It must be one of the package directories specified in the Lerna.json or a descendant of one of those directories.
 
 ```
 $ lerna import ~/Product --dest=utilities
+```
+
+### `--dest-name`
+When importing repositories, you can specify the name of the new directory created to store the imported repository. If this argument is not passed, by default lerna import will use the name of name of the directory from which the external repository was imported.   
+
+```
+$ lerna import ~/Product --dest-name=MyProduct
 ```
 
 ### `--preserve-commit`
@@ -58,6 +65,7 @@ $ lerna import ~/Product --dest=utilities
 Each git commit has an **author** and a **committer** (with a separate date for each). Usually they're the same person (and date), but since `lerna import` re-creates each commit from the external repository, the **committer** becomes the current git user (and date). This is *technically* correct, but may be undesireable, for example, on Github, which displays both the **author** and **committer** if they're different people, leading to potentially confusing history/blames on imported commits.
 
 Enabling this option preserves the original **committer** (and commit date) to avoid such issues.
+
 
 ```
 $ lerna import ~/Product --preserve-commit

--- a/commands/import/__tests__/import-command.test.js
+++ b/commands/import/__tests__/import-command.test.js
@@ -40,6 +40,30 @@ describe("ImportCommand", () => {
       expect(await pathExists(packageJson)).toBe(true);
     });
 
+    it("allows target base to be any descendant of a lerna package directory", async () => {
+      const [testDir, externalDir] = await initBasicFixtures();
+      const packageJson = path.join(
+        testDir,
+        "packages",
+        "bluePackages",
+        path.basename(externalDir),
+        "package.json"
+      );
+
+      await lernaImport(testDir)(externalDir, "--dest=packages/bluePackages");
+
+      expect(await pathExists(packageJson)).toBe(true);
+    });
+
+    it("creates a module in custom location when dest-name argument passed", async () => {
+      const [testDir, externalDir] = await initBasicFixtures();
+      const packageJson = path.join(testDir, "packages", "customDirectory", "package.json");
+
+      await lernaImport(testDir)(externalDir, "--dest-name=customDirectory");
+
+      expect(await pathExists(packageJson)).toBe(true);
+    });
+
     it("imports a repo with conflicted merge commits when run with --flatten", async () => {
       const [testDir, externalDir] = await initBasicFixtures();
       const branchName = "conflict_branch";

--- a/commands/import/command.js
+++ b/commands/import/command.js
@@ -32,6 +32,11 @@ exports.builder = yargs =>
         alias: "yes",
         type: "boolean",
       },
+      "dest-name": {
+        group: "Command Options:",
+        describe: "Custom name for the new directory created by the import",
+        type: "string",
+      },
     });
 
 exports.handler = function handler(argv) {

--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -62,13 +62,16 @@ class ImportCommand extends Command {
 
     // Compute a target directory relative to the Lerna root
     const targetBase = this.getTargetBase();
-    if (this.getPackageDirectories().indexOf(targetBase) === -1) {
+    // Ensure target directory is inside one of the lerna package directories
+    const containsTarget = packageDir => targetBase.includes(packageDir);
+    if (!this.getPackageDirectories().some(containsTarget)) {
       throw new ValidationError(
         "EDESTDIR",
         `--dest does not match with the package directories: ${this.getPackageDirectories()}`
       );
     }
-    const targetDir = path.join(targetBase, externalRepoBase);
+
+    const targetDir = path.join(targetBase, this.options.destName || externalRepoBase);
 
     // Compute a target directory relative to the Git root
     const gitRepoRoot = this.getWorkspaceRoot();


### PR DESCRIPTION
## Description
This changes the lerna import command to:
1. Support any directory that is contained in one of the lerna packages directories, not just those packages directories themselves, as destination base paths
2. Support naming the new destination directory that will be created by running lerna import inside the base path mentioned above whatever you want, instead of forcing it to be the name of the directory from which the files are being imported.

## Motivation and Context
See https://github.com/lerna/lerna/issues/2232 for a description of the really convoluted workflow that is currently required without these changes for me to use lerna import as desired to achieve the outcomes I want.

## How Has This Been Tested?
I added unit tests for the two new behaviors I wish to support.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
_NOTE: this is my first PR to lerna so if I checked something here incorrectly please let me know how I can improve_

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
