### PR TITLE
Add ignorePackages option

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -53,6 +53,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
 - [`--force-publish`](#--force-publish)
 - [`--git-remote`](#--git-remote-name)
 - [`--create-release`](#--create-release-type)
+- [`--ignore-packages`](#--ignore-packages)
 - [`--ignore-changes`](#--ignore-changes)
 - [`--ignore-scripts`](#--ignore-scripts)
 - [`--include-merged-tags`](#--include-merged-tags)
@@ -218,6 +219,22 @@ To authenticate with GitLab, the following environment variables can be defined.
 - `GL_API_URL` - An absolute URL to the API, including the version. (Default: https://gitlab.com/api/v4)
 
 > NOTE: When using this option, you cannot pass [`--no-changelog`](#--no-changelog).
+
+### `--ignore-packages`
+
+Ignore the given packages when updating or prompting for updated versions. The passed values must be exact package names.
+
+```sh
+lerna version --ignore-packages package-1 package-2'
+```
+
+This option is best specified as root `lerna.json` configuration to share the config with `lerna publish`:
+
+```json
+{
+  "ignorePackages": ["package1", "package2"]
+}
+```
 
 ### `--ignore-changes`
 

--- a/commands/version/__tests__/__snapshots__/version-command.test.js.snap
+++ b/commands/version/__tests__/__snapshots__/version-command.test.js.snap
@@ -119,6 +119,302 @@ index SHA..SHA 100644
 +  \\"version\\": \\"1.0.1\\""
 `;
 
+exports[`VersionCommand --ignore-packages bumps all packages but ignored ones when major version selected 1`] = `
+"v2.0.0
+
+HEAD -> master, tag: v2.0.0
+
+diff --git a/lerna.json b/lerna.json
+index SHA..SHA 100644
+--- a/lerna.json
++++ b/lerna.json
+@@ -2 +2 @@
+-  \\"version\\": \\"1.0.0\\"
++  \\"version\\": \\"2.0.0\\"
+diff --git a/packages/package-2/package.json b/packages/package-2/package.json
+index SHA..SHA 100644
+--- a/packages/package-2/package.json
++++ b/packages/package-2/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"1.0.0\\",
++  \\"version\\": \\"2.0.0\\",
+diff --git a/packages/package-3/package.json b/packages/package-3/package.json
+index SHA..SHA 100644
+--- a/packages/package-3/package.json
++++ b/packages/package-3/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"1.0.0\\",
++  \\"version\\": \\"2.0.0\\",
+@@ -8 +8 @@
+-    \\"package-2\\": \\"^1.0.0\\"
++    \\"package-2\\": \\"^2.0.0\\"
+diff --git a/packages/package-4/package.json b/packages/package-4/package.json
+index SHA..SHA 100644
+--- a/packages/package-4/package.json
++++ b/packages/package-4/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"1.0.0\\",
++  \\"version\\": \\"2.0.0\\","
+`;
+
+exports[`VersionCommand --ignore-packages does not bump anything if changed package is ignored 1`] = `
+"Init commit
+
+HEAD -> master
+
+diff --git a/lerna.json b/lerna.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/lerna.json
+@@ -0,0 +1,3 @@
++{
++  \\"version\\": \\"1.0.0\\"
++}
+diff --git a/package.json b/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/package.json
+@@ -0,0 +1,3 @@
++{
++  \\"name\\": \\"normal\\"
++}
+diff --git a/packages/package-1/package.json b/packages/package-1/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-1/package.json
+@@ -0,0 +1,4 @@
++{
++  \\"name\\": \\"package-1\\",
++  \\"version\\": \\"1.0.0\\"
++}
+diff --git a/packages/package-2/package.json b/packages/package-2/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-2/package.json
+@@ -0,0 +1,7 @@
++{
++  \\"name\\": \\"package-2\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^1.0.0\\"
++  }
++}
+diff --git a/packages/package-3/package.json b/packages/package-3/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-3/package.json
+@@ -0,0 +1,10 @@
++{
++  \\"name\\": \\"package-3\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"peerDependencies\\": {
++    \\"package-2\\": \\"^1.0.0\\"
++  },
++  \\"devDependencies\\": {
++    \\"package-2\\": \\"^1.0.0\\"
++  }
++}
+diff --git a/packages/package-4/package.json b/packages/package-4/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-4/package.json
+@@ -0,0 +1,7 @@
++{
++  \\"name\\": \\"package-4\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^0.0.0\\"
++  }
++}
+diff --git a/packages/package-5/package.json b/packages/package-5/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-5/package.json
+@@ -0,0 +1,11 @@
++{
++  \\"name\\": \\"package-5\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^1.0.0\\"
++  },
++  \\"optionalDependencies\\": {
++    \\"package-3\\": \\"^1.0.0\\"
++  },
++  \\"private\\": true,
++  \\"version\\": \\"1.0.0\\"
++}"
+`;
+
+exports[`VersionCommand --ignore-packages versions changed non ignored packages: commit 1`] = `
+"v1.0.1
+
+HEAD -> master, tag: v1.0.1
+
+diff --git a/lerna.json b/lerna.json
+index SHA..SHA 100644
+--- a/lerna.json
++++ b/lerna.json
+@@ -2 +2 @@
+-  \\"version\\": \\"1.0.0\\"
++  \\"version\\": \\"1.0.1\\"
+diff --git a/packages/package-3/package.json b/packages/package-3/package.json
+index SHA..SHA 100644
+--- a/packages/package-3/package.json
++++ b/packages/package-3/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"1.0.0\\",
++  \\"version\\": \\"1.0.1\\",
+diff --git a/packages/package-4/package.json b/packages/package-4/package.json
+index SHA..SHA 100644
+--- a/packages/package-4/package.json
++++ b/packages/package-4/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"1.0.0\\",
++  \\"version\\": \\"1.0.1\\",
+diff --git a/packages/package-5/package.json b/packages/package-5/package.json
+index SHA..SHA 100644
+--- a/packages/package-5/package.json
++++ b/packages/package-5/package.json
+@@ -7 +7 @@
+-    \\"package-3\\": \\"^1.0.0\\"
++    \\"package-3\\": \\"^1.0.1\\"
+@@ -10 +10 @@
+-  \\"version\\": \\"1.0.0\\"
++  \\"version\\": \\"1.0.1\\""
+`;
+
+exports[`VersionCommand --ignore-packages versions changed non ignored packages: console output 1`] = `
+"
+Changes:
+ - package-3: 1.0.0 => 1.0.1
+ - package-4: 1.0.0 => 1.0.1
+ - package-5: 1.0.0 => 1.0.1 (private)
+"
+`;
+
+exports[`VersionCommand --ignore-packages versions changed non ignored packages: gitHead 1`] = `
+Object {
+  "devDependencies": Object {
+    "package-2": "^1.0.0",
+  },
+  "name": "package-3",
+  "peerDependencies": Object {
+    "package-2": "^1.0.0",
+  },
+  "version": "1.0.1",
+}
+`;
+
+exports[`VersionCommand --ignore-packages versions changed non ignored packages: prompt 1`] = `
+Array [
+  Array [
+    "Select a new version (currently 1.0.0)",
+    Object {
+      "choices": Array [
+        Object {
+          "name": "Patch (1.0.1)",
+          "value": "1.0.1",
+        },
+        Object {
+          "name": "Minor (1.1.0)",
+          "value": "1.1.0",
+        },
+        Object {
+          "name": "Major (2.0.0)",
+          "value": "2.0.0",
+        },
+        Object {
+          "name": "Prepatch (1.0.1-alpha.0)",
+          "value": "1.0.1-alpha.0",
+        },
+        Object {
+          "name": "Preminor (1.1.0-alpha.0)",
+          "value": "1.1.0-alpha.0",
+        },
+        Object {
+          "name": "Premajor (2.0.0-alpha.0)",
+          "value": "2.0.0-alpha.0",
+        },
+        Object {
+          "name": "Custom Prerelease",
+          "value": "PRERELEASE",
+        },
+        Object {
+          "name": "Custom Version",
+          "value": "CUSTOM",
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`VersionCommand --ignore-packages versions changed packages but ignored in independent mode: commit 1`] = `
+"Publish
+
+ - package-1@1.0.1
+ - package-3@4.0.0
+ - package-4@4.1.0
+ - package-5@5.0.1
+
+HEAD -> master, tag: package-5@5.0.1, tag: package-4@4.1.0, tag: package-3@4.0.0, tag: package-1@1.0.1
+
+diff --git a/packages/package-1/package.json b/packages/package-1/package.json
+index SHA..SHA 100644
+--- a/packages/package-1/package.json
++++ b/packages/package-1/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"1.0.0\\"
++  \\"version\\": \\"1.0.1\\"
+diff --git a/packages/package-3/package.json b/packages/package-3/package.json
+index SHA..SHA 100644
+--- a/packages/package-3/package.json
++++ b/packages/package-3/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"3.0.0\\",
++  \\"version\\": \\"4.0.0\\",
+diff --git a/packages/package-4/package.json b/packages/package-4/package.json
+index SHA..SHA 100644
+--- a/packages/package-4/package.json
++++ b/packages/package-4/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"4.0.0\\",
++  \\"version\\": \\"4.1.0\\",
+diff --git a/packages/package-5/package.json b/packages/package-5/package.json
+index SHA..SHA 100644
+--- a/packages/package-5/package.json
++++ b/packages/package-5/package.json
+@@ -4 +4 @@
+-    \\"package-3\\": \\"^3.0.0\\"
++    \\"package-3\\": \\"^4.0.0\\"
+@@ -7 +7 @@
+-  \\"version\\": \\"5.0.0\\"
++  \\"version\\": \\"5.0.1\\""
+`;
+
+exports[`VersionCommand --ignore-packages versions changed packages but ignored in independent mode: console output 1`] = `
+"
+Changes:
+ - package-1: 1.0.0 => 1.0.1
+ - package-3: 3.0.0 => 4.0.0
+ - package-4: 4.0.0 => 4.1.0
+ - package-5: 5.0.0 => 5.0.1 (private)
+"
+`;
+
+exports[`VersionCommand --ignore-packages versions changed packages but ignored in independent mode: gitHead 1`] = `
+Object {
+  "name": "package-1",
+  "version": "1.0.1",
+}
+`;
+
 exports[`VersionCommand --no-git-tag-version versions changed packages without git commit or push: gitHead 1`] = `
 Object {
   "name": "package-1",

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -64,6 +64,10 @@ exports.builder = (yargs, composed) => {
       ].join("\n"),
       type: "array",
     },
+    "ignore-packages": {
+      describe: "Ignore packages matching name(s)",
+      type: "array",
+    },
     "ignore-scripts": {
       describe: "Disable all lifecycle scripts",
       type: "boolean",

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -206,6 +206,10 @@ class VersionCommand extends Command {
         }
       }
 
+      if (this.options.ignorePackages && this.options.ignorePackages.includes(node.name)) {
+        return false;
+      }
+
       return !!node.version;
     });
 
@@ -438,7 +442,9 @@ class VersionCommand extends Command {
 
       if (hasBreakingChange) {
         // _all_ packages need a major version bump whenever _any_ package does
-        this.updates = Array.from(this.packageGraph.values());
+        this.updates = Array.from(this.packageGraph.values()).filter(
+          node => !(this.options.ignorePackages && this.options.ignorePackages.includes(node.name))
+        );
         this.updatesVersions = new Map(this.updates.map(({ name }) => [name, this.globalVersion]));
       } else {
         this.updatesVersions = versions;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Create a way to ignore certain packages when versioning or publishing with lerna.

## Motivation and Context
In https://github.com/lerna/lerna-changelog/issues/128#issuecomment-597693311 was mentioned if there was any way to ignore packages when versioning. I would also like to ignore some packages and not be prompted about versioning them when I run `publish` and `version`, even if these ignored packages or their dependecies have changes.

## How Has This Been Tested?
I added some tests to the project to check that my change was working. I also linked the lerna package and tested the changes locally in a dummy repository.

My changes shouldn't be affecting any other areas than `publish` and `version` commands.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
