### PR TITLE
fix(utils): check validity of bundledDependencies before iteration

### DIFF
--- a/utils/npm-install/npm-install.js
+++ b/utils/npm-install/npm-install.js
@@ -132,7 +132,7 @@ function transformManifest(pkg, dependencies) {
 
   ["bundledDependencies", "bundleDependencies"].forEach((depType) => {
     const collection = json[depType];
-    if (collection) {
+    if (collection instanceof Array) {
       const newCollection = [];
       for (const depName of collection) {
         if (depMap.has(depName)) {

--- a/utils/npm-install/npm-install.js
+++ b/utils/npm-install/npm-install.js
@@ -132,7 +132,7 @@ function transformManifest(pkg, dependencies) {
 
   ["bundledDependencies", "bundleDependencies"].forEach((depType) => {
     const collection = json[depType];
-    if (collection instanceof Array) {
+    if (Array.isArray(collection)) {
       const newCollection = [];
       for (const depName of collection) {
         if (depMap.has(depName)) {


### PR DESCRIPTION
check validity of bundledDependencies before iteration

## Description
According to NPM, bundledDependencies can also be a Boolean which stands for "all dependencies".

## Motivation and Context
When using BundledDependencies according to NPM instructions, lerna fails to bootstrap, showing this error:
`TypeError: collection is not iterable`

## How Has This Been Tested?
I Just added an extra safety test, so before you try to iterate a value, you should first validate that it's actually an array.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
