### PR TITLE
fix(collect-dependents): Avoid skipping dependents of cyclic dependencies

### DIFF
--- a/__fixtures__/toposort/packages/package-cycle-extraneous-1/package.json
+++ b/__fixtures__/toposort/packages/package-cycle-extraneous-1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "package-cycle-extraneous",
+  "name": "package-cycle-extraneous-1",
   "version": "1.0.0",
   "comment": "This package is used to break ties between package-cycle-{1,2}.",
   "dependencies": {

--- a/__fixtures__/toposort/packages/package-cycle-extraneous-2/package.json
+++ b/__fixtures__/toposort/packages/package-cycle-extraneous-2/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-cycle-extraneous-2",
+  "version": "1.0.0",
+  "comment": "This package is used to break ties between package-cycle-{1,2}.",
+  "dependencies": {
+    "package-cycle-1": "1.0.0",
+    "package-cycle-2": "1.0.0"
+  }
+}

--- a/commands/exec/__tests__/exec-command.test.js
+++ b/commands/exec/__tests__/exec-command.test.js
@@ -200,7 +200,8 @@ describe("ExecCommand", () => {
       expect(calledInPackages()).toEqual([
         "package-cycle-1",
         "package-cycle-2",
-        "package-cycle-extraneous",
+        "package-cycle-extraneous-1",
+        "package-cycle-extraneous-2",
         "package-dag-1",
         "package-dag-2a",
         "package-dag-2b",
@@ -228,7 +229,8 @@ describe("ExecCommand", () => {
         "package-cycle-1",
         "package-cycle-2",
         "package-dag-3",
-        "package-cycle-extraneous",
+        "package-cycle-extraneous-1",
+        "package-cycle-extraneous-2",
       ]);
     });
 

--- a/commands/run/__tests__/run-command.test.js
+++ b/commands/run/__tests__/run-command.test.js
@@ -170,7 +170,8 @@ describe("RunCommand", () => {
       expect(output.logged().split("\n")).toEqual([
         "package-cycle-1",
         "package-cycle-2",
-        "package-cycle-extraneous",
+        "package-cycle-extraneous-1",
+        "package-cycle-extraneous-2",
         "package-dag-1",
         "package-dag-2a",
         "package-dag-2b",
@@ -188,7 +189,8 @@ describe("RunCommand", () => {
         Array [
           "packages/package-cycle-1 npm run env (prefixed: true)",
           "packages/package-cycle-2 npm run env (prefixed: true)",
-          "packages/package-cycle-extraneous npm run env (prefixed: true)",
+          "packages/package-cycle-extraneous-1 npm run env (prefixed: true)",
+          "packages/package-cycle-extraneous-2 npm run env (prefixed: true)",
           "packages/package-dag-1 npm run env (prefixed: true)",
           "packages/package-dag-2a npm run env (prefixed: true)",
           "packages/package-dag-2b npm run env (prefixed: true)",
@@ -217,7 +219,8 @@ describe("RunCommand", () => {
         "package-cycle-1",
         "package-cycle-2",
         "package-dag-3",
-        "package-cycle-extraneous",
+        "package-cycle-extraneous-1",
+        "package-cycle-extraneous-2",
       ]);
     });
 

--- a/utils/collect-updates/__helpers__/build-graph.js
+++ b/utils/collect-updates/__helpers__/build-graph.js
@@ -24,11 +24,20 @@ function buildGraph(mapPackages = pkg => pkg) {
       },
     },
     {
-      name: "package-cycle-extraneous",
+      name: "package-cycle-extraneous-1",
       version: "1.0.0",
       description: "This package is used to break ties between package-cycle-{1,2}.",
       dependencies: {
         "package-cycle-1": "1.0.0",
+      },
+    },
+    {
+      name: "package-cycle-extraneous-2",
+      version: "1.0.0",
+      description: "This package is used to break ties between package-cycle-{1,2}.",
+      dependencies: {
+        "package-cycle-1": "1.0.0",
+        "package-cycle-2": "1.0.0",
       },
     },
     {

--- a/utils/collect-updates/__tests__/collect-updates.test.js
+++ b/utils/collect-updates/__tests__/collect-updates.test.js
@@ -40,7 +40,8 @@ makeDiffPredicate.mockImplementation(() => hasDiff);
 const ALL_NODES = Object.freeze([
   expect.objectContaining({ name: "package-cycle-1" }),
   expect.objectContaining({ name: "package-cycle-2" }),
-  expect.objectContaining({ name: "package-cycle-extraneous" }),
+  expect.objectContaining({ name: "package-cycle-extraneous-1" }),
+  expect.objectContaining({ name: "package-cycle-extraneous-2" }),
   expect.objectContaining({ name: "package-dag-1" }),
   expect.objectContaining({ name: "package-dag-2a" }),
   expect.objectContaining({ name: "package-dag-2b" }),

--- a/utils/collect-updates/__tests__/lib-collect-dependents.test.js
+++ b/utils/collect-updates/__tests__/lib-collect-dependents.test.js
@@ -16,8 +16,8 @@ test("source node (dag)", () => {
 
   expect(Array.from(result)).toEqual([
     expect.objectContaining({ name: "package-dag-2a" }),
-    expect.objectContaining({ name: "package-dag-3" }),
     expect.objectContaining({ name: "package-dag-2b" }),
+    expect.objectContaining({ name: "package-dag-3" }),
   ]);
 });
 
@@ -53,7 +53,8 @@ test("source node (cycle)", () => {
 
   expect(Array.from(result)).toEqual([
     expect.objectContaining({ name: "package-cycle-2" }),
-    expect.objectContaining({ name: "package-cycle-extraneous" }),
+    expect.objectContaining({ name: "package-cycle-extraneous-1" }),
+    expect.objectContaining({ name: "package-cycle-extraneous-2" }),
   ]);
 });
 
@@ -65,5 +66,9 @@ test("internal node (cycle)", () => {
 
   const result = collectDependents(candidates);
 
-  expect(Array.from(result)).toEqual([expect.objectContaining({ name: "package-cycle-1" })]);
+  expect(Array.from(result)).toEqual([
+    expect.objectContaining({ name: "package-cycle-1" }),
+    expect.objectContaining({ name: "package-cycle-extraneous-2" }),
+    // package-cycle-extraneous-1 was ignored
+  ]);
 });

--- a/utils/collect-updates/__tests__/lib-collect-packages.test.js
+++ b/utils/collect-updates/__tests__/lib-collect-packages.test.js
@@ -16,7 +16,8 @@ test("returns all packages", () => {
 Array [
   "package-cycle-1",
   "package-cycle-2",
-  "package-cycle-extraneous",
+  "package-cycle-extraneous-1",
+  "package-cycle-extraneous-2",
   "package-dag-1",
   "package-dag-2a",
   "package-dag-2b",
@@ -38,7 +39,8 @@ test("filters packages through isCandidate, passing node and name", () => {
 Array [
   "package-cycle-1",
   "package-cycle-2",
-  "package-cycle-extraneous",
+  "package-cycle-extraneous-1",
+  "package-cycle-extraneous-2",
 ]
 `);
 });

--- a/utils/collect-updates/lib/collect-dependents.js
+++ b/utils/collect-updates/lib/collect-dependents.js
@@ -11,8 +11,10 @@ function collectDependents(nodes) {
       return;
     }
 
-    // depth-first search
+    // breadth-first search
+    const queue = [currentNode];
     const seen = new Set();
+
     const visit = (dependentNode, dependentName, siblingDependents) => {
       if (seen.has(dependentNode)) {
         return;
@@ -26,11 +28,14 @@ function collectDependents(nodes) {
       }
 
       collected.add(dependentNode);
-
-      dependentNode.localDependents.forEach(visit);
+      queue.push(dependentNode);
     };
 
-    currentNode.localDependents.forEach(visit);
+    while (queue.length) {
+      const node = queue.shift();
+
+      node.localDependents.forEach(visit);
+    }
   });
 
   return collected;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In case of cyclic dependencies, some packages of the modified package are skipped.

## Description

packages:
```
package-cycle-1
  localDependents:
    package-cycle-2
    package-cycle-extraneous-1
    package-cycle-extraneous-2

package-cycle-2
  localDependents:
    package-cycle-1
    package-cycle-extraneous-2
```
Let's say we changed `package-cycle-2` then the following will happen:
1. `package-cycle-2` is current node. Check local dependents of `package-cycle-2`
2. Check `package-cycle-1`
3. Add `package-cycle-1` to changed. Remember that we visit it.
4. Dive to the level below. Check local dependents of `package-cycle-1`
5. Skip `package-cycle-2` because it is current node. Remember that we visit it.
6. Skip `package-cycle-extraneous-1` because local dependents of `package-cycle-1` include `package-cycle-2`. Remember that we visit it.
7. Skip `package-cycle-extraneous-2` because local dependents of `package-cycle-1` include `package-cycle-2`. **Remember that we visit it**.
8. Back to the level above. Check `package-cycle-extraneous-2` and skip because we have visited it.

So, we missed `package-cycle-extraneous-2` and it looks like a bug.

I replaced depth-first search to breadth-first search. Now it works well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
