### PR TITLE
fix(version): adds custom change log header

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Run `lerna --help` to see all available commands and options.
 - `command.publish.message`: a custom commit message when performing version updates for publication. See [@lerna/version](commands/version#--message-msg) for more details.
 - `command.publish.registry`: use it to set a custom registry url to publish to instead of
 npmjs.org, you must already be authenticated if required.
+- `command.publish.changelogHeader`: use it to set a custom change log header.
 - `command.bootstrap.ignore`: an array of globs that won't be bootstrapped when running the `lerna bootstrap` command.
 - `command.bootstrap.npmClientArgs`: array of strings that will be passed as arguments directly to `npm install` during the `lerna bootstrap` command.
 - `command.bootstrap.scope`: an array of globs that restricts which packages will be bootstrapped when running the `lerna bootstrap` command.

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -476,7 +476,7 @@ class VersionCommand extends Command {
   }
 
   updatePackageVersions() {
-    const { conventionalCommits, changelogPreset, changelog = true } = this.options;
+    const { conventionalCommits, changelogPreset, changelogHeader, changelog = true } = this.options;
     const independentVersions = this.project.isIndependent();
     const rootPath = this.project.manifest.location;
     const changedFiles = new Set();
@@ -536,6 +536,7 @@ class VersionCommand extends Command {
           changelogPreset,
           rootPath,
           tagPrefix: this.tagPrefix,
+          changelogHeader,
         }).then(({ logPath, newEntry }) => {
           // commit the updated changelog
           changedFiles.add(logPath);

--- a/core/conventional-commits/__tests__/conventional-commits.test.js
+++ b/core/conventional-commits/__tests__/conventional-commits.test.js
@@ -333,6 +333,44 @@ describe("conventional-commits", () => {
       expect(rootChangelogContent).toMatchSnapshot("root");
     });
 
+    it("should contain default header when custom header is not passed", async () => {
+      const cwd = await initFixture("fixed");
+      await gitTag(cwd, "dragons-are-awesome1.0.0");
+      const [pkg1] = await getPackages(cwd);
+
+      await pkg1.set("changed", 1).serialize();
+      await gitAdd(cwd, pkg1.manifestLocation);
+      await gitCommit(cwd, "fix: A second commit for our CHANGELOG");
+
+      // update version
+      await pkg1.set("version", "1.0.1").serialize();
+      const leafChangelog = await updateChangelog(pkg1, "fixed", {});
+      const changeLog = await getFileContent(leafChangelog);
+      expect(changeLog.indexOf("Change Log")).toBe(2);
+    });
+
+    it("should contain custom changelog header when passed", async () => {
+      const customHeader = "ChangeLog";
+      const cwd = await initFixture("fixed");
+      await gitTag(cwd, "dragons-are-awesome1.0.0");
+
+      const [pkg1] = await getPackages(cwd);
+
+      // make a change in package-1
+      await pkg1.set("changed", 1).serialize();
+      await gitAdd(cwd, pkg1.manifestLocation);
+      await gitCommit(cwd, "fix: A second commit for our CHANGELOG");
+
+      // update version
+      await pkg1.set("version", "1.0.1").serialize();
+      const leafChangelog = await updateChangelog(pkg1, "fixed", {
+        changelogHeader: customHeader,
+      });
+
+      const changeLog = await getFileContent(leafChangelog);
+      expect(changeLog.indexOf(customHeader)).toBe(2);
+    });
+
     it("supports custom tagPrefix in fixed mode", async () => {
       const cwd = await initFixture("fixed");
 

--- a/core/conventional-commits/lib/constants.js
+++ b/core/conventional-commits/lib/constants.js
@@ -10,9 +10,10 @@ exports.BLANK_LINE = EOL + EOL;
 exports.COMMIT_GUIDELINE =
   "See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.";
 
-exports.CHANGELOG_HEADER = [
+exports.CHANGELOG_HEADER_TEMPLATE = [
   "# Change Log",
   "",
   "All notable changes to this project will be documented in this file.",
-  exports.COMMIT_GUIDELINE,
-].join(EOL);
+];
+
+exports.CHANGELOG_HEADER = [...exports.CHANGELOG_HEADER_TEMPLATE, exports.COMMIT_GUIDELINE].join(EOL);

--- a/core/conventional-commits/lib/get-custom-changelog-header.js
+++ b/core/conventional-commits/lib/get-custom-changelog-header.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const { CHANGELOG_HEADER_TEMPLATE, COMMIT_GUIDELINE, EOL } = require("./constants");
+
+module.exports = getCustomChangeLogHeader;
+
+/**
+ * Changes default change log header with the provided header
+ * @param {String} header
+ * @returns {String} updated header
+ */
+function getCustomChangeLogHeader(header) {
+  const changeLogHeader = [...CHANGELOG_HEADER_TEMPLATE, COMMIT_GUIDELINE];
+  changeLogHeader[0] = `# ${header}`;
+  return changeLogHeader.join(EOL);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Create a way to customize the change log header via the configuration file.

## Motivation and Context
As of now, there is no way to customize the change log header and is currently hardcoded to "Change Log". By setting the 'changelogHeader' in command configuration, change log header can now be changed.

<!--- If it fixes an open issue, please link to the issue here. -->
[https://github.com/lerna/lerna/issues/2272](url)

## How Has This Been Tested?
1. Added test cases for the changes made.
2. Switched to forked copy and verified the publish and version command on existing lerna repo.

My changes shouldn't be affecting any other areas than *publish* and *version* commands.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
