### PR TITLE
docs: Change link to Snyk

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The above command will automatically hoist things and use relative `file:` speci
 Hoisting has a few benefits:
 
 - All packages use the same version of a given dependency
-- Can keep dependencies at the root up-to-date with an automated tool such as [Snik](https://snyk.io/)
+- Can keep dependencies at the root up-to-date with an automated tool such as [Snyk](https://snyk.io/)
 - Dependency installation time is reduced
 - Less storage is needed
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The above command will automatically hoist things and use relative `file:` speci
 Hoisting has a few benefits:
 
 - All packages use the same version of a given dependency
-- Can keep dependencies at the root up-to-date with an automated tool such as [GreenKeeper](https://greenkeeper.io/)
+- Can keep dependencies at the root up-to-date with an automated tool such as [Snik](https://snyk.io/)
 - Dependency installation time is reduced
 - Less storage is needed
 


### PR DESCRIPTION
## Description
Change link Greenkeeper to Snik on readme.md

## Motivation and Context
Greenkeeper since June 2020 is no longer an open source project.   
Snyk not only has a generous free plan for Open Source repos and small organisations, but also offers dev-friendly security features that Greenkeeper didn’t have. They’re good people, and your repos will be in competent and caring hands.
![image](https://user-images.githubusercontent.com/13484277/102018841-89963c80-3d4e-11eb-8e58-8ac602b347c1.png)

## How Has This Been Tested?
Don't needed test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
