### PR TITLE
feat(filter-options): Allow command to continue if no packages are matched

### DIFF
--- a/core/filter-options/__tests__/get-filtered-packages.test.js
+++ b/core/filter-options/__tests__/get-filtered-packages.test.js
@@ -90,6 +90,20 @@ test.each`
   expect.hasAssertions();
 });
 
+test.each`
+  argv
+  ${["--scope", "not-a-package", "--continue-if-no-match"]}
+  ${["--ignore", "package-*", "--continue-if-no-match"]}
+  ${["--scope", "package-@(1|2)", "--ignore", "package-{1,2}", "--continue-if-no-match"]}
+`("no errors and no packages $argv", async ({ argv }) => {
+  const packageGraph = await buildGraph(cwd);
+  const execOpts = { cwd };
+  const options = parseOptions(...argv);
+
+  const result = await getFilteredPackages(packageGraph, execOpts, options);
+  expect(result).toHaveLength(0);
+});
+
 test("--since returns all packages if no tag is found", async () => {
   const packageGraph = await buildGraph(cwd);
   const execOpts = { cwd };

--- a/core/filter-options/index.js
+++ b/core/filter-options/index.js
@@ -49,6 +49,11 @@ function filterOptions(yargs) {
       `,
       type: "boolean",
     },
+    "continue-if-no-match": {
+      describe: "Don't fail if no package is matched",
+      hidden: true,
+      type: "boolean",
+    },
   };
 
   return yargs.options(opts).group(Object.keys(opts), "Filter Options:");

--- a/core/filter-options/lib/get-filtered-packages.js
+++ b/core/filter-options/lib/get-filtered-packages.js
@@ -9,7 +9,13 @@ function getFilteredPackages(packageGraph, execOpts, options) {
   let chain = Promise.resolve();
 
   chain = chain.then(() =>
-    filterPackages(packageGraph.rawPackageList, options.scope, options.ignore, options.private)
+    filterPackages(
+      packageGraph.rawPackageList,
+      options.scope,
+      options.ignore,
+      options.private,
+      options.continueIfNoMatch
+    )
   );
 
   if (options.since !== undefined) {

--- a/utils/filter-packages/filter-packages.js
+++ b/utils/filter-packages/filter-packages.js
@@ -16,10 +16,11 @@ module.exports = filterPackages;
  * @param {Array.<String>} include A list of globs to match the package name against
  * @param {Array.<String>} exclude A list of globs to filter the package name against
  * @param {Boolean} showPrivate When false, filter out private packages
+ * @param {Boolean} continueIfNoMatch When true, do not throw if no package is matched
  * @return {Array.<Package>} The packages with a name matching the glob
- * @throws when a given glob would produce an empty list of packages
+ * @throws when a given glob would produce an empty list of packages and `continueIfNoMatch` is not set.
  */
-function filterPackages(packagesToFilter, include = [], exclude = [], showPrivate) {
+function filterPackages(packagesToFilter, include = [], exclude = [], showPrivate, continueIfNoMatch) {
   const filtered = new Set(packagesToFilter);
   const patterns = [].concat(arrify(include), negate(exclude));
 
@@ -49,7 +50,7 @@ function filterPackages(packagesToFilter, include = [], exclude = [], showPrivat
       }
     }
 
-    if (!filtered.size) {
+    if (!filtered.size && !continueIfNoMatch) {
       throw new ValidationError("EFILTER", util.format("No packages remain after filtering", patterns));
     }
   }


### PR DESCRIPTION
## Description
- Added new param `continueIfNoMatch` in `filterPackages()` to prevent an exception from being thrown if all filters did not match any package.
- Added `--continue-if-no-match` as a Filter option to enable/disable new param.
- Added documentation to the method and param. Because this option is hidden by design (because it is not really a filter), I'd like to hear what the reviewers may suggest.

## Motivation and Context
My motivation is being able to execute the same command in one or more Lerna-managed mono repos, which may or may not contain the same scopes. As long as every team follows the definition of scopes, the same CI can be applied to every team.

For example:
```
lerna-repo-1/
  package.json
  team-a/
    lib-1/
      package.json
    service-1/
      package.json
  team-b/
    service-1/
      package.json
    service-2/
      package.json
lerna-repo-2/
  team-c/
    component-1/
      package.json
    lib-1/
      package.json
    service-1/
      package.json
```

The CI tries to create a scope like `--scope <team>-<type-of-artifact>-*`. With this new option, we don't need to conditionally select which artifacts to build. For example, building libs of Team B would fail in the current behavior.

Imagine also some people may have suggested adding empty packages only to bypass CI.

## How Has This Been Tested?
I have added unit tests to cover the new param. They contain the same scenarios by the tests that throw the exception (plus the new param);

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
