### PR TITLE
2943: removes lodash.template dependency

### DIFF
--- a/core/conventional-commits/package.json
+++ b/core/conventional-commits/package.json
@@ -38,7 +38,6 @@
     "conventional-recommended-bump": "^6.1.0",
     "fs-extra": "^9.1.0",
     "get-stream": "^6.0.0",
-    "lodash.template": "^4.5.0",
     "npm-package-arg": "^8.1.0",
     "npmlog": "^4.1.2",
     "pify": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "libnpmaccess": "^4.0.1",
         "libnpmpublish": "^4.0.0",
         "load-json-file": "^6.2.0",
-        "lodash.template": "^4.5.0",
         "minimatch": "^3.0.4",
         "multimatch": "^5.0.0",
         "node-fetch": "^2.6.1",
@@ -512,7 +511,6 @@
         "conventional-recommended-bump": "^6.1.0",
         "fs-extra": "^9.1.0",
         "get-stream": "^6.0.0",
-        "lodash.template": "^4.5.0",
         "npm-package-arg": "^8.1.0",
         "npmlog": "^4.1.2",
         "pify": "^5.0.0",
@@ -8470,11 +8468,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -8484,23 +8477,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/loud-rejection": {
       "version": "1.6.0",
@@ -14989,7 +14965,6 @@
         "conventional-recommended-bump": "^6.1.0",
         "fs-extra": "^9.1.0",
         "get-stream": "^6.0.0",
-        "lodash.template": "^4.5.0",
         "npm-package-arg": "^8.1.0",
         "npmlog": "^4.1.2",
         "pify": "^5.0.0",
@@ -20422,11 +20397,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -20436,23 +20406,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
-    "lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "loud-rejection": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "libnpmaccess": "^4.0.1",
     "libnpmpublish": "^4.0.0",
     "load-json-file": "^6.2.0",
-    "lodash.template": "^4.5.0",
     "minimatch": "^3.0.4",
     "multimatch": "^5.0.0",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
# Removes vulnerable unused package ([CVE-2021-23337](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337))

## Description
https://github.com/lerna/lerna/issues/2943

## Motivation and Context
I wanted to replace `lodash.template@4.5.0` with `lodash@4.17.21` in the first place. But then I noticed that there is no `lodash` imports across the project, so I decided to remove this dependency at all.

**Important** make sure it is really unused dependency. If it is not, I'll update the PR.

## How Has This Been Tested?
I ran `npm test` and `npm run lint` in the root of monorepo

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
