### PR TITLE
Fix typo in version readme - `graduate` should be `prerelease`

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -145,7 +145,7 @@ When run with this flag, `lerna version` will graduate the specified packages (c
 lerna version --conventional-commits --conventional-prerelease=package-2,package-4
 
 # force all prerelease packages to be graduated
-lerna version --conventional-commits --conventional-graduate
+lerna version --conventional-commits --conventional-prerelease
 ```
 
 When run with this flag, `lerna version` will release with prerelease versions the specified packages (comma-separated) or all packages using `*`. Releases all unreleased changes as pre(patch/minor/major/release) by prefixing the version recommendation from `conventional-commits` with `pre`, eg. if present changes include a feature commit, the recommended bump will be `minor`, so this flag will result in a `preminor` release. If changes are present for packages that are not specified (if specifying packages), or for packages that are already in prerelease, those packages will be versioned as they normally would using `--conventional-commits`.


### PR DESCRIPTION
## Description
The `lerna version` readme references `--conventional-graduate` instead of `--conventional-prerelease` in one of the examples

## Motivation and Context
Accuracy in docs

## How Has This Been Tested?
Visually looked at the docs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
