### PR TITLE
fix(publish): exception when publishing 1st ver

### DIFF
--- a/commands/publish/lib/get-unpublished-packages.js
+++ b/commands/publish/lib/get-unpublished-packages.js
@@ -17,7 +17,7 @@ function getUnpublishedPackages(packageGraph, opts) {
   const mapper = pkg =>
     getPackument(pkg.name, opts).then(
       packument => {
-        if (packument.versions[pkg.version] === undefined) {
+        if (packument.versions === undefined || packument.versions[pkg.version] === undefined) {
           return pkg;
         }
       },


### PR DESCRIPTION
When no versions are published, the `lerna publish` command resulted the following exception:
```
lerna ERR! TypeError: Cannot read property '0.1.11' of undefined
lerna ERR!     at /home/circleci/project/node_modules/@lerna/publish/lib/get-unpublished-packages.js:20:31
lerna ERR!     at tryCatcher (/home/circleci/project/node_modules/bluebird/js/release/util.js:16:23)
lerna ERR!     at Promise._settlePromiseFromHandler (/home/circleci/project/node_modules/bluebird/js/release/promise.js:547:31)
```

## How Has This Been Tested?
Ran unit tests, checked first publish locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
