### PR TITLE
fix(import): Support non-ASCII characters in file paths

### DIFF
--- a/commands/import/__tests__/__fixtures__/files-with-non-ascii-char/package.json
+++ b/commands/import/__tests__/__fixtures__/files-with-non-ascii-char/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "files-with-non-ascii-char"
+}

--- a/commands/import/__tests__/__fixtures__/files-with-non-ascii-char/檔案
+++ b/commands/import/__tests__/__fixtures__/files-with-non-ascii-char/檔案
@@ -1,0 +1,1 @@
+content

--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -189,11 +189,11 @@ class ImportCommand extends Command {
     // to all affected files.  This moves the git history for the entire
     // external repository into the package subdirectory, commit by commit.
     return patch
-      .replace(/^([-+]{3} COMPARE_[AB])/gm, replacement)
-      .replace(/^(diff --git COMPARE_A)/gm, replacement)
-      .replace(/^(diff --git (?! COMPARE_B\/).+ COMPARE_B)/gm, replacement)
-      .replace(/^(copy (from|to)) /gm, `$1 ${formattedTarget}/`)
-      .replace(/^(rename (from|to)) /gm, `$1 ${formattedTarget}/`);
+      .replace(/^([-+]{3} "?COMPARE_[AB])/gm, replacement)
+      .replace(/^(diff --git "?COMPARE_A)/gm, replacement)
+      .replace(/^(diff --git (?! "?COMPARE_B\/).+ "?COMPARE_B)/gm, replacement)
+      .replace(/^(copy (from|to)) ("?)/gm, `$1 $3${formattedTarget}/`)
+      .replace(/^(rename (from|to)) ("?)/gm, `$1 $3${formattedTarget}/`);
   }
 
   getGitUserFromSha(sha) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When importing, if any file path contain non-ascii char like Chinese, it will occur an error.

```
ValidationError: Failed to apply commit f60aec4.
    Command failed: git am -3 --keep-non-patch
    error: mode change for packages/91b633aa89e0fab2957cc60ec58fe8c5/"\346\252\224\346\241\210", which is not in current HEAD
    error: could not build fake ancestor
    Applying: rename
    Patch failed at 0001 rename
    Use 'git am --show-current-patch' to see the failed patch
    When you have resolved this problem, run "git am --continue".
    If you prefer to skip this patch, run "git am --skip" instead.
    To restore the original branch and stop patching, run "git am --abort".
```

Because git will wrap non-ascii file path by `"`, the path replacement does not handle this.

## Motivation and Context

Fix by checking `"` in regular expression in replacement.

## How Has This Been Tested?

Add a unit test.
The test include git file add, rename and copy action.
I think it cover all regexp.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
