### PR TITLE
lerna version: --amend custom message

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -120,6 +120,12 @@ This is useful during [Continuous integration (CI)](https://en.wikipedia.org/wik
 
 In order to prevent unintended overwrites, this command will skip `git push` (i.e., it implies `--no-push`).
 
+If you need Lerna's commit message to replace the current commit message, pass the keyword 'message' to the --amend flag 
+```sh
+lerna version --amend message"
+# commit message is retained, and `git push` is skipped.
+```
+
 ### `--changelog-preset`
 
 ```sh

--- a/commands/version/__tests__/git-commit.test.js
+++ b/commands/version/__tests__/git-commit.test.js
@@ -38,7 +38,6 @@ describe("git commit", () => {
     expect(mockExec).toHaveBeenLastCalledWith("git", ["commit", "--amend", "--no-edit", "-m", "subject"], opts);
   });
 
-
   test("--no-commit-hooks", async () => {
     const opts = { cwd: "no-verify" };
     await gitCommit("yolo", { commitHooks: false }, opts);

--- a/commands/version/__tests__/git-commit.test.js
+++ b/commands/version/__tests__/git-commit.test.js
@@ -35,7 +35,11 @@ describe("git commit", () => {
   test("--amend with custom message", async () => {
     const opts = { cwd: "no-edit" };
     await gitCommit("subject", { amend: "message" }, opts);
-    expect(mockExec).toHaveBeenLastCalledWith("git", ["commit", "--amend", "--no-edit", "-m", "subject"], opts);
+    expect(mockExec).toHaveBeenLastCalledWith(
+      "git",
+      ["commit", "--amend", "--no-edit", "-m", "subject"],
+      opts
+    );
   });
 
   test("--no-commit-hooks", async () => {

--- a/commands/version/__tests__/git-commit.test.js
+++ b/commands/version/__tests__/git-commit.test.js
@@ -32,6 +32,13 @@ describe("git commit", () => {
     expect(mockExec).toHaveBeenLastCalledWith("git", ["commit", "--amend", "--no-edit"], opts);
   });
 
+  test("--amend with custom message", async () => {
+    const opts = { cwd: "no-edit" };
+    await gitCommit("subject", { amend: "message" }, opts);
+    expect(mockExec).toHaveBeenLastCalledWith("git", ["commit", "--amend", "--no-edit", "-m", "subject"], opts);
+  });
+
+
   test("--no-commit-hooks", async () => {
     const opts = { cwd: "no-verify" };
     await gitCommit("yolo", { commitHooks: false }, opts);

--- a/commands/version/__tests__/version-command.test.js
+++ b/commands/version/__tests__/version-command.test.js
@@ -532,6 +532,14 @@ describe("VersionCommand", () => {
       const message = await getCommitMessage(testDir);
       expect(message).toBe("preserved");
     });
+
+    it("allows custom messages", async () => {
+      const testDir = await initFixture("normal", "preserved");
+      await lernaVersion(testDir)("-m", "subject", "--amend", "message");
+
+      const message = await getCommitMessage(testDir);
+      expect(message).toBe("subject");
+    });
   });
 
   describe("--amend --independent", () => {

--- a/commands/version/__tests__/version-command.test.js
+++ b/commands/version/__tests__/version-command.test.js
@@ -534,7 +534,7 @@ describe("VersionCommand", () => {
     });
 
     it("allows custom messages", async () => {
-      const testDir = await initFixture("normal", "preserved");
+      const testDir = await initFixture("normal", "message");
       await lernaVersion(testDir)("-m", "subject", "--amend", "message");
 
       const message = await getCommitMessage(testDir);

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -18,7 +18,7 @@ exports.builder = (yargs, composed) => {
     },
     amend: {
       describe: "Amend the existing commit, instead of generating a new one.",
-      type: "boolean",
+      type: "string",
     },
     "conventional-commits": {
       describe: "Use conventional-changelog to determine version bump and generate CHANGELOG.",

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -75,7 +75,7 @@ class VersionCommand extends Command {
     this.gitRemote = gitRemote;
     this.tagPrefix = tagVersionPrefix;
     this.commitAndTag = gitTagVersion;
-    this.pushToRemote = gitTagVersion && amend !== true && push;
+    this.pushToRemote = gitTagVersion && amend == null && push;
     // never automatically push to remote when amending a commit
 
     this.createRelease = this.pushToRemote && this.options.createRelease;

--- a/commands/version/lib/git-commit.js
+++ b/commands/version/lib/git-commit.js
@@ -19,7 +19,7 @@ function gitCommit(message, { amend, commitHooks, signGitCommit }, opts) {
     args.push("--gpg-sign");
   }
 
-  if (amend) {
+  if (amend != null) {
     args.push("--amend", "--no-edit");
 
     if (amend === "message") {

--- a/commands/version/lib/git-commit.js
+++ b/commands/version/lib/git-commit.js
@@ -22,7 +22,7 @@ function gitCommit(message, { amend, commitHooks, signGitCommit }, opts) {
   if (amend) {
     args.push("--amend", "--no-edit");
 
-    if(amend === "message") {
+    if (amend === "message") {
       args.push("-m", message);
     }
   } else if (message.indexOf(EOL) > -1) {

--- a/commands/version/lib/git-commit.js
+++ b/commands/version/lib/git-commit.js
@@ -21,6 +21,10 @@ function gitCommit(message, { amend, commitHooks, signGitCommit }, opts) {
 
   if (amend) {
     args.push("--amend", "--no-edit");
+
+    if(amend === "message") {
+      args.push("-m", message);
+    }
   } else if (message.indexOf(EOL) > -1) {
     // Use tempfile to allow multi\nline strings.
     args.push("-F", tempWrite.sync(message, "lerna-commit.txt"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow changing commit message in `lerna version --amend`

## Motivation and Context
For example when committing change-log before bumping, the new version is still unknown - but we might desire it in the commit message. `lerna version --amend message` we replace the change-log commit message, with something more meaningful for us, the new version.

## How Has This Been Tested?
Updated tests accordingly, and tested on a local lerna project.
Test those scenarios:
* `lerna version --amend` - preserve current commit message
* `lerna version` - adds a new commit
* `lerna version --amend message` - replaces current commit message with Lerna's auto generated commit message
* `lerna version --amend message -m "custom"` - replaces current commit message with message passed to `-m` flag


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
