### PR TITLE
feat(add): Filepath dependencies should be treated as local dependencies agnostic of installation method

### DIFF
--- a/core/package-graph/__tests__/package-graph.test.js
+++ b/core/package-graph/__tests__/package-graph.test.js
@@ -92,6 +92,43 @@ describe("PackageGraph", () => {
       expect(pkg1.localDependents.has("pkg-2")).toBe(true);
       expect(pkg2.localDependencies.has("pkg-1")).toBe(true);
     });
+
+    it("localizes tarball", () => {
+      const pkgs = [
+        new Package(
+          {
+            name: "pkg-1",
+            version: "1.0.0",
+          },
+          "/test/pkg-1"
+        ),
+        new Package(
+          {
+            name: "@my-scope/pkg-2",
+            version: "2.0.0",
+            dependencies: {
+              "pkg-1": "file:../pkg-1/pkg-1-1.0.0.tgz",
+            },
+          },
+          "/test/pkg-2"
+        ),
+        new Package(
+          {
+            name: "@my-scope/pkg-3",
+            version: "1.0.0",
+            dependencies: {
+              "@my-scope/pkg-2": "file:../pkg-2/my-scope-pkg-2-1.0.0.tgz",
+            },
+          },
+          "/test/pkg-3"
+        ),
+      ];
+      const graph = new PackageGraph(pkgs);
+      const [, pkg2, pkg3] = graph.values();
+
+      expect(pkg2.localDependencies.has("pkg-1")).toBe(true);
+      expect(pkg3.localDependencies.has("@my-scope/pkg-2")).toBe(true);
+    });
   });
 
   describe("Node", () => {

--- a/core/package-graph/index.js
+++ b/core/package-graph/index.js
@@ -65,7 +65,12 @@ class PackageGraph extends Map {
           return currentNode.externalDependencies.set(depName, resolved);
         }
 
-        if (forceLocal || resolved.fetchSpec === depNode.location || depNode.satisfies(resolved)) {
+        if (
+          forceLocal ||
+          resolved.fetchSpec === depNode.location ||
+          depNode.satisfies(resolved) ||
+          resolved.type === "file"
+        ) {
           // a local file: specifier OR a matching semver
           currentNode.localDependencies.set(depName, resolved);
           depNode.localDependents.set(currentName, currentNode);


### PR DESCRIPTION
Adding support for https://github.com/lerna/lerna/issues/2592 to create a local dependency when a tarball is used

closes https://github.com/lerna/lerna/issues/2592

See issue for in-depth discussion of motivation.

## Description
When calculating the package-graph, do an additional check to see if the file is actually a tarball, in which case it should be added as a local dependency (existing functionality is that is it is tracked as external)

## Motivation and Context
https://github.com/lerna/lerna/issues/2592

## How Has This Been Tested?
Updated test suite for that file to check that tarballs are included as local.

Applied these changes in a private repo and topographical sort is as expected now.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
