### PR TITLE
Added checking of version prefix, when do "lerna version"

### DIFF
--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -187,10 +187,14 @@ class VersionCommand extends Command {
       );
     }
 
+    const opts = Object.assign({}, this.execOpts);
+    if (!this.project.isIndependent() && this.tagPrefix) {
+      opts.match = `${this.tagPrefix}*`;
+    }
     this.updates = collectUpdates(
       this.packageGraph.rawPackageList,
       this.packageGraph,
-      this.execOpts,
+      opts,
       this.options
     ).filter(node => {
       // --no-private completely removes private packages from consideration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A fix for issue https://github.com/lerna/lerna/issues/2056
## Description
<!--- Describe your changes in detail -->
Added a match for tagPrefix for collectUpdates in version command (only for fixed-version repo)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The main problem is, that when we use custom tags in a repo, the version command calculates changes from a wrong tag.
Also, there is an open issue: https://github.com/lerna/lerna/issues/2056

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it on a real repo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
