### PR TITLE
docs: add maintenance note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Important note: this project [is not actively maintained](https://github.com/lerna/lerna/issues/2703). Consider adopting an alternative toolset for monorepo management or migrating to [Lerna Lite](https://github.com/ghiscoding/lerna-lite).**
+**Important note: this project [is not actively maintained](https://github.com/lerna/lerna/issues/2703). Consider adopting an alternative toolset for monorepo management.**
 
 <p align="center">
   <img alt="Lerna" src="https://user-images.githubusercontent.com/645641/79596653-38f81200-80e1-11ea-98cd-1c6a3bb5de51.png" width="480">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Important note: this project [is not actively maintained](https://github.com/lerna/lerna/issues/2703). Consider adopting an alternative toolset for monorepo management or migrating to [Lerna Lite](https://github.com/ghiscoding/lerna-lite).**
+
 <p align="center">
   <img alt="Lerna" src="https://user-images.githubusercontent.com/645641/79596653-38f81200-80e1-11ea-98cd-1c6a3bb5de51.png" width="480">
 </p>


### PR DESCRIPTION
This PR adds a note about the state of this amazing project, as per [discussion](https://github.com/lerna/lerna/issues/2703#issuecomment-1071111156).

## Motivation and Context

This project has been struggling to keep up with the growing number of issues due to the lack of active maintainers, the size of the codebase and the dependence on package managers.  Whilst technically Lerna commands still work, the stability and the overall user experience of using Lerna alongside up-to-date versions of package managers degrades with every release of npm, yarn and/or pnpm — as is indicated by a growing number of issues.

The large user base coming here risks adopting a workflow and toolset which is not future proof.

This note merely states the facts from https://github.com/lerna/lerna/issues/2703 and aims at assisting new and existing developers at making an informed decision about investing their effort into Lerna. Please feel free to change it as you see fit.

Note: I didn't include a list of alternatives to migrate, as I am unaware of an unopinionated/curated list of monorepo management tools. The only [resource](https://monorepo.tools/) I had in mind seems a little biased to me. 