### PR TITLE
Update README.md re --use-workspace

### DIFF
--- a/commands/bootstrap/README.md
+++ b/commands/bootstrap/README.md
@@ -175,7 +175,7 @@ May also be configured in `lerna.json`:
 
 Enables integration with [Yarn Workspaces](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-workspaces-install-phase-1.md) (available since yarn@0.27+).
 The values in the array are the commands in which Lerna will delegate operation to Yarn (currently only bootstrapping).
-If `--use-workspaces` is true then `packages` will be overridden by the value from `package.json/workspaces.`
+If `--use-workspaces` is true then `packages` will be overridden by the value from `package.json/workspaces.`, and both `--ignore` and `--scope` will be ignored.
 May also be configured in `lerna.json`:
 
 ```js


### PR DESCRIPTION
## Description
This PR explains that the `--use-workspace` will cause yarn to ignore `--scope` and `--ignore`.

## Motivation and Context
This PR addresses the confusion caused by --scope, --ignore being broken in project that use yarn workspace.

## How Has This Been Tested?
N/A - just doc change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
