### PR TITLE
fix(npm-publish): Allows disabling of strict SSL checks

### DIFF
--- a/utils/npm-publish/__tests__/npm-publish.test.js
+++ b/utils/npm-publish/__tests__/npm-publish.test.js
@@ -187,6 +187,23 @@ describe("npm-publish", () => {
     expect(runLifecycle).toHaveBeenCalledTimes(2);
   });
 
+  it.each([["true"], [true], ["false"], [false]])(
+    "aliases strict-ssl to strictSSL",
+    async (strictSSLValue) => {
+      const opts = { "strict-ssl": strictSSLValue };
+
+      await npmPublish(pkg, tarFilePath, opts);
+
+      expect(publish).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          strictSSL: strictSSLValue,
+        })
+      );
+    }
+  );
+
   it("calls publish lifecycles", async () => {
     const options = expect.objectContaining({
       projectScope: "@scope",

--- a/utils/npm-publish/npm-publish.js
+++ b/utils/npm-publish/npm-publish.js
@@ -30,6 +30,8 @@ function flattenOptions(obj) {
     // eslint-disable-next-line dot-notation -- (npm v7 compat)
     defaultTag: obj["tag"] || "latest",
     dryRun: obj["dry-run"],
+    // libnpmpublish / npm-registry-fetch check strictSSL rather than strict-ssl
+    strictSSL: obj["strict-ssl"],
     ...obj,
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Alias `strict-ssl` npm configuration setting to `strictSSL` publish `opts`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Since lerna 4, `npm_config_strict_ssl=false` is not respected by the publish process. My team publishes to an internal private registry for CI builds to avoid polluting our `npm view [package] versions` unnecessarily, but we don't (currently?) have SSL working on that garbage heap.

While `strict-ssl` is resolved out of environment and npm settings in `@lerna/npm-conf`, there's nothing downstream looking for that. [`libnpmpublish`](https://www.npmjs.com/package/libnpmpublish) passes all extra arguments directly down to [`npm-registry-fetch`](https://www.npmjs.com/package/npm-registry-fetch), but `npm-registry-fetch` is reading for `strictSSL` rather than `strict-ssl`.

<!--- If it fixes an open issue, please link to the issue here. -->

closes #2942 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

I monkey patched\* the changes into a monorepo I was previously unable to publish to our private registry.

Prior to implementing the changes, adding `npm_config_strict_ssl=false` either A) prepended on the command line (`npm_config_strict_ssl=false npx lerna publish ....`) as environment; or B) applied in a root-level `.npmrc` file would have no impact. This can be validated by running the lerna command in VS Code's `JavaScript Debug Terminal` and placing a breakpoint on this line:

https://github.com/lerna/lerna/blob/a47fc294393a3e9507a8207a5a2f07648a524722/utils/npm-publish/npm-publish.js#L91

When in the un-aliased state, the `opts` / `innerOpts` will still show a `strict-ssl` value, but if you `Go to Definition` or `step into` `libnpmpublish`'s `publish` method and follow down through to `npm-registry-fetch`'s default export method, you'll find that it's passing the `opts.strictSSL` property through to [`make-fetch-happen`'s `fetch` method](https://www.youtube.com/watch?v=Pubd-spHN-0):

https://github.com/npm/npm-registry-fetch/blob/8954f61d8d703e5eb7f3d93c9b40488f8b1b62ac/index.js#L126

After implementing the alias change to `npm-publish.js` and re-running, the breakpoint will now show `strict-ssl` **AND** `strictSSL` in the `opts`. You can follow them down the function calls and see the value get passed correctly all the way to `fetch`.

I've included a unit test to validate this functionality performs the aliasing as expected.

\* _You could probably do the same with `npm link`. I just forgot to._

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
    - A number of tests failed because I am `Marty Henderson`, not `Git McGitterson`
