### PR TITLE
fix(create): Use correct variable name in generated CLI output

### DIFF
--- a/commands/create/__tests__/__snapshots__/create-command.test.js.snap
+++ b/commands/create/__tests__/__snapshots__/create-command.test.js.snap
@@ -67,7 +67,7 @@ index SHA..SHA
 @@ -0,0 +1,26 @@
 +'use strict';
 +
-+const yargs = require('yargs/yargs');
++const factory = require('yargs/yargs');
 +const myCli = require('./my-cli');
 +
 +module.exports = cli;

--- a/commands/create/index.js
+++ b/commands/create/index.js
@@ -450,7 +450,7 @@ class CreateCommand extends Command {
         : dedent`
           'use strict';
 
-          const yargs = require('yargs/yargs');
+          const factory = require('yargs/yargs');
           const ${this.camelName} = require('./${this.dirName}');
 
           module.exports = cli;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When creating a binary without the ES-module flag, the created CLI uses the wrong variable name when requiring `yargs`.
With the ES-module flag, however, it works.

This commit fixes the binary by using the same variable name when requiring, as the ES-module CLI does when importing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It fixes the created CLIs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Changed it, created a new binary and it worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
