### PR TITLE
Disabling the advanced terminal behavior when TERM is dumb

### DIFF
--- a/core/command/index.js
+++ b/core/command/index.js
@@ -133,7 +133,7 @@ class Command {
     let progress;
 
     /* istanbul ignore next */
-    if (ci || !process.stderr.isTTY) {
+    if (ci || !process.stderr.isTTY || process.env.TERM === 'dumb') {
       log.disableColor();
       progress = false;
     } else if (!process.stdout.isTTY) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
I'm using `husky` to run some `lerna` commands in git hooks. 
I use vim-fugitive to run all git commands, which prints the commands in a `dump` terminal at the bottom,  since `lerna` is only disabling Unicode sequences for `TTY` 0 but not for `dump` `$TERM` my output has a lot of escaped Unicode sequences.
This is a similar issues between `vim-figutive` and `lint-staged`
https://github.com/tpope/vim-fugitive/issues/1446

<!--- Why is this change required? What problem does it solve? -->
`TTY` 0 only is not the only condition to disable advanced terminal behavior 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
