### PR TITLE
fix: Bump dot-prop to 5.2.0 (CVE-2020-8116)

### DIFF
--- a/core/project/package.json
+++ b/core/project/package.json
@@ -36,7 +36,7 @@
     "@lerna/validation-error": "file:../validation-error",
     "cosmiconfig": "^5.1.0",
     "dedent": "^0.7.0",
-    "dot-prop": "^4.2.0",
+    "dot-prop": "^5.2.0",
     "glob-parent": "^5.0.0",
     "globby": "^9.2.0",
     "load-json-file": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,7 +1206,7 @@
         "@lerna/validation-error": "file:core/validation-error",
         "cosmiconfig": "^5.1.0",
         "dedent": "^0.7.0",
-        "dot-prop": "^4.2.0",
+        "dot-prop": "^5.2.0",
         "glob-parent": "^5.0.0",
         "globby": "^9.2.0",
         "load-json-file": "^5.3.0",
@@ -2974,11 +2974,18 @@
       }
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "^2.0.0"
+      },
+      "dependencies": {
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+        }
       }
     },
     "duplexer": {
@@ -5902,7 +5909,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bumps `dot-prop` to 5.2.0. Versions between 1.0.1 and 5.1.1 are vulnerable to prototype pollution according to [Snyk](https://snyk.io/vuln/SNYK-JS-DOTPROP-543489). This could cause Lerna users to have failing dependency audit pipelines.

In `dot-prop` 5.0.0, support for Node <8 was removed according to the release notes. It doesn't look like there were functional changes in https://github.com/sindresorhus/dot-prop/commit/a19fd4162f50307a81ac6493236c8a964bd3c86a though. Nonetheless, this could be considered a breaking change, as I noticed the `engines` field in the `package.json` says `"node": ">= 6.9.0"`.

## Motivation and Context
Fixes #2606 
Fixes #2492 
Related to #2575 

## How Has This Been Tested?
- All unit tests pass

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
