### PR TITLE
[Test] Fix github-client tests to not use real env

### DIFF
--- a/utils/github-client/__tests__/github-client.test.js
+++ b/utils/github-client/__tests__/github-client.test.js
@@ -10,10 +10,8 @@ const { createGitHubClient, parseGitRepo } = require("../lib/github-client");
 childProcess.execSync.mockReturnValue("5.6.0");
 
 describe("createGitHubClient", () => {
-  const oldEnv = Object.assign({}, process.env);
-
-  afterEach(() => {
-    process.env = oldEnv;
+  beforeEach(() => {
+    process.env = {};
   });
 
   it("errors if no GH_TOKEN env var", () => {


### PR DESCRIPTION
While trying to setup custom deployment of Lerna I stumbled upon this funny unit test suite that was using real env instead of the mocked one which was causing it to fail in CI because it had github token variable in the env 🤦‍♂️

So here is the fix for it 👌