### PR TITLE
feat(version): support custom command for git tag

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -59,6 +59,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--create-release <type>`](#--create-release-type)
     - [`--exact`](#--exact)
     - [`--force-publish`](#--force-publish)
+    - [`--git-tag-command <cmd>`](#--git-tag-command-cmd)
     - [`--git-remote <name>`](#--git-remote-name)
     - [`--ignore-changes`](#--ignore-changes)
     - [`--ignore-scripts`](#--ignore-scripts)
@@ -262,6 +263,26 @@ lerna version --force-publish
 When run with this flag, `lerna version` will force publish the specified packages (comma-separated) or all packages using `*`.
 
 > This will skip the `lerna changed` check for changed packages and forces a package that didn't have a `git diff` change to be updated.
+
+### `--git-tag-command <cmd>`
+
+Allows users to specify a wrapper command in CD/CI pipelines that have no direct write access.
+
+```sh
+lerna version --git-tag-command "git gh-tag %s -m %s"
+```
+
+This can also be configured in `lerna.json`.
+
+```json
+{
+  "command": {
+    "version": {
+      "gitTagCommand": "git gh-tag %s -m %s"
+    }
+  }
+}
+```
 
 ### `--git-remote <name>`
 

--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -266,7 +266,7 @@ When run with this flag, `lerna version` will force publish the specified packag
 
 ### `--git-tag-command <cmd>`
 
-Allows users to specify a wrapper command in CD/CI pipelines that have no direct write access.
+Allows users to specify a custom command to be used when applying git tags. For example, this may be useful for providing a wrapper command in CI/CD pipelines that have no direct write access.
 
 ```sh
 lerna version --git-tag-command "git gh-tag %s -m %s"

--- a/commands/version/__tests__/git-tag.test.js
+++ b/commands/version/__tests__/git-tag.test.js
@@ -34,4 +34,13 @@ describe("gitTag", () => {
 
     expect(childProcess.exec).toHaveBeenLastCalledWith("git", ["tag", tag, "-m", tag, "--force"], opts);
   });
+
+  it("creates an annotated git tag using the wrapper arguments", async () => {
+    const tag = "v1.2.4";
+    const opts = { cwd: "default" };
+
+    await gitTag(tag, {}, opts, "git-wrapper gh-tag %s -m %s");
+
+    expect(childProcess.exec).toHaveBeenLastCalledWith("git-wrapper", ["gh-tag", tag, "-m", tag], opts);
+  });
 });

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -168,6 +168,11 @@ exports.builder = (yargs, composed) => {
       requiresArg: true,
       defaultDescription: "v",
     },
+    "git-tag-command": {
+      describe:
+        "Allows users to specify a wrapper command in CD/CI pipelines that have no direct write access.",
+      type: "string",
+    },
     y: {
       describe: "Skip all confirmation prompts.",
       alias: "yes",

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -170,7 +170,7 @@ exports.builder = (yargs, composed) => {
     },
     "git-tag-command": {
       describe:
-        "Allows users to specify a wrapper command in CD/CI pipelines that have no direct write access.",
+        "Allows users to specify a custom command to be used when applying git tags. For example, this may be useful for providing a wrapper command in CI/CD pipelines that have no direct write access.",
       type: "string",
     },
     y: {

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -687,7 +687,9 @@ class VersionCommand extends Command {
 
     return Promise.resolve()
       .then(() => gitCommit(message, this.gitOpts, this.execOpts))
-      .then(() => Promise.all(tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts))))
+      .then(() =>
+        Promise.all(tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand)))
+      )
       .then(() => tags);
   }
 
@@ -700,7 +702,7 @@ class VersionCommand extends Command {
 
     return Promise.resolve()
       .then(() => gitCommit(message, this.gitOpts, this.execOpts))
-      .then(() => gitTag(tag, this.gitOpts, this.execOpts))
+      .then(() => gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand))
       .then(() => [tag]);
   }
 

--- a/commands/version/lib/git-tag.js
+++ b/commands/version/lib/git-tag.js
@@ -10,19 +10,21 @@ module.exports.gitTag = gitTag;
  * @param {{ forceGitTag: boolean; signGitTag: boolean; }} gitOpts
  * @param {import("@lerna/child-process").ExecOpts} opts
  */
-function gitTag(tag, { forceGitTag, signGitTag }, opts) {
-  log.silly("gitTag", tag);
+function gitTag(tag, { forceGitTag, signGitTag }, opts, command = "git tag %s -m %s") {
+  log.silly("gitTag", tag, command);
 
-  const args = ["tag", tag, "-m", tag];
+  const [cmd, ...args] = command.split(" ");
+
+  const interpolatedArgs = args.map((arg) => arg.replace(/%s/, tag));
 
   if (forceGitTag) {
-    args.push("--force");
+    interpolatedArgs.push("--force");
   }
 
   if (signGitTag) {
-    args.push("--sign");
+    interpolatedArgs.push("--sign");
   }
 
-  log.verbose("git", args);
-  return childProcess.exec("git", args, opts);
+  log.verbose(cmd, interpolatedArgs);
+  return childProcess.exec(cmd, interpolatedArgs, opts);
 }


### PR DESCRIPTION
## Description
Added support to override the executed command for `git tag` via CLI options and `lerna.json` entry.

## Motivation and Context
Some CD/CI systems have no direct write access to the repository and are not able to tag the normal way via git. An optional wrapper command/alias might be defined.

## How Has This Been Tested?
- Added  unit-tests
- `./core/lerna/cli.js version -h` shows new option

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
