### PR TITLE
Push tags only if commit push succeeds in version command

### DIFF
--- a/commands/version/__tests__/git-push.test.js
+++ b/commands/version/__tests__/git-push.test.js
@@ -61,11 +61,16 @@ test("remote that does not support --atomic", async () => {
   // this call should _not_ throw
   await gitPush("origin", "master", { cwd });
 
-  expect(childProcess.exec).toHaveBeenCalledTimes(2);
+  expect(childProcess.exec).toHaveBeenCalledTimes(3);
+  expect(childProcess.exec).toHaveBeenLastCalledWith("git", ["push", "--no-verify", "origin", "master"], {
+    cwd,
+  });
   expect(childProcess.exec).toHaveBeenLastCalledWith(
     "git",
-    ["push", "--follow-tags", "--no-verify", "origin", "master"],
-    { cwd }
+    ["push", "--tags", "--no-verify", "origin", "master"],
+    {
+      cwd,
+    }
   );
 
   const list = await listRemoteTags(cwd);

--- a/commands/version/lib/git-push.js
+++ b/commands/version/lib/git-push.js
@@ -23,7 +23,8 @@ function gitPush(remote, branch, opts) {
         log.warn("gitPush", error.stderr);
         log.info("gitPush", "--atomic failed, attempting non-atomic push");
 
-        return childProcess.exec("git", ["push", "--follow-tags", "--no-verify", remote, branch], opts);
+        childProcess.exec("git", ["push", "--no-verify", remote, branch], opts);
+        return childProcess.exec("git", ["push", "--tags", "--no-verify", remote, branch], opts);
       }
 
       // ensure unexpected errors still break chain


### PR DESCRIPTION
## Description
Previously, in the non-atomic push of version command, tags were pushed along with the commit, even if it fails.
With this change, a regular commit push will happen and possibly throws an error (e.g. if the branch is behind upstream) before attempting tags push.

## Motivation and Context
✅ Closes: #2694

## How Has This Been Tested?
Current tests were adapted to cover this scenario.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
