### PR TITLE
fix(create): fix package location problem

### DIFF
--- a/commands/create/index.js
+++ b/commands/create/index.js
@@ -56,7 +56,10 @@ class CreateCommand extends Command {
     this.dirName = scope ? name.split("/").pop() : name;
     this.pkgName = name;
     this.pkgsDir =
-      this.project.packageParentDirs.find((pd) => pd.indexOf(pkgLocation) > -1) ||
+      (pkgLocation &&
+        this.project.packageParentDirs.find(
+          (pd) => pd === path.resolve(this.project.rootPath, pkgLocation)
+        )) ||
       this.project.packageParentDirs[0];
 
     this.camelName = camelCase(this.dirName);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix package location problem in windows os

## Description
<!--- Describe your changes in detail -->

windows uses `\` to split path, if  input a packge location split by `/`,  it will always use `this.project.packageParentDirs[0]`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#2102

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Environment:
Executable | Version
-- | --
os --version | windows 10
lerna --version | 4.0.0
npm --version | 7.20.0
yarn --version | 1.22.10
node --version | v14.17.2

package.json workspaces:
```
[
    "packages/*",
    "packages/demo/*",
    "packages/lib/*"
  ]
```

run command
`lerna create demo-vue2 packages/demo`

before change:
```
PACKAGES
└─demo-vue2
    ├─lib
    └─__tests__
```

after change:
```
PACKAGES
└─demo
    └─demo-vue2
        ├─lib
        └─__tests__
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
