### PR TITLE
Adds "--no-git-tag" and "--no-git-commit" version options

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -57,6 +57,8 @@ Running `lerna version --conventional-commits` without the above flags will rele
 - [`--message`](#--message-msg)
 - [`--no-changelog`](#--no-changelog)
 - [`--no-commit-hooks`](#--no-commit-hooks)
+- [`--no-git-tag`](#--no-git-tag)
+- [`--no-git-commit`](#--no-git-commit)
 - [`--no-git-tag-version`](#--no-git-tag-version)
 - [`--no-push`](#--no-push)
 - [`--preid`](#--preid)
@@ -302,6 +304,18 @@ By default, `lerna version` will allow git commit hooks to run when committing v
 Pass `--no-commit-hooks` to disable this behavior.
 
 This option is analogous to the `npm version` option [`--commit-hooks`](https://docs.npmjs.com/misc/config#commit-hooks), just inverted.
+
+### `--no-git-tag`
+
+By default, `lerna version` will tag the release in Git. Pass `--no-git-tag` to disable the tagging.
+
+> Note that this preserves the release commit.
+
+### `--no-git-commit`
+
+By default, `lerna version` will create a release commit in Git. Pass `--no-git-commit` to disable the commit.
+
+> Note that this preserves tagging the release.
 
 ### `--no-git-tag-version`
 

--- a/commands/version/__tests__/version-no-git-commit.test.js
+++ b/commands/version/__tests__/version-no-git-commit.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+jest.mock("../lib/git-push");
+jest.mock("../lib/is-anything-committed");
+jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
+
+const path = require("path");
+
+// helpers
+const loggingOutput = require("@lerna-test/logging-output");
+const initFixture = require("@lerna-test/init-fixture")(path.resolve(__dirname, "../../publish/__tests__"));
+const showCommit = require("@lerna-test/show-commit");
+
+// test command
+const lernaVersion = require("@lerna-test/command-runner")(require("../command"));
+
+describe("--no-git-commit", () => {
+  it("does not create a git commit", async () => {
+    const testDir = await initFixture("normal");
+    await lernaVersion(testDir)("--no-git-commit");
+
+    const logMessages = loggingOutput("info");
+    expect(logMessages).toContain("Skipping commit");
+
+    const commit = await showCommit(testDir);
+    expect(commit).not.toBe("v1.0.1");
+  });
+
+  it("tags the release", async () => {
+    const testDir = await initFixture("normal");
+    await lernaVersion(testDir)("--no-git-commit");
+
+    const logMessages = loggingOutput("info");
+    expect(logMessages).not.toContain("Skipping tag");
+
+    const commit = await showCommit(testDir);
+    expect(commit).toContain("tag:");
+  });
+});

--- a/commands/version/__tests__/version-no-git-tag.test.js
+++ b/commands/version/__tests__/version-no-git-tag.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+jest.mock("../lib/git-push");
+jest.mock("../lib/is-anything-committed");
+jest.mock("../lib/is-behind-upstream");
+jest.mock("../lib/remote-branch-exists");
+
+const path = require("path");
+
+// helpers
+const loggingOutput = require("@lerna-test/logging-output");
+const initFixture = require("@lerna-test/init-fixture")(path.resolve(__dirname, "../../publish/__tests__"));
+const getCommitMessage = require("@lerna-test/get-commit-message");
+
+// test command
+const lernaVersion = require("@lerna-test/command-runner")(require("../command"));
+
+describe("--no-git-tag", () => {
+  it("does not create a git tag", async () => {
+    const testDir = await initFixture("normal");
+    await lernaVersion(testDir)("--no-git-tag");
+
+    const logMessages = loggingOutput("info");
+    expect(logMessages).toContain("Skipping tags");
+
+    const commit = await getCommitMessage(testDir);
+    expect(commit).not.toContain("tag:");
+  });
+
+  it("creates a release commit", async () => {
+    const testDir = await initFixture("normal");
+    await lernaVersion(testDir)("--no-git-tag");
+
+    const logMessages = loggingOutput("info");
+    expect(logMessages).not.toContain("Skipping commit");
+
+    const commit = await getCommitMessage(testDir);
+    expect(commit).toBe("v1.0.1");
+  });
+});

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -100,6 +100,26 @@ exports.builder = (yargs, composed) => {
       describe: "Do not commit or tag version changes.",
       type: "boolean",
     },
+    "no-git-tag": {
+      describe: "Do not tag the version changes",
+      type: "boolean",
+    },
+    "git-tag": {
+      // proxy for --no-git-tag
+      hidden: true,
+      type: "boolean",
+      default: true,
+    },
+    "no-git-commit": {
+      describe: "Do not commit the version changes",
+      type: "boolean",
+    },
+    "git-commit": {
+      // proxy for --no-git-commit
+      hidden: true,
+      type: "boolean",
+      default: true,
+    },
     "git-tag-version": {
       // proxy for --no-git-tag-version
       hidden: true,

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -254,10 +254,16 @@ class VersionCommand extends Command {
   execute() {
     const tasks = [() => this.updatePackageVersions()];
 
-    if (this.commitAndTag) {
+    if (this.options.gitTag || this.options.gitCommit) {
       tasks.push(() => this.commitAndTagUpdates());
-    } else {
-      this.logger.info("execute", "Skipping git tag/commit");
+    }
+
+    if (!this.options.gitTag) {
+      this.logger.info("execute", "Skipping tags");
+    }
+
+    if (!this.options.gitCommit) {
+      this.logger.info("execute", "Skipping commit");
     }
 
     if (this.pushToRemote) {
@@ -277,14 +283,6 @@ class VersionCommand extends Command {
       );
     } else {
       this.logger.info("execute", "Skipping releases");
-    }
-
-    if (!this.options.gitTags) {
-      this.logger.info("execute", "Skipping tags");
-    }
-
-    if (!this.options.gitCommit) {
-      this.logger.info("execute", "Skipping commit");
     }
 
     return pWaterfall(tasks).then(() => {
@@ -606,7 +604,7 @@ class VersionCommand extends Command {
       chain = chain.then(() => this.runRootLifecycle("version"));
     }
 
-    if (this.commitAndTag) {
+    if (this.options.gitCommit) {
       chain = chain.then(() => gitAdd(Array.from(changedFiles), this.execOpts));
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This pull request allows to granularly control the tagging and committing steps during the `lerna version` command.

- Closes https://github.com/lerna/lerna/issues/2067

## Description
<!--- Describe your changes in detail -->

This pull request introduces two new options to the `lerna version` command:

- `--no-git-tag` - when provided, skips the tagging of the release;
- `--no-git-commit` - when provided, skips the release commit.

> Internally, `this.commitAndTag` value is rewritten to align with these two newly introduced options.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Our Git workflow requires each release to have a dedicated Pull request and be reviewed before landing in `master`. This implies that the release process is split into two steps:

1. Release pull request. Contains a release commit **without tags**.
1. Tagging on master, after the release pull request is merged.

With the current implementation of `lerna version` it's possible to either:

1. commit + tag (default).
1. Skip both commit and tag.

The flow described above would require to preserve the git commit, but skip tagging, as tags are set once the release pull request is merged into `master`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Please see the added integration tests (c02f9130ae58b3102e7ce6a209de8f5a3dc7e5b7).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
