### PR TITLE
Bump node-fetch to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -536,7 +536,6 @@
       "version": "file:helpers/clone-fixture",
       "dev": true,
       "requires": {
-        "@lerna-test/git-init": "file:helpers/git-init",
         "@lerna-test/init-fixture": "file:helpers/init-fixture",
         "execa": "^1.0.0",
         "file-url": "^2.0.2",
@@ -1007,7 +1006,7 @@
     "@lerna/gitlab-client": {
       "version": "file:utils/gitlab-client",
       "requires": {
-        "node-fetch": "^2.5.0",
+        "node-fetch": "^2.6.1",
         "npmlog": "^4.1.2",
         "whatwg-url": "^7.0.0"
       }
@@ -5902,7 +5901,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/utils/gitlab-client/package.json
+++ b/utils/gitlab-client/package.json
@@ -31,7 +31,7 @@
     "test": "echo \"Run tests from root\" && exit 1"
   },
   "dependencies": {
-    "node-fetch": "^2.5.0",
+    "node-fetch": "^2.6.1",
     "npmlog": "^4.1.2",
     "whatwg-url": "^7.0.0"
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Bump node-fetch from 2.5 to 2.6.1 to fix security vulnerability flagged by github and dependabot
See changelog for node-fetch here: https://github.com/node-fetch/node-fetch/blob/master/docs/CHANGELOG.md#v261

This is mentioned in this issue: https://github.com/lerna/lerna/issues/2759

## Motivation and Context
Bump node-fetch from 2.5 to 2.6.1 to fix security vulnerability flagged by github and dependabot

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
n/a
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
