### PR TITLE
feat(version): add `--git-add-include` parameter

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -51,6 +51,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
 - [`--exact`](#--exact)
 - [`--force-publish`](#--force-publish)
 - [`--git-remote`](#--git-remote-name)
+- [`--git-add-include`](#--git-add-include-glob)
 - [`--create-release`](#--create-release-type)
 - [`--ignore-changes`](#--ignore-changes)
 - [`--include-merged-tags`](#--include-merged-tags)
@@ -193,6 +194,26 @@ lerna version --git-remote upstream
 ```
 
 When run with this flag, `lerna version` will push the git changes to the specified remote instead of `origin`.
+
+### `--git-add-include <glob>`
+
+```sh
+lerna version --git-add-include ".version"
+```
+
+When run with this flag, `lerna version` will stage additional files when `git add` is executed. [globby](https://www.npmjs.com/package/globby) is used to resolve the files and the package location is used as current working directory. [#2333](https://github.com/lerna/lerna/issues/2333)
+
+This can be configured in lerna.json, as well:
+
+```json
+{
+  "command": {
+    "version": {
+      "gitAddInclude": [".version"]
+    }
+  }
+}
+```
 
 ### `--create-release <type>`
 

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -105,6 +105,10 @@ exports.builder = (yargs, composed) => {
       hidden: true,
       type: "boolean",
     },
+    "git-add-include": {
+      describe: "Additionally stage files via git add when modified while versioning process",
+      type: "string",
+    },
     "no-push": {
       describe: "Do not push tagged commit to git remote.",
       type: "boolean",

--- a/commands/version/package.json
+++ b/commands/version/package.json
@@ -49,6 +49,7 @@
     "@lerna/validation-error": "file:../../core/validation-error",
     "chalk": "^2.3.1",
     "dedent": "^0.7.0",
+    "globby": "^9.2.0",
     "load-json-file": "^5.3.0",
     "minimatch": "^3.0.4",
     "npmlog": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1350,6 +1350,7 @@
         "@lerna/validation-error": "file:core/validation-error",
         "chalk": "^2.3.1",
         "dedent": "^0.7.0",
+        "globby": "^9.2.0",
         "load-json-file": "^5.3.0",
         "minimatch": "^3.0.4",
         "npmlog": "^4.1.2",
@@ -4106,8 +4107,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4128,14 +4128,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4150,20 +4148,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4280,8 +4275,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4293,7 +4287,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4308,7 +4301,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4316,14 +4308,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4342,7 +4332,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4423,8 +4412,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4436,7 +4424,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4522,8 +4509,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4559,7 +4545,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4579,7 +4564,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4623,14 +4607,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/utils/npm-conf/lib/types.js
+++ b/utils/npm-conf/lib/types.js
@@ -45,6 +45,7 @@ exports.types = {
   "fetch-retry-maxtimeout": Number,
   git: String,
   "git-tag-version": Boolean,
+  "git-add-include": String,
   "commit-hooks": Boolean,
   global: Boolean,
   globalconfig: path,


### PR DESCRIPTION
## Description
Introduce a new CLI and `lerna.json` option: `git-add-include` which allows an array of glob patterns (if needed).

## Motivation and Context
I summarize two feature requests in #2333 because I need it for my Open Source project https://github.com/matzeeable/wp-reactjs-starter which I want to restructure into a multi-package repository. I started to use `lerna` today and have successfully implemented it. Unfortunely there are two things which are missing so `lerna` can be used together with WordPress plugin development.

In WordPress the version is read from the [Plugin header fields](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/#header-fields) so there is an additional file `index.php` which needs to be `git add`'ed. The version is adjusted via [`version`](https://github.com/matzeeable/wp-reactjs-starter/blob/6aa27807cf6ae92b94acbb880bc4f539ed407f5f/package.json#L40) automatically.

## How Has This Been Tested?
It does not affect other areas of lerna because it is only used in `updatePackageVersions()`. I tested the changes locally on my lerna example repository.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.