### PR TITLE
fix(version): pass `--atomic` to `git push`

### DIFF
--- a/commands/version/lib/git-push.js
+++ b/commands/version/lib/git-push.js
@@ -8,5 +8,5 @@ module.exports = gitPush;
 function gitPush(remote, branch, opts) {
   log.silly("gitPush", remote, branch);
 
-  return childProcess.exec("git", ["push", "--follow-tags", "--no-verify", remote, branch], opts);
+  return childProcess.exec("git", ["push", "--follow-tags", "--atomic", "--no-verify", remote, branch], opts);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix #2392

## Description
<!--- Describe your changes in detail -->

Pass `--atomic` to `git push`. See [git's doc](https://git-scm.com/docs/git-push#Documentation/git-push.txt---no-atomic)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As #2392 said.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually.

```
% git push --follow-tags --atomic --no-verify origin master
error: atomic push failed for ref refs/heads/master. status: 2

fatal: the remote end hung up unexpectedly\nTo git.easyops.local:anyclouds/next-libs.git
 ! [rejected]        master -> master (non-fast-forward)
error: failed to push some refs to 'git@git.easyops.local:anyclouds/next-libs.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
