### PR TITLE
remove unused dependency in create which causes compilation issues in some ts projects

### DIFF
--- a/commands/create/package.json
+++ b/commands/create/package.json
@@ -41,7 +41,6 @@
     "camelcase": "^5.0.0",
     "dedent": "^0.7.0",
     "fs-extra": "^8.1.0",
-    "globby": "^9.2.0",
     "init-package-json": "^1.10.3",
     "npm-package-arg": "^6.1.0",
     "p-reduce": "^1.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the unused globby dependency in `@lerna/create`

## Motivation and Context

Dependency is unused, so it should be removed.

The old version of `globby` which was in the `package.json` also depended on `glob`, which depended on `@types/glob`, which depended on `@types/node`. If a lerna monorepo contains a typescript package which depends on `zone.js`, it fails to compile because `zone.js` and `@types/node` have conflicting definitions of `global`. A project which depends on lerna in the root of the project will have `@types/node` in its root `node_modules` due to this deep dependency issue. Because of node's module resolution behavior, this `@types/node` will be read during compilation even if a package in the lerna monorepo does not require it.


## How Has This Been Tested?
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ~My code follows the code style of this project.~ n/a
- [x] ~My change requires a change to the documentation.~ n/a
- [x] ~I have updated the documentation accordingly.~ n/a
- [x] I have read the **CONTRIBUTING** document.
- [x] ~I have added tests to cover my changes.~ n/a
- [x] All new and existing tests passed.
