### PR TITLE
#2973: fix overall exit code of 128 if git push --atomic fails

### DIFF
--- a/commands/version/lib/git-push.js
+++ b/commands/version/lib/git-push.js
@@ -23,6 +23,10 @@ function gitPush(remote, branch, opts) {
         /atomic/.test(error.stderr) ||
         (process.env.GIT_REDIRECT_STDERR === "2>&1" && /atomic/.test(error.stdout))
       ) {
+        // childProcess.exec has propagated the error code to the process exit code --
+        // we'll clear it here as it will not propagate a success code
+        process.exitCode = 0;
+
         // --atomic is only supported in git >=2.4.0, which some crusty CI environments deem unnecessary to upgrade.
         // so let's try again without attempting to pass an option that is almost 5 years old as of this writing...
         log.warn("gitPush", error.stderr);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fixes #2973

## Description
If a crusty old CI environment is in use that does not support git push --atomic, lerna does:

git push [stuff] --atomic
if it failed due to lack of atomic support:
git push [stuff]

however the child-process module captures the error exit code from the first failed command, and sets process.exitCode equal to it, which means that the overall command always exits with an error

## How Has This Been Tested?
I have tried pushing locally to Azure DevOps which gives error 128 without this change, and success with it.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
