### PR TITLE
WIP: Add automatic scope resolution with --currentScope

### DIFF
--- a/core/filter-options/index.js
+++ b/core/filter-options/index.js
@@ -15,6 +15,11 @@ function filterOptions(yargs) {
       type: "string",
       requiresArg: true,
     },
+    currentScope: {
+      describe: "Include only package in current working directory.",
+      type: "boolean",
+      conflicts: "scope",
+    },
     ignore: {
       describe: "Exclude packages with names matching the given glob.",
       type: "string",

--- a/core/filter-options/lib/get-filtered-packages.js
+++ b/core/filter-options/lib/get-filtered-packages.js
@@ -2,6 +2,7 @@
 
 const npmlog = require("npmlog");
 const figgyPudding = require("figgy-pudding");
+const path = require("path");
 const collectUpdates = require("@lerna/collect-updates");
 const filterPackages = require("@lerna/filter-packages");
 
@@ -9,6 +10,7 @@ module.exports = getFilteredPackages;
 
 const FilterConfig = figgyPudding({
   scope: {},
+  currentScope: {},
   ignore: {},
   private: {},
   since: {},
@@ -25,8 +27,20 @@ const FilterConfig = figgyPudding({
 function getFilteredPackages(packageGraph, execOpts, opts) {
   const options = FilterConfig(opts);
 
+  let scope;
+
   if (options.scope) {
-    options.log.notice("filter", "including %j", options.scope);
+    scope = options.scope;
+  }
+
+  if (options.currentScope) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const { name } = require(path.join(process.cwd(), "package.json"));
+    scope = name;
+  }
+
+  if (scope) {
+    options.log.notice("filter", "including %j", scope);
   }
 
   if (options.ignore) {
@@ -38,7 +52,7 @@ function getFilteredPackages(packageGraph, execOpts, opts) {
   chain = chain.then(() =>
     filterPackages(
       packageGraph.rawPackageList,
-      options.scope,
+      scope,
       options.ignore,
       options.private,
       options.continueIfNoMatch


### PR DESCRIPTION
Add --currentScope filter option. Work in progress - if you find this change desirable I will add necessary tests. 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When adding --currentScope in commands, lerna will use the current working directory package as scope

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running a lerna command for a specific package is common. For example in order to add an npm to a package one will `lerna add --scope={current package name}`. This is quite verbose is foreign to the old fashioned `npm install` in package directory. I suggest adding an option, and in the future maybe even making this a default behavior, to use the current working directory as scope.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TBD

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
