### PR TITLE
chore: document that multiple string values no longer accepted for --hoist

### DIFF
--- a/commands/bootstrap/README.md
+++ b/commands/bootstrap/README.md
@@ -58,7 +58,7 @@ the most commonly used version will be hoisted, and a warning will be emitted.
 
 Note: `--hoist` is [incompatible with `file:` specifiers](https://github.com/lerna/lerna/issues/1679#issuecomment-461544321). Use one or the other.
 
-Note: `--hoist` [no longer accepts multiple string values](https://github.com/lerna/lerna/issues/2307) since [v3.18.0](/releases/tag/v3.18.0). Use the following instead:
+Note: `--hoist` [no longer accepts multiple string values](https://github.com/lerna/lerna/issues/2307) since [v3.18.0](https://github.com/lerna/lerna/releases/tag/v3.18.0). Use the following instead:
 
 a. Wrap string values by quotes:
 ```

--- a/commands/bootstrap/README.md
+++ b/commands/bootstrap/README.md
@@ -58,6 +58,32 @@ the most commonly used version will be hoisted, and a warning will be emitted.
 
 Note: `--hoist` is [incompatible with `file:` specifiers](https://github.com/lerna/lerna/issues/1679#issuecomment-461544321). Use one or the other.
 
+Note: `--hoist` [no longer accepts multiple string values](https://github.com/lerna/lerna/issues/2307) since [v3.18.0](/releases/tag/v3.18.0). Use the following instead:
+
+a. Wrap string values by quotes:
+```
+$ lerna bootstrap --hoist "{rollup,postcss-cli,webpack-cli,babel-loader,npm-run-all}"
+```
+
+b. Specify the list of values in `lerna.json`:
+```json
+{
+  "command": {
+    "bootstrap": {
+      "hoist": [
+        "rollup",
+        "postcss-cli",
+        "webpack-cli",
+        "babel-loader",
+        "npm-run-all"
+      ]
+    }
+  },
+  ...
+}
+```
+
+
 ### --strict
 
 When used in conjunction with hoist will throw an error and stop bootstrapping after emitting the version warnings. Has no effect if you aren't hoisting, or if there are no version warnings.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a note for "--hoist" that multiple string values no longer accepted into the bootstrap command readme.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I had the same problem as the author of the issue (https://github.com/lerna/lerna/issues/2307). I spent a lot of time to find a solution. But it was so easy.
I think it should be documented.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are no changes for code, only for documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.