### PR TITLE
add --destination option to lerna add command

### DIFF
--- a/commands/add/README.md
+++ b/commands/add/README.md
@@ -43,11 +43,15 @@ Use a custom registry to install the targeted package.
 
 Skip the chained `lerna bootstrap`.
 
+### `--destination`
+
+Package destination to install to.
+
 ## Examples
 
 ```sh
 # Adds the module-1 package to the packages in the 'prefix-' prefixed folders
-lerna add module-1 packages/prefix-*
+lerna add module-1 --destination packages/prefix-*
 
 # Install module-1 to module-2
 lerna add module-1 --scope=module-2

--- a/commands/add/__tests__/add-command.test.js
+++ b/commands/add/__tests__/add-command.test.js
@@ -160,10 +160,10 @@ describe("AddCommand", () => {
     expect(pkg1).not.toDependOn("@test/package-1");
   });
 
-  it("filters targets by optional directory globs", async () => {
+  it("filters targets by optional directory destination globs", async () => {
     const testDir = await initFixture("basic");
 
-    await lernaAdd(testDir)("@test/package-1", "packages/package-2");
+    await lernaAdd(testDir)("@test/package-1", "--destination packages/package-2");
     const [, pkg2, pkg3, pkg4] = await getPackages(testDir);
 
     expect(pkg2).toDependOn("@test/package-1");

--- a/commands/add/command.js
+++ b/commands/add/command.js
@@ -5,7 +5,7 @@ const filterable = require("@lerna/filter-options");
 /**
  * @see https://github.com/yargs/yargs/blob/master/docs/advanced.md#providing-a-command-module
  */
-exports.command = "add <pkg> [globs..]";
+exports.command = "add <pkg..>";
 
 exports.describe = "Add a single dependency to matched packages";
 
@@ -13,13 +13,16 @@ exports.builder = yargs => {
   yargs
     .positional("pkg", {
       describe: "Package name to add as a dependency",
-      type: "string",
-    })
-    .positional("globs", {
-      describe: "Optional package directory globs to match",
       type: "array",
     })
     .options({
+      d: {
+        group: "Command Options:",
+        describe: "Package directory globs to install to",
+        type: "array",
+        alias: "destination",
+        requiresArg: true,
+      },
       D: {
         group: "Command Options:",
         type: "boolean",
@@ -50,7 +53,7 @@ exports.builder = yargs => {
       },
     })
     .example(
-      "$0 add module-1 packages/prefix-*",
+      "$0 add module-1 --destination packages/prefix-*",
       "Adds the module-1 package to the packages in the 'prefix-' prefixed folders"
     )
     .example("$0 add module-1 --scope=module-2", "Install module-1 to module-2")


### PR DESCRIPTION
## Description
Moved the destination argument to a separate option.

Added a `--destination (-d)` option to the `lerna add` command which accepts globs to set the destination where we should add the packages, for example... 
```
lerna add package-1 --destination packages/*
```

## Motivation and Context
This allows for multiple package installs in one command (#2004)

## How Has This Been Tested?
Unit tests updated to match the new use of the `lerna add` command, currently broken because you can't throw errors in nested asynchronous callbacks of a promise. Will fix it as soon as we get more clarity around this new `--destination` approach.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
