### PR TITLE
Enhance non-atomic push fallback condition in version command

### DIFF
--- a/commands/version/lib/git-push.js
+++ b/commands/version/lib/git-push.js
@@ -15,8 +15,8 @@ function gitPush(remote, branch, opts) {
       // the error message _should_ be on stderr except when GIT_REDIRECT_STDERR has been configured to redirect
       // to stdout. More details in https://git-scm.com/docs/git#Documentation/git.txt-codeGITREDIRECTSTDERRcode
       if (
-        /atomic/.test(error.stderr) ||
-        (process.env.GIT_REDIRECT_STDERR === "2>&1" && /atomic/.test(error.stdout))
+        /does not support --atomic/.test(error.stderr) ||
+        (process.env.GIT_REDIRECT_STDERR === "2>&1" && /does not support --atomic/.test(error.stdout))
       ) {
         // --atomic is only supported in git >=2.4.0, which some crusty CI environments deem unnecessary to upgrade.
         // so let's try again without attempting to pass an option that is almost 5 years old as of this writing...


### PR DESCRIPTION


## Description
Previously, we were checking for `atomic` in the atomic git push error to check if a non-atomic push should be performed.
However, this keyword appears in all failure scenarios, not only when git lacks support to `--atomic` flag.
With this change, this condition is more precise and will fail the lerna publish command properly instead of leading to a unwanted fallback.

## Motivation and Context
✅ Closes: #2695

## How Has This Been Tested?
The current test scenario already covers this well.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
