### PR TITLE
Upgrading @zkochan/cmd-shim to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -932,6 +932,18 @@
         "@zkochan/cmd-shim": "^3.1.0",
         "fs-extra": "^8.1.0",
         "npmlog": "^4.1.2"
+      },
+      "dependencies": {
+        "@zkochan/cmd-shim": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz",
+          "integrity": "sha512-o8l0+x7C7sMZU3v9GuJIAU10qQLtwR1dtRQIOmlNMtyaqhmpXOzx1HWiYoWfmmf9HHZoAkXpc9TM9PQYF9d4Jg==",
+          "requires": {
+            "is-windows": "^1.0.0",
+            "mkdirp-promise": "^5.0.1",
+            "mz": "^2.5.0"
+          }
+        }
       }
     },
     "@lerna/describe-ref": {
@@ -1653,13 +1665,12 @@
       }
     },
     "@zkochan/cmd-shim": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz",
-      "integrity": "sha512-o8l0+x7C7sMZU3v9GuJIAU10qQLtwR1dtRQIOmlNMtyaqhmpXOzx1HWiYoWfmmf9HHZoAkXpc9TM9PQYF9d4Jg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-5.0.0.tgz",
+      "integrity": "sha512-9hBJPDVzyfoKvwG1x5BpL4djQt7yCWpnpGgomtvZWaMcB6C5UWtfOZBf3f/oYXVhRK89mKgfbpiD/JhwnbSQ1Q==",
+      "dev": true,
       "requires": {
-        "is-windows": "^1.0.0",
-        "mkdirp-promise": "^5.0.1",
-        "mz": "^2.5.0"
+        "is-windows": "^1.0.2"
       }
     },
     "JSONStream": {
@@ -5902,7 +5913,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -9220,9 +9232,9 @@
       "dev": true
     },
     "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "requires": {
         "any-promise": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@lerna-test/show-commit": "file:helpers/show-commit",
     "@lerna-test/silence-logging": "file:helpers/silence-logging",
     "@lerna-test/update-lerna-config": "file:helpers/update-lerna-config",
-    "@zkochan/cmd-shim": "^3.1.0",
+    "@zkochan/cmd-shim": "~5.0.0",
     "camelcase": "^5.3.1",
     "debug": "^4.1.1",
     "eslint": "^6.6.0",

--- a/utils/create-symlink/package.json
+++ b/utils/create-symlink/package.json
@@ -31,7 +31,7 @@
     "test": "echo \"Run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@zkochan/cmd-shim": "^3.1.0",
+    "@zkochan/cmd-shim": "~5.0.0",
     "fs-extra": "^8.1.0",
     "npmlog": "^4.1.2"
   }


### PR DESCRIPTION
Upgrading @zkochan/cmd-shim to 5.0.0.   

## Description
Change of version within package.json files for the root project and for utils/create-symlink.

## Motivation and Context

We discovered that symbolic links were not being created for a local repository when running `lerna add projectChild --scope=projectParent --loglevel=silly`, with no errors being reported.   Investigation revealed that the promise returned from creating a 'binary' symbolic link (type='exec') in a prior project dependency using the cmd-shim was never being resolved or rejected (windows 10 64 bit running git bash), which halted progress of the pMapSeries in symlink-dependencies, causing early termination.  Upgrading to the latest version of cmd-shim resulted in the successful resolving of the promise and allowed the linking to complete, which itself resulted in creating the link to our projects above.

## How Has This Been Tested?

`npm run test` from a fresh checkout of master results in 829 linting problems due to missing node_module directories in subpackages.  I was able to force a global install of lerna to run lerna bootstrap on this project, but this didn't resolve the issue.

`npm jest` results in all tests passing.

`npm run integration` results in 2 publishing failures.

I'd be happy to try to resolve these test failures, but my suspicion is that they are unrelated to my dependency upgrade.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
