### PR TITLE
Feat/changelog preview

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -371,13 +371,11 @@ lerna publish from-git --tag-version-prefix=''
 
 ### `--changelog-preview`
 
-This option allows to preview and make changes in the changelog before its committed.
+This option allows to preview and make changes in the changelog before its committed. Should only be run locally and not in CI environment.
 
 ```bash
 # locally
 lerna version --changelog-preview
-# on ci
-lerna publish --changelog-preview
 ```
 
 ## Deprecated Options

--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -66,6 +66,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
 - [`--sign-git-tag`](#--sign-git-tag)
 - [`--yes`](#--yes)
 - [`--tag-version-prefix`](#--tag-version-prefix)
+- [`--changelog-preview`](#--changelog-preview)
 
 ### `--allow-branch <glob>`
 
@@ -366,6 +367,17 @@ Keep in mind that currently you have to supply it twice: for `version` command a
 lerna version --tag-version-prefix=''
 # on ci
 lerna publish from-git --tag-version-prefix=''
+```
+
+### `--changelog-preview`
+
+This option allows to preview and make changes in the changelog before its committed.
+
+```bash
+# locally
+lerna version --changelog-preview
+# on ci
+lerna publish --changelog-preview
 ```
 
 ## Deprecated Options

--- a/commands/version/__tests__/version-conventional-commits.test.js
+++ b/commands/version/__tests__/version-conventional-commits.test.js
@@ -58,7 +58,13 @@ describe("--conventional-commits", () => {
         expect(ConventionalCommitUtilities.updateChangelog).toHaveBeenCalledWith(
           expect.objectContaining({ name, version }),
           "independent",
-          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v", prereleaseId: undefined }
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: "v",
+            prereleaseId: undefined,
+            changelogPreview: false,
+          }
         );
       });
     });
@@ -84,7 +90,7 @@ describe("--conventional-commits", () => {
         expect(ConventionalCommitUtilities.updateChangelog).toHaveBeenCalledWith(
           expect.objectContaining({ name, version }),
           "independent",
-          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v" }
+          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v", changelogPreview: false }
         );
       });
     });
@@ -107,7 +113,7 @@ describe("--conventional-commits", () => {
         expect(ConventionalCommitUtilities.updateChangelog).toHaveBeenCalledWith(
           expect.objectContaining({ name, version }),
           "independent",
-          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v" }
+          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v", changelogPreview: false }
         );
       });
     });
@@ -131,7 +137,7 @@ describe("--conventional-commits", () => {
       expect(ConventionalCommitUtilities.updateChangelog).toHaveBeenCalledWith(
         expect.any(Object),
         "independent",
-        changelogOpts
+        Object.assign({}, changelogOpts, { changelogPreview: false })
       );
     });
 
@@ -171,7 +177,13 @@ describe("--conventional-commits", () => {
         expect(ConventionalCommitUtilities.updateChangelog).toHaveBeenCalledWith(
           expect.objectContaining({ name, version: "2.0.0" }),
           "fixed",
-          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v", prereleaseId: undefined }
+          {
+            changelogPreset: undefined,
+            rootPath: cwd,
+            tagPrefix: "v",
+            prereleaseId: undefined,
+            changelogPreview: false,
+          }
         );
       });
 
@@ -218,7 +230,7 @@ describe("--conventional-commits", () => {
         expect(ConventionalCommitUtilities.updateChangelog).toHaveBeenCalledWith(
           expect.objectContaining({ name, version: "2.0.0-alpha.0" }),
           "fixed",
-          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v" }
+          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v", changelogPreview: false }
         );
       });
 
@@ -263,7 +275,7 @@ describe("--conventional-commits", () => {
       expect(ConventionalCommitUtilities.updateChangelog).toHaveBeenCalledWith(
         expect.any(Object),
         "fixed",
-        changelogOpts
+        Object.assign({}, changelogOpts, { changelogPreview: false })
       );
     });
 

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -140,6 +140,10 @@ exports.builder = (yargs, composed) => {
       alias: "yes",
       type: "boolean",
     },
+    "changelog-preview": {
+      describe: "Peview and make changes in changelog before its committed.",
+      type: "boolean",
+    },
   };
 
   if (composed) {

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -476,7 +476,7 @@ class VersionCommand extends Command {
   }
 
   updatePackageVersions() {
-    const { conventionalCommits, changelogPreset, changelog = true } = this.options;
+    const { conventionalCommits, changelogPreset, changelog = true, changelogPreview = false } = this.options;
     const independentVersions = this.project.isIndependent();
     const rootPath = this.project.manifest.location;
     const changedFiles = new Set();
@@ -536,6 +536,7 @@ class VersionCommand extends Command {
           changelogPreset,
           rootPath,
           tagPrefix: this.tagPrefix,
+          changelogPreview,
         }).then(({ logPath, newEntry }) => {
           // commit the updated changelog
           changedFiles.add(logPath);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a way to preview and modify the generated changelog file when using conventional commits. 

When the version command is run with `--changelog-preview` option, once the change log is written it will open in VIM where the user can preview and make changes to the log file. Once the user exists out of vim the file is committed. This will happen for every change log generated. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At times you want to preview or make changes to the generated change log. For eg:
1. Correct a spelling or a grammatical error in a commit message.
2. Remove certain commit messages from the log.
3. Add additional documentation links (styleguidist or storybooks) with the change log.

<!--- If it fixes an open issue, please link to the issue here. -->
ISSUE: https://github.com/lerna/lerna/issues/1094

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Switched to forked copy and verified the publish and version command on existing lerna repo.

My changes shouldn't be affecting any other areas than publish and version commands.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
