### PR TITLE
feat(add): Add `--peer` option to save target in `peerDependencies`

### DIFF
--- a/commands/add/README.md
+++ b/commands/add/README.md
@@ -7,7 +7,7 @@ Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` C
 ## Usage
 
 ```sh
-$ lerna add <package>[@version] [--dev] [--exact]
+$ lerna add <package>[@version] [--dev] [--exact] [--peer]
 ```
 
 Add local or remote `package` as dependency to packages in the current Lerna repo. Note that only a single package can be added at a time compared to `yarn add` or `npm install`.
@@ -35,6 +35,10 @@ $ lerna add --exact
 
 Add the new package with an exact version (e.g., `1.0.1`) rather than the default `^` semver range (e.g., `^1.0.1`).
 
+### `--peer`
+
+Add the new package to `peerDependencies` instead of `dependencies`.
+
 ### `--registry <url>`
 
 Use a custom registry to install the targeted package.
@@ -54,6 +58,9 @@ lerna add module-1 --scope=module-2
 
 # Install module-1 to module-2 in devDependencies
 lerna add module-1 --scope=module-2 --dev
+
+# Install module-1 to module-2 in peerDependencies
+lerna add module-1 --scope=module-2 --peer
 
 # Install module-1 in all modules except module-1
 lerna add module-1

--- a/commands/add/__tests__/add-command.test.js
+++ b/commands/add/__tests__/add-command.test.js
@@ -169,6 +169,28 @@ describe("AddCommand", () => {
     expect(pkg2).toDevDependOn("@test/package-1");
   });
 
+  describe("peerDependencies", () => {
+    it("should add target package to peerDependencies", async () => {
+      const testDir = await initFixture("basic");
+
+      await lernaAdd(testDir)("@test/package-1", "--peer");
+      const [, pkg2, pkg3, pkg4] = await getPackages(testDir);
+
+      expect(pkg2).toPeerDependOn("@test/package-1");
+      expect(pkg3).toPeerDependOn("@test/package-1");
+      expect(pkg4).toPeerDependOn("@test/package-1");
+    });
+
+    it("should add target package to peerDependencies with alias", async () => {
+      const testDir = await initFixture("basic");
+
+      await lernaAdd(testDir)("-P", "@test/package-1");
+      const [, pkg2] = await getPackages(testDir);
+
+      expect(pkg2).toPeerDependOn("@test/package-1");
+    });
+  });
+
   it("should not reference packages to themeselves", async () => {
     const testDir = await initFixture("basic");
 

--- a/commands/add/command.js
+++ b/commands/add/command.js
@@ -32,6 +32,12 @@ exports.builder = yargs => {
         alias: "exact",
         describe: "Save version exactly",
       },
+      P: {
+        group: "Command Options:",
+        type: "boolean",
+        alias: "peer",
+        describe: "Save to peerDependencies",
+      },
       registry: {
         group: "Command Options:",
         describe: "Use the specified registry for all npm client operations.",
@@ -55,6 +61,7 @@ exports.builder = yargs => {
     )
     .example("$0 add module-1 --scope=module-2", "Install module-1 to module-2")
     .example("$0 add module-1 --scope=module-2 --dev", "Install module-1 to module-2 in devDependencies")
+    .example("$0 add module-1 --scope=module-2 --peer", "Install module-1 to module-2 in peerDependencies")
     .example("$0 add module-1", "Install module-1 in all modules except module-1")
     .example("$0 add module-1 --no-bootstrap", "Skip automatic `lerna bootstrap`")
     .example("$0 add babel-core", "Install babel-core in all modules");

--- a/commands/add/index.js
+++ b/commands/add/index.js
@@ -25,8 +25,17 @@ class AddCommand extends Command {
     return false;
   }
 
+  get dependencyType() {
+    if (this.options.dev) {
+      return "devDependencies";
+    }
+    if (this.options.peer) {
+      return "peerDependencies";
+    }
+    return "dependencies";
+  }
+
   initialize() {
-    this.dependencyType = this.options.dev ? "devDependencies" : "dependencies";
     this.spec = npa(this.options.pkg);
     this.dirs = new Set(this.options.globs.map(fp => path.resolve(this.project.rootPath, fp)));
     this.selfSatisfied = this.packageSatisfied();

--- a/helpers/pkg-matchers/index.js
+++ b/helpers/pkg-matchers/index.js
@@ -7,11 +7,17 @@ const Package = require("@lerna/package");
 
 exports.toDependOn = createDependencyMatcher("dependencies");
 exports.toDevDependOn = createDependencyMatcher("devDependencies");
+exports.toPeerDependOn = createDependencyMatcher("peerDependencies");
 exports.toHaveBinaryLinks = toHaveBinaryLinks;
 exports.toHaveExecutables = toHaveExecutables;
 
 function createDependencyMatcher(dependencyType) {
-  const verb = dependencyType === "dependencies" ? "depend" : "dev-depend";
+  const verbMap = {
+    dependencies: "depend",
+    devDependencies: "dev-depend",
+    peerDependencies: "peer-depend",
+  };
+  const verb = verbMap[dependencyType] || "dev-depend";
 
   return (received, name, range, options) => {
     const pkg = Package.lazy(received);


### PR DESCRIPTION
## Description
Added peer option in add command.
Pretty similar to devDependencies.

## Motivation and Context
A lot of packages need to define peerDependencies as well as other options. Currently, only manual option is available.
#1947 

## How Has This Been Tested?
- Link lerna to local machine
- Run add command with peer flag
- check peerDependencies in your package

Mac OS 10.15 Catalina, Node 12.

Added one more expect to check if peerDependency added.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
