### PR TITLE
fix: do not require conventional commits for releases

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -204,7 +204,7 @@ lerna version --conventional-commits --create-release github
 lerna version --conventional-commits --create-release gitlab
 ```
 
-When run with this flag, `lerna version` will create an official GitHub or GitLab release based on the changed packages. Requires `--conventional-commits` to be passed so that changelogs can be generated.
+When run with this flag, `lerna version` will create an official GitHub or GitLab release based on the changed packages.
 
 To authenticate with GitHub, the following environment variables can be defined.
 

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -79,10 +79,6 @@ class VersionCommand extends Command {
     this.createRelease = this.pushToRemote && this.options.createRelease;
     this.releaseNotes = [];
 
-    if (this.createRelease && this.options.conventionalCommits !== true) {
-      throw new ValidationError("ERELEASE", "To create a release, you must enable --conventional-commits");
-    }
-
     if (this.createRelease && this.options.changelog === false) {
       throw new ValidationError("ERELEASE", "To create a release, you cannot pass --no-changelog");
     }
@@ -476,7 +472,7 @@ class VersionCommand extends Command {
   }
 
   updatePackageVersions() {
-    const { conventionalCommits, changelogPreset, changelog = true } = this.options;
+    const { changelogPreset, changelog = true } = this.options;
     const independentVersions = this.project.isIndependent();
     const rootPath = this.project.manifest.location;
     const changedFiles = new Set();
@@ -526,7 +522,7 @@ class VersionCommand extends Command {
       pkg => this.runPackageLifecycle(pkg, "version").then(() => pkg),
     ];
 
-    if (conventionalCommits && changelog) {
+    if (changelog) {
       // we can now generate the Changelog, based on the
       // the updated version that we're about to release.
       const type = independentVersions ? "independent" : "fixed";
@@ -565,7 +561,7 @@ class VersionCommand extends Command {
     if (!independentVersions) {
       this.project.version = this.globalVersion;
 
-      if (conventionalCommits && changelog) {
+      if (changelog) {
         chain = chain.then(() =>
           ConventionalCommitUtilities.updateChangelog(this.project.manifest, "root", {
             changelogPreset,


### PR DESCRIPTION
## Description

Removes the requirement to use conventional commits for releases because it prevents you from releasing 0.x.x of a module.

## Motivation and Context

Some projects (such as the one I'm working on at the moment) want to use lerna to coordinate releases across multiple modules but cannot release v1 due to reasons out of our control - there is no code requirement to use version numbers generated by the conventional commits module, a manually chosen version number works just as well.

Fixes #2521 

## How Has This Been Tested?

I did a [release](https://applitools.com/blog/wp-content/uploads/2019/05/pasted-image-0.png) of https://github.com/ipfs/js-ipfs - it prompted me to choose versions for the various packages, I did, they were published to npm, github releases and changelogs were created as expected.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

