### PR TITLE
chore: add catch error for verifyWorkingTree

### DIFF
--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -275,7 +275,19 @@ class PublishCommand extends Command {
     let chain = Promise.resolve();
 
     // attempting to publish a tagged release with local changes is not allowed
-    chain = chain.then(() => this.verifyWorkingTreeClean());
+    chain = chain
+      .then(() => this.verifyWorkingTreeClean())
+      .catch((err) => {
+        // an execa error is thrown when git suffers a fatal error (such as no git repository present)
+        if (err.failed && /git describe/.test(err.command)) {
+          // (we tried)
+          this.logger.silly("EWORKINGTREE", err.message);
+          this.logger.notice("FYI", "Unable to verify working tree, proceed at your own risk");
+        } else {
+          // validation errors should be preserved
+          throw err;
+        }
+      });
 
     chain = chain.then(() => getCurrentTags(this.execOpts, matchingPattern));
     chain = chain.then((taggedPackageNames) => {
@@ -360,7 +372,19 @@ class PublishCommand extends Command {
     let chain = Promise.resolve();
 
     // attempting to publish a canary release with local changes is not allowed
-    chain = chain.then(() => this.verifyWorkingTreeClean());
+    chain = chain
+      .then(() => this.verifyWorkingTreeClean())
+      .catch((err) => {
+        // an execa error is thrown when git suffers a fatal error (such as no git repository present)
+        if (err.failed && /git describe/.test(err.command)) {
+          // (we tried)
+          this.logger.silly("EWORKINGTREE", err.message);
+          this.logger.notice("FYI", "Unable to verify working tree, proceed at your own risk");
+        } else {
+          // validation errors should be preserved
+          throw err;
+        }
+      });
 
     // find changed packages since last release, if any
     chain = chain.then(() =>


### PR DESCRIPTION
## Description
The function `verifyWorkingTreeClean()` should have a error catch.

## Motivation and Context
Just like the process in `detectFromPackage`, the function `detectCanaryVersions` and `detectFromGit` should also have the same error catch.

## How Has This Been Tested?
Run `lerna publish from git` when my monorepo packages have something in the working tree. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
