### PR TITLE
feat: Support the `workspace:` protocol

### DIFF
--- a/commands/link/__tests__/__fixtures__/explicit-local/lerna.json
+++ b/commands/link/__tests__/__fixtures__/explicit-local/lerna.json
@@ -1,0 +1,8 @@
+{
+  "commands": {
+    "link": {
+      "localDependencies": "explicit"
+    }
+  },
+  "version": "1.0.0"
+}

--- a/commands/link/__tests__/__fixtures__/explicit-local/package.json
+++ b/commands/link/__tests__/__fixtures__/explicit-local/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/commands/link/__tests__/__fixtures__/explicit-local/packages/package-1/package.json
+++ b/commands/link/__tests__/__fixtures__/explicit-local/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/package-1",
+  "version": "1.0.0"
+}

--- a/commands/link/__tests__/__fixtures__/explicit-local/packages/package-2/package.json
+++ b/commands/link/__tests__/__fixtures__/explicit-local/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/package-1": "workspace:1.0.0"
+  }
+}

--- a/commands/link/__tests__/__fixtures__/explicit-local/packages/package-3/package.json
+++ b/commands/link/__tests__/__fixtures__/explicit-local/packages/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@test/package-1": "1.0.0"
+  }
+}

--- a/commands/link/__tests__/link-command.test.js
+++ b/commands/link/__tests__/link-command.test.js
@@ -186,6 +186,23 @@ Array [
     });
   });
 
+  describe("with --local-dependencies explicit", () => {
+    it("should only symlink packages with the workspace: protocol", async () => {
+      const testDir = await initFixture("explicit-local");
+      await lernaLink(testDir)();
+
+      expect(symlinkedDirectories(testDir)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "_src": "packages/package-1",
+            "dest": "packages/package-2/node_modules/@test/package-1",
+            "type": "junction",
+          },
+        ]
+      `);
+    });
+  });
+
   describe("with --contents", () => {
     it("should symlink sub-directory of package folders and bin directories", async () => {
       const testDir = await initFixture("with-contents");

--- a/commands/link/index.js
+++ b/commands/link/index.js
@@ -28,9 +28,15 @@ class LinkCommand extends Command {
       }
     }
 
-    this.targetGraph = this.options.forceLocal
-      ? new PackageGraph(this.allPackages, "allDependencies", "forceLocal")
-      : this.packageGraph;
+    let { localDependencies } = this.options;
+    if (!localDependencies && this.options.forceLocal) {
+      localDependencies = "force";
+    }
+
+    this.targetGraph =
+      localDependencies === "force" || localDependencies === "explicit"
+        ? new PackageGraph(this.allPackages, "allDependencies", localDependencies)
+        : this.packageGraph;
   }
 
   execute() {

--- a/core/package-graph/__tests__/package-graph.test.js
+++ b/core/package-graph/__tests__/package-graph.test.js
@@ -92,6 +92,46 @@ describe("PackageGraph", () => {
       expect(pkg1.localDependents.has("pkg-2")).toBe(true);
       expect(pkg2.localDependencies.has("pkg-1")).toBe(true);
     });
+
+    it("only localizes workspace: siblings when it must be explicit", () => {
+      const pkgs = [
+        new Package(
+          {
+            name: "pkg-1",
+            version: "1.0.0",
+          },
+          "/test/pkg-1"
+        ),
+        new Package(
+          {
+            name: "pkg-2",
+            version: "1.0.0",
+            dependencies: {
+              "pkg-1": "^1.0.0",
+            },
+          },
+          "/test/pkg-2"
+        ),
+        new Package(
+          {
+            name: "pkg-3",
+            version: "1.0.0",
+            dependencies: {
+              "pkg-1": "workspace:^1.0.0",
+            },
+          },
+          "/test/pkg-3"
+        ),
+      ];
+
+      const graph = new PackageGraph(pkgs, "allDependencies", "explicit");
+      const [pkg1, pkg2, pkg3] = graph.values();
+
+      expect(pkg1.localDependents.has("pkg-2")).toBe(false);
+      expect(pkg2.localDependencies.has("pkg-1")).toBe(false);
+      expect(pkg1.localDependents.has("pkg-3")).toBe(true);
+      expect(pkg3.localDependencies.has("pkg-1")).toBe(true);
+    });
   });
 
   describe("Node", () => {

--- a/core/package-graph/index.js
+++ b/core/package-graph/index.js
@@ -13,11 +13,19 @@ const { reportCycles } = require("./lib/report-cycles");
  * @param {String} graphType ("allDependencies" or "dependencies")
  *    Pass "dependencies" to create a graph of only dependencies,
  *    excluding the devDependencies that would normally be included.
- * @param {Boolean} forceLocal Force all local dependencies to be linked.
  * @param {String} localDependencies Force all local dependencies to be linked.
  */
 class PackageGraph extends Map {
-  constructor(packages, graphType = "allDependencies", forceLocal) {
+  constructor(
+    packages,
+    graphType = "allDependencies",
+    localDependencies = "auto" // | "force" | "explicit"
+  ) {
+    // For backward compatibility
+    if (localDependencies === true || localDependencies === "forceLocal") {
+      localDependencies = "force"; // eslint-disable-line
+    }
+
     super(packages.map(pkg => [pkg.name, new PackageGraphNode(pkg)]));
 
     if (packages.length !== this.size) {
@@ -75,8 +83,13 @@ class PackageGraph extends Map {
           return currentNode.externalDependencies.set(depName, resolved);
         }
 
-        if (forceLocal || resolved.fetchSpec === depNode.location || depNode.satisfies(resolved)) {
-          // a local file: specifier OR a matching semver
+        if (
+          explicitWorkspace ||
+          localDependencies === "force" ||
+          resolved.fetchSpec === depNode.location ||
+          (localDependencies !== "explicit" && depNode.satisfies(resolved))
+        ) {
+          // a local file: specifier, a matching semver or a workspace: version
           currentNode.localDependencies.set(depName, resolved);
           depNode.localDependents.set(currentName, currentNode);
         } else {

--- a/core/package-graph/index.js
+++ b/core/package-graph/index.js
@@ -14,6 +14,7 @@ const { reportCycles } = require("./lib/report-cycles");
  *    Pass "dependencies" to create a graph of only dependencies,
  *    excluding the devDependencies that would normally be included.
  * @param {Boolean} forceLocal Force all local dependencies to be linked.
+ * @param {String} localDependencies Force all local dependencies to be linked.
  */
 class PackageGraph extends Map {
   constructor(packages, graphType = "allDependencies", forceLocal) {
@@ -57,8 +58,17 @@ class PackageGraph extends Map {
         // Yarn decided to ignore https://github.com/npm/npm/pull/15900 and implemented "link:"
         // As they apparently have no intention of being compatible, we have to do it for them.
         // @see https://github.com/yarnpkg/yarn/issues/4212
-        const spec = graphDependencies[depName].replace(/^link:/, "file:");
+        let spec = graphDependencies[depName].replace(/^link:/, "file:");
+
+        // npa doesn't support the explicit workspace: protocol, supported by
+        // pnpm and Yarn.
+        const explicitWorkspace = /^workspace:/.test(spec);
+        if (explicitWorkspace) {
+          spec = spec.replace(/^workspace:/, "");
+        }
+
         const resolved = npa.resolve(depName, spec, currentNode.location);
+        resolved.explicitWorkspace = explicitWorkspace;
 
         if (!depNode) {
           // it's an external dependency, store the resolution and bail

--- a/core/package/__tests__/core-package.test.js
+++ b/core/package/__tests__/core-package.test.js
@@ -7,6 +7,7 @@ const os = require("os");
 const path = require("path");
 const loadJsonFile = require("load-json-file");
 const writePkg = require("write-pkg");
+const npa = require("npm-package-arg");
 
 // file under test
 const Package = require("..");
@@ -271,6 +272,37 @@ describe("Package", () => {
           woo: "hoo",
         })
       );
+    });
+  });
+
+  describe(".updateLocalDependency()", () => {
+    it("works with workspace: protocols", () => {
+      const pkg = factory({
+        dependencies: {
+          a: "workspace:^1.0.0",
+          b: "workspace:^1.0.0",
+          c: "workspace:./foo",
+          d: "file:./foo",
+          e: "^1.0.0",
+        },
+      });
+
+      const resolved = npa.resolve("a", "^1.0.0", ".");
+      resolved.explicitWorkspace = true;
+
+      pkg.updateLocalDependency(resolved, "2.0.0", "^");
+
+      expect(pkg.toJSON()).toMatchInlineSnapshot(`
+        Object {
+          "dependencies": Object {
+            "a": "workspace:^2.0.0",
+            "b": "workspace:^1.0.0",
+            "c": "workspace:./foo",
+            "d": "file:./foo",
+            "e": "^1.0.0",
+          },
+        }
+      `);
     });
   });
 });

--- a/core/package/index.js
+++ b/core/package/index.js
@@ -209,6 +209,9 @@ class Package {
     if (resolved.registry || resolved.type === "directory") {
       // a version (1.2.3) OR range (^1.2.3) OR directory (file:../foo-pkg)
       depCollection[depName] = `${savePrefix}${depVersion}`;
+      if (resolved.explicitWorkspace) {
+        depCollection[depName] = `workspace:${depCollection[depName]}`;
+      }
     } else if (resolved.gitCommittish) {
       // a git url with matching committish (#v1.2.3 or #1.2.3)
       const [tagPrefix] = /^\D*/.exec(resolved.gitCommittish);

--- a/utils/query-graph/query-graph.js
+++ b/utils/query-graph/query-graph.js
@@ -8,6 +8,8 @@ const QueryGraphConfig = figgyPudding({
   graphType: "graph-type",
   "reject-cycles": {},
   rejectCycles: "reject-cycles",
+  "local-dependencies": {},
+  localDependencies: "local-dependencies",
 });
 
 class QueryGraph {
@@ -16,6 +18,7 @@ class QueryGraph {
    *
    * @param {Array<Package>} packages An array of Packages to build the graph out of
    * @param {String} [opts.graphType="allDependencies"] "dependencies" excludes devDependencies from graph
+   * @param {String} [opts.localDependencies="auto"] Valid values are "force" or "explicit"
    * @param {Boolean} [opts.rejectCycles] Whether or not to reject cycles
    * @constructor
    */
@@ -23,7 +26,7 @@ class QueryGraph {
     const options = QueryGraphConfig(opts);
 
     // Create dependency graph
-    this.graph = new PackageGraph(packages, options.graphType);
+    this.graph = new PackageGraph(packages, options.graphType, options.localDependencies);
 
     // Evaluate cycles
     this.cycles = this.graph.collapseCycles(options.rejectCycles);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Yarn 2 and pnpm (I know that it isn't supported, but saw that you are working on it) support the `workspace:` protocol for monorepo package versions.

When used, it explicitly marks a dependency to assert that it is never downloaded from the registry. Both the package managers allow making the `workspace:` protocol required: if it isn't specified, then the dependency is downloaded from the registry even if a local package would match the requested version.
[yarn docs](https://yarnpkg.com/features/workspaces#workspace-ranges-workspace), [pnpm docs](https://pnpm.js.org/en/workspaces#workspace-ranges-workspace).

This PR contains two different commits: the first one makes lerna not fail when someone uses the `workspace` protocol (which is what made me open this PR).

The second one implements a `--local-dependencies` option which makes `lerna` actually use the `workspace` protocol. I'm not sure that this is needed since people would probably directly enable the `useWorkspaces` option and delegate this task to yarn, but I added the commit just in case you could be interested in it. I would have no problems with dropping it.

Please don't review them as a single unit :pray:

## Motivation and Context

I didn't open an issue about it, but this is currently blocking Babel from upgrading to yarn 2 (https://github.com/babel/babel/pull/11142).

## How Has This Been Tested?

I added tests to the affected packages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (I will do it depending on what gets accepted)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
