### PR TITLE
Allow lerna import <repo> --dest to rename a package during import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ composer.lock
 *.swo
 
 # Project Specific
-/node_modules
+node_modules
 *.log
 /lib
 tmp

--- a/commands/import/README.md
+++ b/commands/import/README.md
@@ -49,8 +49,18 @@ $ lerna import ~/Product --flatten
 
 When importing repositories, you can specify the destination directory by the directory listed in lerna.json.
 
+The following command would import an external git repo called Product at destination ./utilities/Product
+
 ```
 $ lerna import ~/Product --dest=utilities
+```
+
+Specifying a subdirectory will rename the imported package accordingly.
+
+The following command would import an external git repo called Product at destination ./utilities/product-schema
+
+```
+$ lerna import ~/Product --dest=utilities/product-schema
 ```
 
 ### `--preserve-commit`

--- a/commands/import/__tests__/import-command.test.js
+++ b/commands/import/__tests__/import-command.test.js
@@ -352,5 +352,17 @@ describe("ImportCommand", () => {
         "--dest does not match with the package directories: core,packages"
       );
     });
+
+    it("creates a module in specified package subdir", async () => {
+      const externalDir = await initFixture("external", "Init external commit");
+      const testDir = await initFixture("multi-packages");
+
+      const packageJson = path.join(testDir, "packages", "components", "package.json");
+
+      await lernaImport(testDir)(externalDir, "--dest=packages/components");
+
+      expect(await lastCommitInDir(testDir)).toBe("Init external commit");
+      expect(await pathExists(packageJson)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
This allows a user to specify `lerna import <external-repo> --dest=package/<rename-your-package>`.

This references issue #3081

## Description
We perform a few simple steps:
1. check that the --dest provided begins with a registered package location
2. if a subdirectory is specified, use that as the target location without the git repo name

## Motivation and Context
I found it really difficult migrating an external lib to our monorepo with lerna while also preserving the git history. We had to manually rename the package which created discontinuity in the version history.

This feature gives us the ability to seamlessley migrate another repo into a monorepo under a desired package path. I think it's probably a common theme altering the package name to suit the context of your new monorepo.

## How Has This Been Tested?
I've created a unit test to verify that an external repo will import under the destination specified as `packages/components`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
