### PR TITLE
Update git-add.js

### DIFF
--- a/commands/version/lib/git-add.js
+++ b/commands/version/lib/git-add.js
@@ -12,5 +12,5 @@ function gitAdd(files, opts) {
 
   const filePaths = files.map(file => slash(path.relative(opts.cwd, path.resolve(opts.cwd, file))));
 
-  return childProcess.exec("git", ["add", "--", ...filePaths], opts);
+  return childProcess.exec("git", ["add", "-u","--", ...filePaths], opts);
 }

--- a/commands/version/lib/git-add.js
+++ b/commands/version/lib/git-add.js
@@ -12,5 +12,5 @@ function gitAdd(files, opts) {
 
   const filePaths = files.map(file => slash(path.relative(opts.cwd, path.resolve(opts.cwd, file))));
 
-  return childProcess.exec("git", ["add", "-u","--", ...filePaths], opts);
+  return childProcess.exec("git", ["add", "-u", "--", ...filePaths], opts);
 }


### PR DESCRIPTION
tested this way is the simplest to resolve 
#2151 
#1075 
#2267 
#2141 
#2113 
#1096 
#216 

etc....

```
       -u, --update
          Update the index just where it already has an entry matching <pathspec>. This removes as well as modifies index entries to match the working tree, but adds no new files.     
If no <pathspec> is given when -u option is used, all tracked files in the entire working tree are updated (old versions of Git used to limit the update to the current directory and its subdirectories).
```


It has a flaw in that it cannot track the newly created files,  but no new files are created in our scenario, so it is suitable for us.

