### PR TITLE
mention that "lerna clean" can also clean the root

### DIFF
--- a/commands/clean/README.md
+++ b/commands/clean/README.md
@@ -15,4 +15,4 @@ Remove the `node_modules` directory from all packages.
 `lerna clean` accepts all [filter flags](https://www.npmjs.com/package/@lerna/filter-options), as well as `--yes`.
 
 
-> `lerna clean` does not remove modules from the root `node_modules` directory, even if you have the `--hoist` option enabled.
+> `lerna clean` does not remove modules from the root `node_modules` directory, even if you have the `--hoist` option enabled, unless the root is also a package that you have listed in `lerna.json`. Note that making your root also be a package managed by Lerna should work in most cases, but is not fully tested, and there may be edge cases that don't work.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`lerna clean` does not remove modules from the root `node_modules` directory, even if you have the `--hoist` option enabled, unless the root is also a package that you have listed in `lerna.json`.

## Motivation and Context

For example [ Lerna clean does not remove node_modules folder at the root, #1304 ](https://github.com/lerna/lerna/issues/1304).

## How Has This Been Tested?

I have been using this approach for a while with no issues. I know that some discussions have mentioned that making the root also be a package managed by Lerna may have unexpected results, but so far I have been fine under all scenarios that I've needed Lerna for.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
