### PR TITLE
Upgrade `actions/setup-node` in CI and use built-in dependency caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,16 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           # only lint on latest node
           node-version: 14
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: 'npm'
       - run: npm -g i npm@7
       - run: npm ci
       - run: npm run ci:lint
@@ -36,15 +31,10 @@ jobs:
         script: [ 'ci:test:unit', 'ci:test:integration' ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: 'npm'
       - name: Configure git metadata
         run: |
           git config --global user.email test@example.com
@@ -63,7 +53,7 @@ jobs:
         subset: [ publish, non-publish ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           # only run windows tests on latest node
           node-version: 14


### PR DESCRIPTION
Quick PR to simplify caching in CI.

## Description
This PR upgrades `actions/setup-node` to `v2`, which includes built-in dependency caching, so the `actions/cache` steps can be removed.

## Motivation and Context
CI should use the latest versions of actions. This PR also simplifies dependency caching.

## How Has This Been Tested?
Will be tested in CI when the PR is opened.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
