### PR TITLE
docs(version): Alphabetize list of options

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -45,14 +45,14 @@ Running `lerna version --conventional-commits` without the above flags will rele
 
 - [`--allow-branch`](#--allow-branch-glob)
 - [`--amend`](#--amend)
+- [`--changelog-preset`](#--changelog-preset)
 - [`--conventional-commits`](#--conventional-commits)
 - [`--conventional-graduate`](#--conventional-graduate)
 - [`--conventional-prerelease`](#--conventional-prerelease)
-- [`--changelog-preset`](#--changelog-preset)
+- [`--create-release`](#--create-release-type)
 - [`--exact`](#--exact)
 - [`--force-publish`](#--force-publish)
 - [`--git-remote`](#--git-remote-name)
-- [`--create-release`](#--create-release-type)
 - [`--ignore-changes`](#--ignore-changes)
 - [`--ignore-scripts`](#--ignore-scripts)
 - [`--include-merged-tags`](#--include-merged-tags)
@@ -64,8 +64,8 @@ Running `lerna version --conventional-commits` without the above flags will rele
 - [`--preid`](#--preid)
 - [`--sign-git-commit`](#--sign-git-commit)
 - [`--sign-git-tag`](#--sign-git-tag)
-- [`--yes`](#--yes)
 - [`--tag-version-prefix`](#--tag-version-prefix)
+- [`--yes`](#--yes)
 
 ### `--allow-branch <glob>`
 
@@ -117,6 +117,19 @@ This is useful during [Continuous integration (CI)](https://en.wikipedia.org/wik
 
 In order to prevent unintended overwrites, this command will skip `git push` (i.e., it implies `--no-push`).
 
+### `--changelog-preset`
+
+```sh
+lerna version --conventional-commits --changelog-preset angular-bitbucket
+```
+
+By default, the changelog preset is set to [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#angular-convention).
+In some cases you might want to change either use a another preset or a custom one.
+
+Presets are names of built-in or installable configuration for conventional changelog.
+Presets may be passed as the full name of the package, or the auto-expanded suffix
+(e.g., `angular` is expanded to `conventional-changelog-angular`).
+
 ### `--conventional-commits`
 
 ```sh
@@ -153,18 +166,27 @@ lerna version --conventional-commits --conventional-prerelease
 
 When run with this flag, `lerna version` will release with prerelease versions the specified packages (comma-separated) or all packages using `*`. Releases all unreleased changes as pre(patch/minor/major/release) by prefixing the version recommendation from `conventional-commits` with `pre`, eg. if present changes include a feature commit, the recommended bump will be `minor`, so this flag will result in a `preminor` release. If changes are present for packages that are not specified (if specifying packages), or for packages that are already in prerelease, those packages will be versioned as they normally would using `--conventional-commits`.
 
-### `--changelog-preset`
+### `--create-release <type>`
 
 ```sh
-lerna version --conventional-commits --changelog-preset angular-bitbucket
+lerna version --conventional-commits --create-release github
+lerna version --conventional-commits --create-release gitlab
 ```
 
-By default, the changelog preset is set to [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#angular-convention).
-In some cases you might want to change either use a another preset or a custom one.
+When run with this flag, `lerna version` will create an official GitHub or GitLab release based on the changed packages. Requires `--conventional-commits` to be passed so that changelogs can be generated.
 
-Presets are names of built-in or installable configuration for conventional changelog.
-Presets may be passed as the full name of the package, or the auto-expanded suffix
-(e.g., `angular` is expanded to `conventional-changelog-angular`).
+To authenticate with GitHub, the following environment variables can be defined.
+
+- `GH_TOKEN` (required) - Your GitHub authentication token (under Settings > Developer settings > Personal access tokens).
+- `GHE_API_URL` - When using GitHub Enterprise, an absolute URL to the API.
+- `GHE_VERSION` - When using GitHub Enterprise, the currently installed GHE version. [Supports the following versions](https://github.com/octokit/plugin-enterprise-rest.js).
+
+To authenticate with GitLab, the following environment variables can be defined.
+
+- `GL_TOKEN` (required) - Your GitLab authentication token (under User Settings > Access Tokens).
+- `GL_API_URL` - An absolute URL to the API, including the version. (Default: https://gitlab.com/api/v4)
+
+> NOTE: When using this option, you cannot pass [`--no-changelog`](#--no-changelog).
 
 ### `--exact`
 
@@ -196,28 +218,6 @@ lerna version --git-remote upstream
 ```
 
 When run with this flag, `lerna version` will push the git changes to the specified remote instead of `origin`.
-
-### `--create-release <type>`
-
-```sh
-lerna version --conventional-commits --create-release github
-lerna version --conventional-commits --create-release gitlab
-```
-
-When run with this flag, `lerna version` will create an official GitHub or GitLab release based on the changed packages. Requires `--conventional-commits` to be passed so that changelogs can be generated.
-
-To authenticate with GitHub, the following environment variables can be defined.
-
-- `GH_TOKEN` (required) - Your GitHub authentication token (under Settings > Developer settings > Personal access tokens).
-- `GHE_API_URL` - When using GitHub Enterprise, an absolute URL to the API.
-- `GHE_VERSION` - When using GitHub Enterprise, the currently installed GHE version. [Supports the following versions](https://github.com/octokit/plugin-enterprise-rest.js).
-
-To authenticate with GitLab, the following environment variables can be defined.
-
-- `GL_TOKEN` (required) - Your GitLab authentication token (under User Settings > Access Tokens).
-- `GL_API_URL` - An absolute URL to the API, including the version. (Default: https://gitlab.com/api/v4)
-
-> NOTE: When using this option, you cannot pass [`--no-changelog`](#--no-changelog).
 
 ### `--ignore-changes`
 
@@ -345,16 +345,6 @@ This option is analogous to the `npm version` [option](https://docs.npmjs.com/mi
 
 This option is analogous to the `npm version` [option](https://docs.npmjs.com/misc/config#sign-git-tag) of the same name.
 
-### `--yes`
-
-```sh
-lerna version --yes
-# skips `Are you sure you want to publish these packages?`
-```
-
-When run with this flag, `lerna version` will skip all confirmation prompts.
-Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous_integration) to automatically answer the publish confirmation prompt.
-
 ### `--tag-version-prefix`
 
 This option allows to provide custom prefix instead of the default one: `v`.
@@ -367,6 +357,16 @@ lerna version --tag-version-prefix=''
 # on ci
 lerna publish from-git --tag-version-prefix=''
 ```
+
+### `--yes`
+
+```sh
+lerna version --yes
+# skips `Are you sure you want to publish these packages?`
+```
+
+When run with this flag, `lerna version` will skip all confirmation prompts.
+Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous_integration) to automatically answer the publish confirmation prompt.
 
 ## Deprecated Options
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- I was looking for `--create-release` option and thought it was odd that the list of options in this README is _almost_ alphabetized.
- Looks like it started out in alphabetical order in but went out of order at some point. 

## Motivation and Context
- Was confused for a few seconds because I didn't see `--create-release` and `--yes` options where I expected them to be. 
- Hopefully this shaves off a few seconds of people who read this README.

## How Has This Been Tested?
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
