### PR TITLE
fix(): both npmClient and hoist are valid.

### DIFF
--- a/utils/npm-install/npm-install.js
+++ b/utils/npm-install/npm-install.js
@@ -22,7 +22,7 @@ function npmInstall(
   let cmd = npmClient || "npm";
 
   if (npmGlobalStyle) {
-    cmd = cmd === "yarn" ? "npm" : npmClient;
+    cmd = cmd === "yarn" ? "npm" : cmd;
     args.push("--global-style");
   }
 

--- a/utils/npm-install/npm-install.js
+++ b/utils/npm-install/npm-install.js
@@ -22,7 +22,7 @@ function npmInstall(
   let cmd = npmClient || "npm";
 
   if (npmGlobalStyle) {
-    cmd = "npm";
+    cmd = cmd === "yarn" ? "npm" : npmClient;
     args.push("--global-style");
   }
 


### PR DESCRIPTION
fix: #2869

When we use hoist, `npmGlobalStyle` is equal to `true` and makes `npmClient` always `npm`. The set 
 of `npmClient` won't take effect.

https://github.com/lerna/lerna/blob/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/commands/bootstrap/index.js#L548

https://github.com/lerna/lerna/blob/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/utils/npm-install/npm-install.js#L25
