### PR TITLE
fix(bootstrap): reject-cycles when using workspaces

### DIFF
--- a/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/.yarnrc
+++ b/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/.yarnrc
@@ -1,0 +1,1 @@
+workspaces-experimental true

--- a/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/lerna.json
+++ b/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/lerna.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "npmClient": "yarn",
+  "useWorkspaces": true
+}

--- a/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/package.json
+++ b/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "root",
+  "private": true,
+  "workspaces": [
+    "workspaces/*"
+  ]
+}

--- a/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/workspaces/package-1/package.json
+++ b/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/workspaces/package-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "foo": "^1.0.0"
+  }
+}

--- a/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/workspaces/package-2/package.json
+++ b/commands/bootstrap/__tests__/__fixtures__/yarn-workspaces-cyclic/workspaces/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-2": "^1.0.0"
+  }
+}

--- a/commands/bootstrap/__tests__/bootstrap-command.test.js
+++ b/commands/bootstrap/__tests__/bootstrap-command.test.js
@@ -656,6 +656,12 @@ describe("BootstrapCommand", () => {
 
       await expect(command).rejects.toThrow("Dependency cycles detected, you should fix these!");
     });
+    it("should throw an error with --reject-cycles when using yarn-workspaces", async () => {
+      const testDir = await initFixture("yarn-workspaces-cyclic");
+      const command = lernaBootstrap(testDir)("--reject-cycles");
+
+      await expect(command).rejects.toThrow("Dependency cycles detected, you should fix these!");
+    });
   });
 
   it("succeeds in repositories with zero packages", async () => {

--- a/commands/bootstrap/index.js
+++ b/commands/bootstrap/index.js
@@ -185,6 +185,9 @@ class BootstrapCommand extends Command {
 
   execute() {
     if (this.options.useWorkspaces || this.rootHasLocalFileDependencies()) {
+      if (this.options.rejectCycles) {
+        this.packageGraph.collapseCycles({ rejectCycles: this.options.rejectCycles });
+      }
       return this.installRootPackageOnly();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
when the --reject-cycles flag is set and the repo is using workspaces,
run `collapseCycles()` to detect cycles before installing root package dependencies.

## Motivation and Context
Currently the --reject-cycles flag does not have any effect when using workspaces.
Without workspaces it is evaluated during `runLifecycleInPackages()`, but as far as I can tell this code-path is never reached with workspaces.
This would also fix the open issue [2776](https://github.com/lerna/lerna/issues/2776)

## How Has This Been Tested?

added a test-case including fixture for yarn workspace with cyclic dependency
for local testing I have published to verdaccio with `e2e:local-publish`.
output before:

```
❯ npx lerna bootstrap --reject-cycles
lerna notice cli v5.1.1
lerna info bootstrap root only

up to date, audited 604 packages in 754ms

52 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

output after my change:
```
❯ npx lerna bootstrap --reject-cycles
lerna notice cli v999.9.20
lerna ERR! ECYCLE Dependency cycles detected, you should fix these!
lerna ERR! ECYCLE one -> two -> one
```

with this Lerna config:
```
❯ cat lerna.json
{
  "packages": [
    "packages/*"
  ],
  "version": "0.0.0",
  "useWorkspaces": true
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (I had issues with some snapshot tests locally that seem unrelated to my changes)

