### PR TITLE
[WIP] Make lerna version understand --scope argument

### DIFF
--- a/commands/version/__tests__/__snapshots__/version-command.test.js.snap
+++ b/commands/version/__tests__/__snapshots__/version-command.test.js.snap
@@ -187,6 +187,27 @@ index SHA..SHA 100644
 +  \\"version\\": \\"1.0.1\\""
 `;
 
+exports[`VersionCommand --scope should change versiosn only for scoped packages 1`] = `
+"v1.0.1
+
+HEAD -> master, tag: v1.0.1
+
+diff --git a/lerna.json b/lerna.json
+index SHA..SHA 100644
+--- a/lerna.json
++++ b/lerna.json
+@@ -2 +2 @@
+-  \\"version\\": \\"1.0.0\\"
++  \\"version\\": \\"1.0.1\\"
+diff --git a/packages/package-4/package.json b/packages/package-4/package.json
+index SHA..SHA 100644
+--- a/packages/package-4/package.json
++++ b/packages/package-4/package.json
+@@ -3 +3 @@
+-  \\"version\\": \\"1.0.0\\",
++  \\"version\\": \\"1.0.1\\","
+`;
+
 exports[`VersionCommand independent mode versions changed packages: commit 1`] = `
 "Publish
 

--- a/commands/version/__tests__/version-command.test.js
+++ b/commands/version/__tests__/version-command.test.js
@@ -232,6 +232,20 @@ describe("VersionCommand", () => {
     });
   });
 
+  describe("--scope", () => {
+    // TODO: This test makes no sense because of collect-updates mock
+    it("should change versiosn only for scoped packages", async () => {
+      const testDir = await initFixture("normal");
+
+      collectUpdates.setUpdated(testDir, "package-4");
+
+      await lernaVersion(testDir)("--scope", "package-1");
+
+      const patch = await showCommit(testDir);
+      expect(patch).toMatchSnapshot();
+    });
+  });
+
   describe("--no-git-tag-version", () => {
     it("versions changed packages without git commit or push", async () => {
       const testDir = await initFixture("normal");

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -3,6 +3,8 @@
 const log = require("npmlog");
 const semver = require("semver");
 
+const filterable = require("@lerna/filter-options");
+
 /**
  * @see https://github.com/yargs/yargs/blob/master/docs/advanced.md#providing-a-command-module
  */
@@ -191,7 +193,7 @@ exports.builder = (yargs, composed) => {
     yargs.group(Object.keys(opts), "Command Options:");
   }
 
-  return yargs
+  yargs
     .option("ignore", {
       // TODO: remove in next major release
       // NOT the same as filter-options --ignore
@@ -268,6 +270,8 @@ exports.builder = (yargs, composed) => {
 
       return argv;
     });
+
+  return filterable(yargs);
 };
 
 exports.handler = function handler(argv) {

--- a/commands/version/package.json
+++ b/commands/version/package.json
@@ -39,6 +39,7 @@
     "@lerna/collect-updates": "file:../../utils/collect-updates",
     "@lerna/command": "file:../../core/command",
     "@lerna/conventional-commits": "file:../../core/conventional-commits",
+    "@lerna/filter-options": "^3.20.0",
     "@lerna/github-client": "file:../../utils/github-client",
     "@lerna/gitlab-client": "file:../../utils/gitlab-client",
     "@lerna/output": "file:../../utils/output",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1357,6 +1357,7 @@
         "@lerna/collect-updates": "file:utils/collect-updates",
         "@lerna/command": "file:core/command",
         "@lerna/conventional-commits": "file:core/conventional-commits",
+        "@lerna/filter-options": "^3.20.0",
         "@lerna/github-client": "file:utils/github-client",
         "@lerna/gitlab-client": "file:utils/gitlab-client",
         "@lerna/output": "file:utils/output",
@@ -5902,7 +5903,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",


### PR DESCRIPTION
*Sorry for not folllowing a template to the fullest yet, this is still a WIP, and I would like some feedback first before moving on*

## Description
This PR implements `--scope` argument for `lerna version` (and seems like subsequently `lerna publish` too).

## Motivation and Context
https://github.com/lerna/lerna/issues/2512

## How Has This Been Tested?
All existing test for `commands/version` are passing.
Test for `command/publish` which checks `--scope` not available, obviously fails.

I tested locally via CLI linking, it works as expected for my use case, although I am not 100% yet certain whether it will work as expected for cases when a version has to be updated in packages outside `--scope` argument.

Quickly tried to unit-test, but run into a problem that `collectUpdates` function is completely mocked, and to test it properly I need to unmock the function, which might be a potentially breaking (and quite large) change to current test suite, so I decided not to follow that road yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
