### PR TITLE
feat: support common js config files

### DIFF
--- a/core/project/README.md
+++ b/core/project/README.md
@@ -4,7 +4,7 @@
 
 ## Configuration Resolution
 
-Lerna's file-based configuration is located in `lerna.json` or the `lerna` property of `package.json`.
+Lerna's file-based configuration is located in `lerna.json`, a commonjs module exported from `lerna.config.js` or the `lerna` property of `package.json`.
 Wherever this configuration is found is considered the "root" of the lerna-managed multi-package repository.
 A minimum-viable configuration only needs a `version` property; the following examples are equivalent:
 

--- a/core/project/__fixtures__/basic-cjs/lerna.config.js
+++ b/core/project/__fixtures__/basic-cjs/lerna.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  version: "1.0.0",
+};

--- a/core/project/__fixtures__/basic-cjs/node_modules/external/package.json
+++ b/core/project/__fixtures__/basic-cjs/node_modules/external/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "external",
+  "version": "1.0.1"
+}

--- a/core/project/__fixtures__/basic-cjs/package.json
+++ b/core/project/__fixtures__/basic-cjs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "devDependencies": {
+    "external": "^1.0.0",
+    "lerna": "500.0.0"
+  }
+}

--- a/core/project/__tests__/project.test.js
+++ b/core/project/__tests__/project.test.js
@@ -51,6 +51,13 @@ describe("Project", () => {
       });
     });
 
+    it("returns parsed lerna.config.js", async () => {
+      const project = new Project(await initFixture("basic-cjs"));
+      expect(project.config).toEqual({
+        version: "1.0.0",
+      });
+    });
+
     it("defaults to an empty object", async () => {
       await initFixture("no-lerna-config");
 

--- a/core/project/index.js
+++ b/core/project/index.js
@@ -19,7 +19,7 @@ const makeFileFinder = require("./lib/make-file-finder");
 class Project {
   constructor(cwd) {
     const explorer = cosmiconfig("lerna", {
-      searchPlaces: ["lerna.json", "package.json"],
+      searchPlaces: ["lerna.json", "lerna.config.js", "package.json"],
       transform(obj) {
         // cosmiconfig returns null when nothing is found
         if (!obj) {


### PR DESCRIPTION
## Description
Support a commonjs format config file as `lerna.config.js`, as described in #2269 

## Motivation and Context
- more flexible shared tooling
- provide more flexible options depending on git context (i.e. conventional pre-release for specific branches, etc)
- in our particular case, we want to share `lerna version`, `lerna publish`, etc configurations (conventional commits is big factor) across a few dozen monorepos in a clean and overrideable fashion
- the `lerna.config.js` filename takes inspiration from `jest.config.js` and `babel.config.js`, but I'm open to other conventions, and cosmic config was a great choice :)

## How Has This Been Tested?
- I've tested it locally using yarn link and a complicated lerna config file
- I've added a simple unit test that loads and asserts a fixture `lerna.config.js`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - downstream tools such as dependabot, renovatebot, etc may expect a lerna.json file still yet?

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
