### PR TITLE
docs: add info about npm automation tokens

### DIFF
--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -26,6 +26,8 @@ During all publish operations, appropriate [lifecycle scripts](#lifecycle-script
 
 Check out [Per-Package Configuration](#per-package-configuration) for more details about publishing scoped packages, custom registries, and custom dist-tags.
 
+> If you're using [npm automation access token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-access-tokens) please remember to [disable lerna access verification feature](#--no-verify-access). Automation token doesn't grant permissions needed for the verification to be successful. [Click here to read more about this issue](https://github.com/lerna/lerna/issues/2788).
+
 ## Positionals
 
 ### bump `from-git`
@@ -204,6 +206,8 @@ By default, `lerna` will verify the logged-in npm user's access to the packages 
 If you are using a third-party registry that does not support `npm access ls-packages`, you will need to pass this flag (or set `command.publish.verifyAccess` to `false` in lerna.json).
 
 > Please use with caution
+
+> For the time being, use this flag/option always when you're handling NPM authorization with the use of [automation access token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-access-tokens). [Click here to read more about this issue](https://github.com/lerna/lerna/issues/2788).
 
 ### `--otp`
 


### PR DESCRIPTION
## Description
This simple PR adds an additional info regarding how to  handle NPM automation tokens when using lerna to the README of the publish command.
Comments/suggestions welcome!

## Motivation and Context
The is an issue whilst using lerna publish with the npm automation token. References issue #2788.

## How Has This Been Tested?
NPM automation tokens work only with `--no-verify-access` flag provided. That was tested by me and other users (look into the issue linked above).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Hard to tell really. That's just a documentation change, so I guess it's the closest to the new functionality than to bug fix or breaking change 🤷 
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
