### PR TITLE
fix: drastically reduce time taken to check for cycles

### DIFF
--- a/core/package-graph/index.js
+++ b/core/package-graph/index.js
@@ -218,6 +218,9 @@ class PackageGraph extends Map {
     /** @type {(PackageGraphNode | CyclicPackageGraphNode)[]} */
     const walkStack = [];
 
+    /** @type {Set<PackageGraphNode>} */
+    const alreadyVisited = new Set();
+
     function visits(baseNode, dependentNode) {
       if (nodeToCycle.has(baseNode)) {
         return;
@@ -227,6 +230,12 @@ class PackageGraph extends Map {
       while (nodeToCycle.has(topLevelDependent)) {
         topLevelDependent = nodeToCycle.get(topLevelDependent);
       }
+
+      // Otherwise the same node is checked multiple times which is very wasteful in a large repository
+      if (alreadyVisited.has(topLevelDependent)) {
+        return;
+      }
+      alreadyVisited.add(topLevelDependent);
 
       if (
         topLevelDependent === baseNode ||


### PR DESCRIPTION
In our monorepo with 219 packages, `lerna exec` takes 5 minutes
to check for cycles in our package graph.

Most of time is spent checking and re-checking the same nodes over
and over again.

Add a double-work breaker (a `Set` of already-visited nodes) to only
visit every package once.

Brings the time taken down to virtually nothing.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
