### PR TITLE
fix(bootstrap): preserve indentation style in package-lock.json when running bootstrap

### DIFF
--- a/utils/npm-install/__tests__/npm-install.test.js
+++ b/utils/npm-install/__tests__/npm-install.test.js
@@ -20,6 +20,7 @@ const { npmInstall, npmInstallDependencies } = require("..");
 describe("npm-install", () => {
   childProcess.exec.mockResolvedValue();
   fs.rename.mockResolvedValue();
+  fs.copy.mockResolvedValue();
   writePkg.mockResolvedValue();
 
   describe("npmInstall()", () => {
@@ -141,7 +142,7 @@ describe("npm-install", () => {
 
       await npmInstallDependencies(pkg, dependencies, {});
 
-      expect(fs.rename).toHaveBeenLastCalledWith(pkg.manifestLocation, backupManifest);
+      expect(fs.copy).toHaveBeenLastCalledWith(pkg.manifestLocation, backupManifest);
       expect(fs.renameSync).toHaveBeenLastCalledWith(backupManifest, pkg.manifestLocation);
       expect(writePkg).toHaveBeenLastCalledWith(pkg.manifestLocation, {
         name: "npm-install-deps",
@@ -463,19 +464,19 @@ describe("npm-install", () => {
       });
     });
 
-    it("rejects with rename error", async () => {
+    it("rejects with copy error", async () => {
       const pkg = new Package(
         {
-          name: "npm-install-deps-rename-error",
+          name: "npm-install-deps-copy-error",
           version: "1.0.0",
         },
-        path.normalize("/test/npm-install-deps/renameError")
+        path.normalize("/test/npm-install-deps/copyError")
       );
       const dependencies = ["I'm just here so we don't exit early"];
 
-      fs.rename.mockRejectedValueOnce(new Error("Unable to rename file"));
+      fs.copy.mockRejectedValueOnce(new Error("Unable to copy file"));
 
-      await expect(npmInstallDependencies(pkg, dependencies, {})).rejects.toThrow("Unable to rename file");
+      await expect(npmInstallDependencies(pkg, dependencies, {})).rejects.toThrow("Unable to copy file");
     });
 
     it("cleans up synchronously after writeFile error", async () => {

--- a/utils/npm-install/npm-install.js
+++ b/utils/npm-install/npm-install.js
@@ -63,7 +63,7 @@ function npmInstallDependencies(pkg, dependencies, config) {
 
   log.silly("npmInstallDependencies", "backup", pkg.manifestLocation);
 
-  return fs.rename(pkg.manifestLocation, packageJsonBkp).then(() => {
+  return fs.copy(pkg.manifestLocation, packageJsonBkp).then(() => {
     const cleanup = () => {
       log.silly("npmInstallDependencies", "cleanup", pkg.manifestLocation);
       // Need to do this one synchronously because we might be doing it on exit.


### PR DESCRIPTION
## Description

This PR fixes preservation of the indentation style used in `package.json` files by copying `package.json` files to their backup location, instead of renaming them. This works because write-pkg will use the same indentation style as the `package.json` file that it is about to overwrite.

## Motivation and Context

Running `lerna bootstrap` always converts spaces to tabs in `package-lock.json` indentations. This happens because Lerna temporarily replaces package.json with a tab-indented file before running `npm install`. It would be better if Lerna preserved the indentation style, like npm and write-pkg do.

Fixes #2845 

## How Has This Been Tested?

I ran `npm link` with my local copy and tested it in my project by running `npm link lerna` and `lerna bootstrap`. My `package-lock.json` files were saved with space indentations, as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
