### PR TITLE
fix(deps): upgrade octokit/enterprise-rest to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1000,7 +1000,7 @@
       "version": "file:utils/github-client",
       "requires": {
         "@lerna/child-process": "file:core/child-process",
-        "@octokit/plugin-enterprise-rest": "^3.6.1",
+        "@octokit/plugin-enterprise-rest": "^6.0.1",
         "@octokit/rest": "^16.28.4",
         "git-url-parse": "^11.1.2",
         "npmlog": "^4.1.2"
@@ -1429,9 +1429,9 @@
       }
     },
     "@octokit/plugin-enterprise-rest": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-3.6.2.tgz",
-      "integrity": "sha512-3wF5eueS5OHQYuAEudkpN+xVeUsg8vYEMMenEzLphUZ7PRZ8OJtDcsreL3ad9zxXmBbaFWzLmFcdob5CLyZftA=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz",
+      "integrity": "sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw=="
     },
     "@octokit/request": {
       "version": "5.3.1",

--- a/utils/github-client/__tests__/github-client.test.js
+++ b/utils/github-client/__tests__/github-client.test.js
@@ -32,7 +32,7 @@ describe("createGitHubClient", () => {
 
   it("initializes GHE plugin when GHE_VERSION env var is set", () => {
     process.env.GH_TOKEN = "TOKEN";
-    process.env.GHE_VERSION = "2.14";
+    process.env.GHE_VERSION = "2.18";
 
     createGitHubClient();
 

--- a/utils/github-client/package.json
+++ b/utils/github-client/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lerna/child-process": "file:../../core/child-process",
-    "@octokit/plugin-enterprise-rest": "^3.6.1",
+    "@octokit/plugin-enterprise-rest": "^6.0.1",
     "@octokit/rest": "^16.28.4",
     "git-url-parse": "^11.1.2",
     "npmlog": "^4.1.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change upgrades the octokit/enterprise-rest plugin to v6

## Motivation and Context
Currently, Lerna is using v3 of the plugin and that doesn't support Github enterprise 2.18

## How Has This Been Tested?
Updated test to use GHE_VERSION 2.18

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
