### PR TITLE
feat(version): add `from-package` bump option

### DIFF
--- a/commands/version/__tests__/version-bump.test.js
+++ b/commands/version/__tests__/version-bump.test.js
@@ -83,7 +83,7 @@ describe("version bump", () => {
 
     await expect(command).rejects.toThrow(
       "bump must be an explicit version string _or_ one of: " +
-        "'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', or 'prerelease'."
+        "'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease', or 'from-package'."
     );
   });
 

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -176,7 +176,7 @@ exports.builder = (yargs, composed) => {
     // set argv.composed for wrapped execution logic
     yargs.default("composed", composed).hide("composed");
   } else {
-    exports.addBumpPositional(yargs);
+    exports.addBumpPositional(yargs, ["from-package"]);
   }
 
   yargs.options(opts);

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -320,8 +320,14 @@ class VersionCommand extends Command {
     if (repoVersion) {
       predicate = makeGlobalVersionPredicate(repoVersion);
     } else if (increment && independentVersions) {
-      // compute potential prerelease ID for each independent update
-      predicate = (node) => semver.inc(node.version, increment, resolvePrereleaseId(node.prereleaseId));
+      // useful in Continuous integration (CI) to generate tags, changelogs
+      // and release notes from manually increased pkg.version's.
+      if (bump === "from-package") {
+        predicate = (node) => node.version;
+      } else {
+        // compute potential prerelease ID for each independent update
+        predicate = (node) => semver.inc(node.version, increment, resolvePrereleaseId(node.prereleaseId));
+      }
     } else if (increment) {
       // compute potential prerelease ID once for all fixed updates
       const prereleaseId = prereleaseIdFromVersion(this.project.version);


### PR DESCRIPTION
Thanks for this great project, we've been using Lerna w/ success over at https://github.com/muxinc/elements
Just a little thing came up with versioning and automation, below explains the issue.

## Description
This change adds a new positional parameter `from-package` to keep the versions that are already in the `version`'s of the mono-repo packages. Definitely not set on the naming, it might be confusing with the same positional parameter in the publish command. Just wanted to create this PR and see if there's interest in this functionality? Thanks

## Motivation and Context
It solves an issue where one wants to set the package versions manually locally or in a PR and then let an automated CI run the actual version command generating tags (could use --amend to reuse commit), and the changelogs and release notes. This can be used with --conventional-commits because the positional takes priority when it comes to calculating the versions.

(I guess another way to tackle this issue is to have a new CLI param that disables the recommended-bump from --conventional-commits)

## How Has This Been Tested?
Yes, I ran the test commands on Mac OS 12.3, Node 16.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
