### PR TITLE
fix(version): --atomic fallback when GIT_REDIRECT_STDERR is enabled

### DIFF
--- a/commands/version/lib/git-push.js
+++ b/commands/version/lib/git-push.js
@@ -12,12 +12,16 @@ function gitPush(remote, branch, opts) {
     .exec("git", ["push", "--follow-tags", "--no-verify", "--atomic", remote, branch], opts)
     .catch(error => {
       // @see https://github.com/sindresorhus/execa/blob/v1.0.0/index.js#L159-L179
-      // the error message _should_ be on stderr, and I don't care if Windows does it wrong
-      if (/atomic/.test(error.stderr)) {
+      // the error message _should_ be on stderr except when GIT_REDIRECT_STDERR has been configured to redirect
+      // to stdout. More details in https://git-scm.com/docs/git#Documentation/git.txt-codeGITREDIRECTSTDERRcode
+      if (
+        /atomic/.test(error.stderr) ||
+        (process.env.GIT_REDIRECT_STDERR === "2>&1" && /atomic/.test(error.stdout))
+      ) {
         // --atomic is only supported in git >=2.4.0, which some crusty CI environments deem unnecessary to upgrade.
         // so let's try again without attempting to pass an option that is almost 5 years old as of this writing...
-        log.warn("gitPush", "--atomic failed, attempting non-atomic push");
         log.warn("gitPush", error.stderr);
+        log.info("gitPush", "--atomic failed, attempting non-atomic push");
 
         return childProcess.exec("git", ["push", "--follow-tags", "--no-verify", remote, branch], opts);
       }


### PR DESCRIPTION
## Description

Lerna --atomic fallback now checks if the environment variable GIT_REDIRECT_STDERR has been configured. This configuration is necessary to handle a questionable Windows Server 2019 behavior. More details [here](https://github.com/lerna/lerna/pull/2393#issuecomment-589444164)

## Motivation and Context

This change is necessary to support Azure Pipelines on Windows Server 2019.

## How Has This Been Tested?

* Unit testing.
* Using a modified lerna version in an Azure Pipeline.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
