### PR TITLE
fix(create): fix create package location problem

### DIFF
--- a/commands/create/index.js
+++ b/commands/create/index.js
@@ -45,11 +45,13 @@ class CreateCommand extends Command {
       esModule,
       keywords,
       license,
-      loc: pkgLocation,
+      loc,
       name: pkgName,
       yes,
     } = this.options;
 
+    const pkgLocation = path.resolve(this.project.rootPath, loc);
+    
     // npm-package-arg handles all the edge-cases with scopes
     const { name, scope } = npa(pkgName);
 

--- a/commands/create/index.js
+++ b/commands/create/index.js
@@ -50,8 +50,7 @@ class CreateCommand extends Command {
       yes,
     } = this.options;
 
-    const pkgLocation = path.resolve(this.project.rootPath, loc);
-    
+    const pkgLocation = loc ? path.resolve(this.project.rootPath, loc) : "";
     // npm-package-arg handles all the edge-cases with scopes
     const { name, scope } = npa(pkgName);
 


### PR DESCRIPTION
fix package location problem when use `lerna create <pkg> [loc]`

## Description
when I use relative path to create package,  it will always use this.project.packageParentDirs[0]

## Motivation and Context
https://github.com/lerna/lerna/issues/2980

## How Has This Been Tested?
Using lerna create, the package keeps creating in apps/ directory after run command `lerna create core ./libs` .

lerna.json  
```json
"packages": [
    "apps/*",
    "libs/*"
  ]
```

before run command 
```
├── apps/
└── libs/
```


run command `lerna create core ./libs`
```
├── apps/
└── libs/
|  └── core/
|     ├── __tests__/
|     └── lib/
```

Executable | Version
-- | --
lerna --version | 4.0.0
npm --version | 7.21.1
yarn --version | 1.22.10
node --version |  v16.8.0


OS | Version
-- | --
macOS Big Sur | 11.2.3




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
