### PR TITLE
chore: remove references to git.io

### DIFF
--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -121,7 +121,7 @@ This option can be used to publish a [`prerelease`](http://carrot.is/coding/npm_
 
 ### `--git-head <sha>`
 
-Explicit SHA to set as [`gitHead`](https://git.io/fh7np) on manifests when packing tarballs, only allowed with [`from-package`](#bump-from-package) positional.
+Explicit SHA to set as [`gitHead`](https://github.com/npm/read-package-json/blob/67f2d8d501e2621441a8235b08d589fbeeb7dba6/read-json.js#L327) on manifests when packing tarballs, only allowed with [`from-package`](#bump-from-package) positional.
 
 For example, when publishing from AWS CodeBuild (where `git` is not available),
 you could use this option to pass the appropriate [environment variable](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html) to use for this package metadata:

--- a/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/config-builder-preset.js
+++ b/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/config-builder-preset.js
@@ -1,11 +1,11 @@
 "use strict";
 
-// https://git.io/vx5iq (conventional-changelog-angular/conventional-recommended-bump.js, etc)
+// https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
 const parserOpts = require("./parser-opts");
 const writerOpts = require("./writer-opts");
 const whatBump = require("./what-bump");
 
-// https://git.io/fhyKK
+// https://github.com/conventional-changelog/conventional-changelog/blob/943542f3b2342bb5933d84847fb19b727c607df0/packages/conventional-changelog-ember/index.js#L10
 module.exports = presetOpts;
 
 function presetOpts(param) {

--- a/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/legacy-callback-preset.js
+++ b/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/legacy-callback-preset.js
@@ -1,11 +1,11 @@
 "use strict";
 
-// https://git.io/vx5iq (conventional-changelog-angular/conventional-recommended-bump.js, etc)
+// https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
 const parserOpts = require("./parser-opts");
 const writerOpts = require("./writer-opts");
 const whatBump = require("./what-bump");
 
-// https://git.io/fhyKK
+// https://github.com/conventional-changelog/conventional-changelog/blob/943542f3b2342bb5933d84847fb19b727c607df0/packages/conventional-changelog-ember/index.js#L10
 module.exports = presetOpts;
 
 function presetOpts(cb) {

--- a/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/local-preset.js
+++ b/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/local-preset.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// https://git.io/vx5iq (conventional-changelog-angular/conventional-recommended-bump.js, etc)
+// https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
 const parserOpts = require("./parser-opts");
 const writerOpts = require("./writer-opts");
 const whatBump = require("./what-bump");

--- a/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/null-preset.js
+++ b/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/null-preset.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// https://git.io/vx5iq (conventional-changelog-angular/conventional-recommended-bump.js, etc)
+// https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
 const parserOpts = require("./parser-opts");
 const writerOpts = require("./writer-opts");
 const whatBump = require("./null-what-bump");

--- a/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/old-api-preset.js
+++ b/core/conventional-commits/__tests__/__fixtures__/fixed/scripts/old-api-preset.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// https://git.io/vx5iq (conventional-changelog-angular/conventional-recommended-bump.js, etc)
+// https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
 const parserOpts = require("./parser-opts");
 const writerOpts = require("./writer-opts");
 const whatBump = require("./what-bump");

--- a/core/otplease/otplease.js
+++ b/core/otplease/otplease.js
@@ -104,7 +104,7 @@ function attempt(fn, opts, otpCache) {
  * @returns {Promise<string>}
  */
 function getOneTimePassword(message = "This operation requires a one-time password:") {
-  // Logic taken from npm internals: https://git.io/fNoMe
+  // Logic taken from npm internals: https://github.com/npm/cli/blob/4f801d8a476f7ca52b0f182bf4e17a80db12b4e2/lib/utils/read-user-info.js#L21-L35
   return promptTextInput(message, {
     filter: (otp) => otp.replace(/\s+/g, ""),
     validate: (otp) =>


### PR DESCRIPTION
It appears git.io was a URL shortener service used in a few places within the workspace.

An automated issue #3116 flagged up that the service is being discontinued, so this PR simply expands the shortened URLs to their original forms.

Closes #3116