### PR TITLE
fix(publish, version): Pass includeMergedTags to describeRef

### DIFF
--- a/commands/publish/__tests__/publish-canary.test.js
+++ b/commands/publish/__tests__/publish-canary.test.js
@@ -381,7 +381,20 @@ test("publish --canary --include-merged-tags calls git describe correctly", asyn
 
   await lernaPublish(cwd)("--canary", "--include-merged-tags");
 
-  expect(spy).toHaveBeenCalledWith(
+  expect(spy).toBeCalledTimes(2);
+
+  // The first call happens when we do verifyWorkingTreeClean
+  expect(spy).toHaveBeenNthCalledWith(
+    1,
+    "git",
+    // notably lacking "--first-parent"
+    ["describe", "--always", "--long", "--dirty"],
+    expect.objectContaining({ cwd })
+  );
+
+  // The second call happens before we do makeVersion
+  expect(spy).toHaveBeenNthCalledWith(
+    2,
     "git",
     // notably lacking "--first-parent"
     ["describe", "--always", "--long", "--dirty", "--match", "v*.*.*"],

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -247,8 +247,8 @@ class PublishCommand extends Command {
     });
   }
 
-  verifyWorkingTreeClean() {
-    return describeRef(this.execOpts).then(checkWorkingTree.throwIfUncommitted);
+  verifyWorkingTreeClean(includeMergedTags) {
+    return describeRef(this.execOpts, includeMergedTags).then(checkWorkingTree.throwIfUncommitted);
   }
 
   detectFromGit() {
@@ -342,7 +342,7 @@ class PublishCommand extends Command {
     let chain = Promise.resolve();
 
     // attempting to publish a canary release with local changes is not allowed
-    chain = chain.then(() => this.verifyWorkingTreeClean());
+    chain = chain.then(() => this.verifyWorkingTreeClean(includeMergedTags));
 
     // find changed packages since last release, if any
     chain = chain.then(() =>

--- a/commands/version/__tests__/version-command.test.js
+++ b/commands/version/__tests__/version-command.test.js
@@ -54,7 +54,8 @@ describe("VersionCommand", () => {
       // --no-changelog should have _no_ effect
       await lernaVersion(testDir)("--no-changelog");
 
-      expect(checkWorkingTree).toHaveBeenCalled();
+      expect(checkWorkingTree).toHaveBeenCalledTimes(1);
+      expect(checkWorkingTree).toHaveBeenCalledWith(expect.anything(), undefined);
 
       expect(PromptUtilities.select.mock.calls).toMatchSnapshot("prompt");
       expect(PromptUtilities.confirm).toHaveBeenLastCalledWith(
@@ -123,6 +124,14 @@ describe("VersionCommand", () => {
 
       await expect(command).rejects.toThrow("released");
       // notably different than the actual message, but good enough here
+    });
+
+    it("passes includeMergedTags to checkWorkingTree", async () => {
+      const testDir = await initFixture("normal");
+      await lernaVersion(testDir)("--include-merged-tags");
+
+      expect(checkWorkingTree).toHaveBeenCalledTimes(1);
+      expect(checkWorkingTree).toHaveBeenCalledWith(expect.anything(), true);
     });
 
     it("calls `checkWorkingTree.throwIfUncommitted` when using --force-publish", async () => {

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -250,10 +250,10 @@ class VersionCommand extends Command {
 
     // amending a commit probably means the working tree is dirty
     if (this.commitAndTag && this.gitOpts.amend !== true) {
-      const { forcePublish, conventionalCommits, conventionalGraduate } = this.options;
+      const { forcePublish, conventionalCommits, conventionalGraduate, includeMergedTags } = this.options;
       const checkUncommittedOnly = forcePublish || (conventionalCommits && conventionalGraduate);
       const check = checkUncommittedOnly ? checkWorkingTree.throwIfUncommitted : checkWorkingTree;
-      tasks.unshift(() => check(this.execOpts));
+      tasks.unshift(() => check(this.execOpts, includeMergedTags));
     } else {
       this.logger.warn("version", "Skipping working tree validation, proceed at your own risk");
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5902,7 +5902,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/utils/check-working-tree/__tests__/check-working-tree.test.js
+++ b/utils/check-working-tree/__tests__/check-working-tree.test.js
@@ -14,7 +14,7 @@ describe("check-working-tree", () => {
     const result = await checkWorkingTree({ cwd: "foo" });
 
     expect(result).toEqual({ refCount: "1" });
-    expect(describeRef).toHaveBeenLastCalledWith({ cwd: "foo" });
+    expect(describeRef).toHaveBeenLastCalledWith({ cwd: "foo" }, undefined);
   });
 
   it("rejects when current commit has already been released", async () => {
@@ -37,5 +37,14 @@ describe("check-working-tree", () => {
     await expect(checkWorkingTree({ cwd: "foo" })).rejects.toThrow("Working tree has uncommitted changes");
 
     expect(collectUncommitted).toHaveBeenLastCalledWith({ cwd: "foo" });
+  });
+
+  it("passes includeMergedTags to describeRef", async () => {
+    describeRef.mockResolvedValueOnce({ refCount: "1" });
+
+    const result = await checkWorkingTree({ cwd: "foo" }, true);
+
+    expect(result).toEqual({ refCount: "1" });
+    expect(describeRef).toHaveBeenLastCalledWith({ cwd: "foo" }, true);
   });
 });

--- a/utils/check-working-tree/lib/check-working-tree.js
+++ b/utils/check-working-tree/lib/check-working-tree.js
@@ -9,10 +9,10 @@ module.exports.mkThrowIfUncommitted = mkThrowIfUncommitted;
 module.exports.throwIfReleased = throwIfReleased;
 module.exports.throwIfUncommitted = mkThrowIfUncommitted();
 
-function checkWorkingTree({ cwd } = {}) {
+function checkWorkingTree({ cwd } = {}, includeMergedTags) {
   let chain = Promise.resolve();
 
-  chain = chain.then(() => describeRef({ cwd }));
+  chain = chain.then(() => describeRef({ cwd }, includeMergedTags));
 
   // wrap each test separately to allow all applicable errors to be reported
   const tests = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #2482

1. Make `PublishCommand.verifyWorkingTreeClean` respect `includeMergedTags`
2. Make `checkWorkingTree` respect `includeMergedTags`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, `lerna version --include-merged-tags` and `lerna publish --canary --include-merged-tags`  still call git --first-parent, which fails on CentOS 7. This patch is meant to fix it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have run unit and integration tests.
Note: "lerna publish sets correct exit code when libnpmpublish fails" fails for me, but it does so on `master` as well.

Used [patch-package](https://www.npmjs.com/package/patch-package) to replace `@lerna/publish/index.js` with the patched version. Tested the `lerna publish --canary --preid next --dist-tag next --yes --no-verify-access --include-merged-tags` on my CentOS 7 CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. Note: "lerna publish sets correct exit code when libnpmpublish fails" fails for me, but it does so on `master` as well.
