### PR TITLE
Replace `"red"` color with `"brightBlue"` on package's output prefix

### DIFF
--- a/core/child-process/index.js
+++ b/core/child-process/index.js
@@ -10,7 +10,7 @@ const logTransformer = require("strong-log-transformer");
 const children = new Set();
 
 // when streaming processes are spawned, use this color for prefix
-const colorWheel = ["cyan", "magenta", "blue", "yellow", "green", "red"];
+const colorWheel = ["cyan", "magenta", "blue", "yellow", "green", "white"];
 const NUM_COLORS = colorWheel.length;
 
 // ever-increasing index ensures colors are always sequential

--- a/core/child-process/index.js
+++ b/core/child-process/index.js
@@ -10,7 +10,7 @@ const logTransformer = require("strong-log-transformer");
 const children = new Set();
 
 // when streaming processes are spawned, use this color for prefix
-const colorWheel = ["cyan", "magenta", "blue", "yellow", "green", "white"];
+const colorWheel = ["cyan", "magenta", "blue", "yellow", "green", "blueBright"];
 const NUM_COLORS = colorWheel.length;
 
 // ever-increasing index ensures colors are always sequential


### PR DESCRIPTION
## Description
Replaced color wheel's `"red"` color with `"brightBlue"`.

## Motivation and Context
When running a script/command on multiple packages, the output of each package may be prefixed with the package's name. 

This prefix of each package is colored differently, but the color wheel is limited to six colors in the following order: `"cyan"`, `"magenta"`, `"blue"`, `"yellow"`, `"green"` and `"red"`. The color `"red"` is used every six packages, but this color is generally associated to error messages.

Whenever I see lerna output parts of the text in red, I believe an error happened. But that is not what actually happened.

Only removing the color red would leave the color wheel with even fewer options.
Remove prefix coloring also seems not to be a good alternative, as the colors are helpful when reading the output.

As I solution, I propose to change it to one of the other colors available for chalk. As all of the "solid" colors left would be problematic, I opted for `brightBlue`.

It solves #2711. 

## How Has This Been Tested?
Ran a monorepo locally with more than six packages to the the different prefix color applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
