### PR TITLE
fix(create-symlink): Replace @zkochan/cmd-shim with cmd-shim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -931,7 +931,7 @@
     "@lerna/create-symlink": {
       "version": "file:utils/create-symlink",
       "requires": {
-        "@zkochan/cmd-shim": "^3.1.0",
+        "cmd-shim": "^4.0.1",
         "fs-extra": "^8.1.0",
         "npmlog": "^4.1.2"
       }
@@ -1648,6 +1648,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz",
       "integrity": "sha512-o8l0+x7C7sMZU3v9GuJIAU10qQLtwR1dtRQIOmlNMtyaqhmpXOzx1HWiYoWfmmf9HHZoAkXpc9TM9PQYF9d4Jg==",
+      "dev": true,
       "requires": {
         "is-windows": "^1.0.0",
         "mkdirp-promise": "^5.0.1",
@@ -1758,7 +1759,8 @@
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -2362,6 +2364,15 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
+      }
+    },
+    "cmd-shim": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-4.0.1.tgz",
+      "integrity": "sha512-exU/B+ts37psdPUgBhYZsHTGZ6kmZuy0i3L6+TG1BzvrQCfgc4VPpjnY4WxCz7tdMtgtCwXUIu7wLsTZ1LsIRg==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "mkdirp-infer-owner": "^1.0.2"
       }
     },
     "co": {
@@ -6909,10 +6920,28 @@
         "minimist": "0.0.8"
       }
     },
+    "mkdirp-infer-owner": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-1.0.2.tgz",
+      "integrity": "sha512-gU3/MnB7QwipTZzStIdCEx1/WqmXWCZzHNU7f/WyW53VbCy/mKGki96WvJuFNkv7S9UZGh/lrIWKa6cbIoW6ag==",
+      "requires": {
+        "chownr": "^1.1.3",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^1.0.3"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+        }
+      }
+    },
     "mkdirp-promise": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
       "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+      "dev": true,
       "requires": {
         "mkdirp": "*"
       }
@@ -6960,6 +6989,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "requires": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -9020,6 +9050,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
       }
@@ -9028,6 +9059,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }

--- a/utils/create-symlink/__tests__/create-symlink.test.js
+++ b/utils/create-symlink/__tests__/create-symlink.test.js
@@ -1,9 +1,9 @@
 "use strict";
 
-jest.mock("@zkochan/cmd-shim");
+jest.mock("cmd-shim");
 jest.mock("fs-extra");
 
-const cmdShim = require("@zkochan/cmd-shim");
+const cmdShim = require("cmd-shim");
 const fs = require("fs-extra");
 const path = require("path");
 const createSymlink = require("..");

--- a/utils/create-symlink/create-symlink.js
+++ b/utils/create-symlink/create-symlink.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const cmdShim = require("@zkochan/cmd-shim");
+const cmdShim = require("cmd-shim");
 const fs = require("fs-extra");
 const log = require("npmlog");
 const path = require("path");

--- a/utils/create-symlink/package.json
+++ b/utils/create-symlink/package.json
@@ -31,7 +31,7 @@
     "test": "echo \"Run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@zkochan/cmd-shim": "^3.1.0",
+    "cmd-shim": "^4.0.1",
     "fs-extra": "^8.1.0",
     "npmlog": "^4.1.2"
   }


### PR DESCRIPTION
## Description
There seems to be an issue for windows users with @zkochan/cmd-shim.
The issue is described in #2472.
In commit [60d1100](https://github.com/lerna/lerna/commit/60d1100) cmd-shim@2.0.2 was replaced with @zkochan/cmd-shim because cmd-shim was no longer maintained.
In the meantime cmd-shim is again actively maintained and does not have the above mentioned issue.
I thus suggest to switch back to cmd-shim@4.0.1


## Motivation and Context
Fixes #2472

## How Has This Been Tested?
- Tested in minimal reproducible example from #2472 on windows with yarn and npm.
- Unit and integration tests passed locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
