### PR TITLE
fix(import): Better handling of "Patch is empty"

### DIFF
--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -237,9 +237,9 @@ class ImportCommand extends Command {
           tracker.completeWork(1);
         })
         .catch(err => {
-          const patchIsEmptyMessages = ["Patch is empty.", "Патч пустой."];
-          const patchIsEmpty = patchIsEmptyMessages.some(message => err.stdout.startsWith(message));
-          if (patchIsEmpty) {
+          // Getting commit diff to see if it's empty
+          const diff = this.externalExecSync("git", ["diff", "-s", `${sha}^!`]).trim();
+          if (diff === '') {
             tracker.completeWork(1);
 
             // Automatically skip empty commits

--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -239,7 +239,7 @@ class ImportCommand extends Command {
         .catch(err => {
           // Getting commit diff to see if it's empty
           const diff = this.externalExecSync("git", ["diff", "-s", `${sha}^!`]).trim();
-          if (diff === '') {
+          if (diff === "") {
             tracker.completeWork(1);
 
             // Automatically skip empty commits

--- a/commands/import/index.js
+++ b/commands/import/index.js
@@ -237,7 +237,9 @@ class ImportCommand extends Command {
           tracker.completeWork(1);
         })
         .catch(err => {
-          if (err.stdout.indexOf("Patch is empty.") === 0) {
+          const patchIsEmptyMessages = ["Patch is empty.", "Патч пустой."];
+          const patchIsEmpty = patchIsEmptyMessages.some(message => err.stdout.startsWith(message));
+          if (patchIsEmpty) {
             tracker.completeWork(1);
 
             // Automatically skip empty commits


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed check for hard-coded "Patch is empty." git message in favor of `git diff COMMIT^!` check.
Fixes #2351 , fixes #2587

## Motivation and Context
Command `lerna import --flatten <path/to/repo>` fails if `LANG` environment variable set to `ru_RU.UTF-8` (default value on macOS in Russia).
Example output:
```
lerna ERR! import Rolling back to previous HEAD (commit fff5b779833c57820df2f76c812fd0e89641de07)
lerna ERR! EIMPORT Failed to apply commit ef18c6c.
lerna ERR! EIMPORT Command failed: git am -3 --keep-non-patch
lerna ERR! EIMPORT Патч пустой.
lerna ERR! EIMPORT Когда вы устраните эту проблему, запустите «git am --continue».
lerna ERR! EIMPORT Если вы хотите пропустить этот патч, то запустите «git am --skip».
lerna ERR! EIMPORT Чтобы вернуться на предыдущую ветку и остановить применение изменений, запустите «git am --abort».
lerna ERR! EIMPORT 
lerna ERR! EIMPORT 
lerna ERR! EIMPORT You may try again with --flatten to import flat history.
```

## How Has This Been Tested?
Updated command's code and successfully imported repo with multiple locales including: `en_US.UTF-8`, `ru_RU.UTF-8`, `en_IN.utf8`, `es_ES.UTF-8` and `de_CH.ISO8859-1`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
