### PR TITLE
fix: broken symlink in windows

### DIFF
--- a/utils/create-symlink/package.json
+++ b/utils/create-symlink/package.json
@@ -31,7 +31,7 @@
     "test": "echo \"Run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@zkochan/cmd-shim": "^3.1.0",
+    "@zkochan/cmd-shim": "^4.3.0",
     "fs-extra": "^8.1.0",
     "npmlog": "^4.1.2"
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgraded `@zkochan/cmd-shim` to ^5.0.0, deprecated the dependency package `mkdirp-promise`, fixed the directory linking problem in windows.


## Motivation and Context
the current `mkdirp-promise@3.0.1` uses `mkdirp@*` and mkdirp uses the new Promise syntax, it does not symlink directories correctly in windows.

fix #2539 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a new lerna repository containing two packages, one depending on the other.
- Ensure a version 1.x of mkdirp gets installed
- For example by putting it in the devDependencies of the root package.json.
- Run `lerna bootstrap --hoist`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
