### PR TITLE
fix(bootstrap,utils): propagate maxBuffer to execa

### DIFF
--- a/commands/bootstrap/index.js
+++ b/commands/bootstrap/index.js
@@ -36,7 +36,15 @@ class BootstrapCommand extends Command {
   }
 
   initialize() {
-    const { registry, npmClient = "npm", npmClientArgs = [], mutex, hoist, nohoist } = this.options;
+    const {
+      registry,
+      maxBuffer,
+      npmClient = "npm",
+      npmClientArgs = [],
+      mutex,
+      hoist,
+      nohoist,
+    } = this.options;
 
     if (npmClient === "yarn" && hoist) {
       throw new ValidationError(
@@ -99,11 +107,13 @@ class BootstrapCommand extends Command {
 
     this.runPackageLifecycle = createRunner({ registry });
     this.npmConfig = {
+      maxBuffer,
       registry,
       npmClient,
       npmClientArgs,
       mutex,
     };
+    this.logger.verbose("bootstrap", "maxBuffer %o", maxBuffer);
 
     if (npmClient === "npm" && this.options.ci && hasNpmVersion(">=5.7.0")) {
       // never `npm ci` when hoisting

--- a/utils/npm-install/npm-install.js
+++ b/utils/npm-install/npm-install.js
@@ -14,7 +14,16 @@ module.exports.npmInstallDependencies = npmInstallDependencies;
 
 function npmInstall(
   pkg,
-  { registry, npmClient, npmClientArgs, npmGlobalStyle, mutex, stdio = "pipe", subCommand = "install" }
+  {
+    registry,
+    maxBuffer,
+    npmClient,
+    npmClientArgs,
+    npmGlobalStyle,
+    mutex,
+    stdio = "pipe",
+    subCommand = "install",
+  }
 ) {
   // build command, arguments, and options
   const opts = getNpmExecOpts(pkg, registry);
@@ -44,6 +53,9 @@ function npmInstall(
   // provide env sentinels to avoid recursive execution from scripts
   opts.env.LERNA_EXEC_PATH = pkg.location;
   opts.env.LERNA_ROOT_PATH = pkg.rootPath;
+
+  log.silly("Applying maxBuffer", [maxBuffer]);
+  opts.maxBuffer = maxBuffer;
 
   log.silly("npmInstall", [cmd, args]);
   return childProcess.exec(cmd, args, opts);


### PR DESCRIPTION
Fixes #2690

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Ensures that the `--max-buffer` argument's value reaches the intended audience (execa lib) so that on Windows OS (where I was getting max buffer size exceeded errors) it's a problem that can be worked around with the mentioned CLI arg.

## Description

1. Ensure that the CLI arg's value is extracted from the options in the bootstrap script.
2. Pass it down to the npm install utility function
3. In there ensure that it gets further passed down in the `opts` that will then make it to `execa`.

## Motivation and Context

Fixes #2690

## How Has This Been Tested?

Just manually, wasn't entirely sure how to write a test case for this because it doesn't reproduce unless you have a large project that you are trying to build on Windows in vanilla Command Prompt or Powershell (in my case anyway).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
