### PR TITLE
feat(version): add customizable conventionalChangelog options

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -125,6 +125,25 @@ When run with this flag, `lerna version` will use the [Conventional Commits Spec
 
 Passing [`--no-changelog`](#--no-changelog) will disable the generation (or updating) of `CHANGELOG.md` files.
 
+You can customize the changelog generation ([reference](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#conventionalchangelogcoreoptions-context-gitrawcommitsopts-parseropts-writeropts)) in your `lerna.json`:
+
+```json
+{
+  "command": {
+    "version": {
+      "conventionalCommits": true,
+      "conventionalChangelog": {
+        "options": {},
+        "context": {},
+        "gitRawCommitsOpts": {},
+        "parserOpts": {},
+        "writerOpts": {}
+      }
+    }
+  }
+},
+```
+
 ### `--conventional-graduate`
 
 ```sh

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -476,7 +476,7 @@ class VersionCommand extends Command {
   }
 
   updatePackageVersions() {
-    const { conventionalCommits, changelogPreset, changelog = true } = this.options;
+    const { conventionalCommits, changelogPreset, conventionalChangelog, changelog = true } = this.options;
     const independentVersions = this.project.isIndependent();
     const rootPath = this.project.manifest.location;
     const changedFiles = new Set();
@@ -534,6 +534,7 @@ class VersionCommand extends Command {
       actions.push(pkg =>
         ConventionalCommitUtilities.updateChangelog(pkg, type, {
           changelogPreset,
+          conventionalChangelog,
           rootPath,
           tagPrefix: this.tagPrefix,
         }).then(({ logPath, newEntry }) => {
@@ -569,6 +570,7 @@ class VersionCommand extends Command {
         chain = chain.then(() =>
           ConventionalCommitUtilities.updateChangelog(this.project.manifest, "root", {
             changelogPreset,
+            conventionalChangelog,
             rootPath,
             tagPrefix: this.tagPrefix,
             version: this.globalVersion,

--- a/core/conventional-commits/lib/update-changelog.js
+++ b/core/conventional-commits/lib/update-changelog.js
@@ -11,7 +11,11 @@ const readExistingChangelog = require("./read-existing-changelog");
 
 module.exports = updateChangelog;
 
-function updateChangelog(pkg, type, { changelogPreset, rootPath, tagPrefix = "v", version }) {
+function updateChangelog(
+  pkg,
+  type,
+  { changelogPreset, conventionalChangelog = {}, rootPath, tagPrefix = "v", version }
+) {
   log.silly(type, "for %s at %s", pkg.name, pkg.location);
 
   return getChangelogConfig(changelogPreset, rootPath).then(config => {
@@ -55,7 +59,13 @@ function updateChangelog(pkg, type, { changelogPreset, rootPath, tagPrefix = "v"
     }
 
     // generate the markdown for the upcoming release.
-    const changelogStream = conventionalChangelogCore(options, context, gitRawCommitsOpts);
+    const changelogStream = conventionalChangelogCore(
+      Object.assign(options, conventionalChangelog.options),
+      Object.assign(context, conventionalChangelog.context),
+      Object.assign(gitRawCommitsOpts, conventionalChangelog.gitRawCommitsOpts),
+      conventionalChangelog.parserOpts,
+      conventionalChangelog.writerOpts
+    );
 
     return Promise.all([
       getStream(changelogStream).then(makeBumpOnlyFilter(pkg)),


### PR DESCRIPTION
## Description
Introduce a way to customize the changelog generation via `lerna.json`.

## Motivation and Context
I summarize two feature requests in #2333 because I need it for my Open Source project https://github.com/matzeeable/wp-reactjs-starter which I want to restructure into a multi-package repository. I started to use `lerna` the last time and have successfully implemented it. Unfortunely there are two things which are missing so `lerna` can be used together with WordPress plugin development.

In WordPress.org description changelog I do not want to show the links to associated GitLab / GitHub issues so I want to disable the option [`linkReferences`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer#linkreferences).

## How Has This Been Tested?
It does not affect other areas of lerna because it is only used in `updatePackageVersions()` and `updateChangelog`. I tested the changes locally on my lerna example repository.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
