### PR TITLE
chore(e2e): Lerna run e2e tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Chore (change that has absolutely no effect on users)
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Configure git metadata
+        run: |
+          git config --global user.email test@example.com
+          git config --global user.name "Tester McPerson"
+
       - name: Install primary node version (see volta config in package.json) and dependencies
         uses: ./.github/actions/install-node-and-dependencies
 

--- a/e2e/lerna-init/lerna-init.spec.ts
+++ b/e2e/lerna-init/lerna-init.spec.ts
@@ -1,4 +1,4 @@
-import { createEmptyDirectoryForWorkspace, readFile, removeWorkspace, runLernaInitAsync } from "../utils";
+import { createEmptyDirectoryForWorkspace, readFile, removeWorkspace, runCLI } from "../utils";
 
 describe("lerna init", () => {
   afterEach(() => removeWorkspace());
@@ -6,7 +6,7 @@ describe("lerna init", () => {
   it("should initialize a lerna workspace", async () => {
     createEmptyDirectoryForWorkspace("lerna-init-test");
 
-    const output = await runLernaInitAsync();
+    const output = await runCLI("init");
 
     expect(output.stderr).toMatchInlineSnapshot(`
       "lerna notice cli v999.9.9-e2e.0
@@ -44,7 +44,7 @@ describe("lerna init", () => {
     it("should initialize a lerna workspace in independent versioning mode", async () => {
       createEmptyDirectoryForWorkspace("lerna-init-test");
 
-      const output = await runLernaInitAsync("--independent");
+      const output = await runCLI("init --independent");
 
       expect(output.stderr).toMatchInlineSnapshot(`
         "lerna notice cli v999.9.9-e2e.0
@@ -83,7 +83,7 @@ describe("lerna init", () => {
     it("should initialize a lerna workspace with exact package version enforcement", async () => {
       createEmptyDirectoryForWorkspace("lerna-init-test");
 
-      const output = await runLernaInitAsync("--exact");
+      const output = await runCLI("init --exact");
 
       expect(output.stderr).toMatchInlineSnapshot(`
         "lerna notice cli v999.9.9-e2e.0
@@ -127,7 +127,7 @@ describe("lerna init", () => {
     it("should initialize a lerna workspace in independent versioning mode with exact package version enforcement", async () => {
       createEmptyDirectoryForWorkspace("lerna-init-test");
 
-      const output = await runLernaInitAsync("--independent --exact");
+      const output = await runCLI("init --independent --exact");
 
       expect(output.stderr).toMatchInlineSnapshot(`
         "lerna notice cli v999.9.9-e2e.0

--- a/e2e/lerna-run/lerna-run.spec.ts
+++ b/e2e/lerna-run/lerna-run.spec.ts
@@ -1,11 +1,10 @@
 import { existsSync } from "fs-extra";
 import {
   addNxToWorkspace,
-  addScriptsToPackageAsync,
+  addScriptsToPackage,
   createEmptyDirectoryForWorkspace,
   removeWorkspace,
-  runLernaCommandAsync,
-  runLernaInitAsync,
+  runCLI,
   tmpProjPath,
 } from "../utils";
 
@@ -26,22 +25,22 @@ describe("lerna run", () => {
 
   it("should run script on all child packages", async () => {
     createEmptyDirectoryForWorkspace("lerna-run-test");
-    await runLernaInitAsync();
+    await runCLI("init");
 
-    await runLernaCommandAsync("create package-1");
-    await addScriptsToPackageAsync("package-1", {
+    await runCLI("create package-1");
+    await addScriptsToPackage("package-1", {
       "print-name": "echo test-package-1",
     });
-    await runLernaCommandAsync("create package-2");
-    await addScriptsToPackageAsync("package-2", {
+    await runCLI("create package-2");
+    await addScriptsToPackage("package-2", {
       "print-name": "echo test-package-2",
     });
-    await runLernaCommandAsync("create package-3");
-    await addScriptsToPackageAsync("package-3", {
+    await runCLI("create package-3");
+    await addScriptsToPackage("package-3", {
       "print-name": "echo test-package-3",
     });
 
-    const output = await runLernaCommandAsync("run print-name -- --silent");
+    const output = await runCLI("run print-name -- --silent");
 
     expect(output.combinedOutput).toMatchInlineSnapshot(`
       test-package-X
@@ -63,22 +62,22 @@ describe("lerna run", () => {
   describe("--stream", () => {
     it("should run script on all child packages with package name prefixes", async () => {
       createEmptyDirectoryForWorkspace("lerna-run-test");
-      await runLernaInitAsync();
+      await runCLI("init");
 
-      await runLernaCommandAsync("create package-1");
-      await addScriptsToPackageAsync("package-1", {
+      await runCLI("create package-1");
+      await addScriptsToPackage("package-1", {
         "print-name": "echo test-package-1",
       });
-      await runLernaCommandAsync("create package-2");
-      await addScriptsToPackageAsync("package-2", {
+      await runCLI("create package-2");
+      await addScriptsToPackage("package-2", {
         "print-name": "echo test-package-2",
       });
-      await runLernaCommandAsync("create package-3");
-      await addScriptsToPackageAsync("package-3", {
+      await runCLI("create package-3");
+      await addScriptsToPackage("package-3", {
         "print-name": "echo test-package-3",
       });
 
-      const output = await runLernaCommandAsync("run print-name --stream -- --silent");
+      const output = await runCLI("run print-name --stream -- --silent");
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
         package-X: test-package-X
@@ -98,22 +97,22 @@ describe("lerna run", () => {
   describe("--parallel", () => {
     it("should run script on all child packages with package name prefixes", async () => {
       createEmptyDirectoryForWorkspace("lerna-run-test");
-      await runLernaInitAsync();
+      await runCLI("init");
 
-      await runLernaCommandAsync("create package-1");
-      await addScriptsToPackageAsync("package-1", {
+      await runCLI("create package-1");
+      await addScriptsToPackage("package-1", {
         "print-name": "echo test-package-1",
       });
-      await runLernaCommandAsync("create package-2");
-      await addScriptsToPackageAsync("package-2", {
+      await runCLI("create package-2");
+      await addScriptsToPackage("package-2", {
         "print-name": "echo test-package-2",
       });
-      await runLernaCommandAsync("create package-3");
-      await addScriptsToPackageAsync("package-3", {
+      await runCLI("create package-3");
+      await addScriptsToPackage("package-3", {
         "print-name": "echo test-package-3",
       });
 
-      const output = await runLernaCommandAsync("run print-name --parallel -- --silent");
+      const output = await runCLI("run print-name --parallel -- --silent");
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
         package-X: test-package-X
@@ -133,22 +132,22 @@ describe("lerna run", () => {
   describe("--no-bail", () => {
     it("should run script on all child packages and throw, but not abort, on script failure", async () => {
       createEmptyDirectoryForWorkspace("lerna-run-test");
-      await runLernaInitAsync();
+      await runCLI("init");
 
-      await runLernaCommandAsync("create package-1");
-      await addScriptsToPackageAsync("package-1", {
+      await runCLI("create package-1");
+      await addScriptsToPackage("package-1", {
         "print-name": "echo test-package-1",
       });
-      await runLernaCommandAsync("create package-2");
-      await addScriptsToPackageAsync("package-2", {
+      await runCLI("create package-2");
+      await addScriptsToPackage("package-2", {
         "print-name": "echo test-package-2",
       });
-      await runLernaCommandAsync("create package-3");
-      await addScriptsToPackageAsync("package-3", {
+      await runCLI("create package-3");
+      await addScriptsToPackage("package-3", {
         "print-name": "exit 100",
       });
 
-      await expect(runLernaCommandAsync("run print-name --no-bail -- --silent")).rejects
+      await expect(runCLI("run print-name --no-bail -- --silent")).rejects
         .toThrowErrorMatchingInlineSnapshot(`
               Command failed: npx --registry=http://localhost:4872/ --yes lerna@999.9.9-e2e.0 run print-name --no-bail -- --silent
               lerna notice cli v999.9.9-e2e.0
@@ -170,22 +169,22 @@ describe("lerna run", () => {
     describe("--parallel", () => {
       it("should run script on all child packages and suppress package name prefixes", async () => {
         createEmptyDirectoryForWorkspace("lerna-run-test");
-        await runLernaInitAsync();
+        await runCLI("init");
 
-        await runLernaCommandAsync("create package-1");
-        await addScriptsToPackageAsync("package-1", {
+        await runCLI("create package-1");
+        await addScriptsToPackage("package-1", {
           "print-name": "echo test-package-1",
         });
-        await runLernaCommandAsync("create package-2");
-        await addScriptsToPackageAsync("package-2", {
+        await runCLI("create package-2");
+        await addScriptsToPackage("package-2", {
           "print-name": "echo test-package-2",
         });
-        await runLernaCommandAsync("create package-3");
-        await addScriptsToPackageAsync("package-3", {
+        await runCLI("create package-3");
+        await addScriptsToPackage("package-3", {
           "print-name": "echo test-package-3",
         });
 
-        const output = await runLernaCommandAsync("run print-name --no-prefix --parallel -- --silent");
+        const output = await runCLI("run print-name --no-prefix --parallel -- --silent");
 
         expect(output.combinedOutput).toMatchInlineSnapshot(`
           test-package-X
@@ -205,22 +204,22 @@ describe("lerna run", () => {
     describe("--stream", () => {
       it("should run script on all child packages and suppress package name prefixes", async () => {
         createEmptyDirectoryForWorkspace("lerna-run-test");
-        await runLernaInitAsync();
+        await runCLI("init");
 
-        await runLernaCommandAsync("create package-1");
-        await addScriptsToPackageAsync("package-1", {
+        await runCLI("create package-1");
+        await addScriptsToPackage("package-1", {
           "print-name": "echo test-package-1",
         });
-        await runLernaCommandAsync("create package-2");
-        await addScriptsToPackageAsync("package-2", {
+        await runCLI("create package-2");
+        await addScriptsToPackage("package-2", {
           "print-name": "echo test-package-2",
         });
-        await runLernaCommandAsync("create package-3");
-        await addScriptsToPackageAsync("package-3", {
+        await runCLI("create package-3");
+        await addScriptsToPackage("package-3", {
           "print-name": "echo test-package-3",
         });
 
-        const output = await runLernaCommandAsync("run print-name --no-prefix --stream -- --silent");
+        const output = await runCLI("run print-name --no-prefix --stream -- --silent");
 
         expect(output.combinedOutput).toMatchInlineSnapshot(`
           test-package-X
@@ -241,22 +240,22 @@ describe("lerna run", () => {
   describe("--profile", () => {
     it("should run script on all child packages and create a performance profile", async () => {
       createEmptyDirectoryForWorkspace("lerna-run-test");
-      await runLernaInitAsync();
+      await runCLI("init");
 
-      await runLernaCommandAsync("create package-1");
-      await addScriptsToPackageAsync("package-1", {
+      await runCLI("create package-1");
+      await addScriptsToPackage("package-1", {
         "print-name": "echo test-package-1",
       });
-      await runLernaCommandAsync("create package-2");
-      await addScriptsToPackageAsync("package-2", {
+      await runCLI("create package-2");
+      await addScriptsToPackage("package-2", {
         "print-name": "echo test-package-2",
       });
-      await runLernaCommandAsync("create package-3");
-      await addScriptsToPackageAsync("package-3", {
+      await runCLI("create package-3");
+      await addScriptsToPackage("package-3", {
         "print-name": "echo test-package-3",
       });
 
-      const output = await runLernaCommandAsync("run print-name --profile -- --silent");
+      const output = await runCLI("run print-name --profile -- --silent");
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
         test-package-X
@@ -286,24 +285,22 @@ describe("lerna run", () => {
   describe("--profile --profile-location", () => {
     it("should run script on all child packages and create a performance profile at provided location", async () => {
       createEmptyDirectoryForWorkspace("lerna-run-test");
-      await runLernaInitAsync();
+      await runCLI("init");
 
-      await runLernaCommandAsync("create package-1");
-      await addScriptsToPackageAsync("package-1", {
+      await runCLI("create package-1");
+      await addScriptsToPackage("package-1", {
         "print-name": "echo test-package-1",
       });
-      await runLernaCommandAsync("create package-2");
-      await addScriptsToPackageAsync("package-2", {
+      await runCLI("create package-2");
+      await addScriptsToPackage("package-2", {
         "print-name": "echo test-package-2",
       });
-      await runLernaCommandAsync("create package-3");
-      await addScriptsToPackageAsync("package-3", {
+      await runCLI("create package-3");
+      await addScriptsToPackage("package-3", {
         "print-name": "echo test-package-3",
       });
 
-      const output = await runLernaCommandAsync(
-        `run print-name --profile --profile-location=profiles -- --silent`
-      );
+      const output = await runCLI(`run print-name --profile --profile-location=profiles -- --silent`);
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
         test-package-X
@@ -333,22 +330,22 @@ describe("lerna run", () => {
   describe("--npm-client", () => {
     it("should run script on all child packages using yarn", async () => {
       createEmptyDirectoryForWorkspace("lerna-run-test");
-      await runLernaInitAsync();
+      await runCLI("init");
 
-      await runLernaCommandAsync("create package-1");
-      await addScriptsToPackageAsync("package-1", {
+      await runCLI("create package-1");
+      await addScriptsToPackage("package-1", {
         "print-name": "echo test-package-1",
       });
-      await runLernaCommandAsync("create package-2");
-      await addScriptsToPackageAsync("package-2", {
+      await runCLI("create package-2");
+      await addScriptsToPackage("package-2", {
         "print-name": "echo test-package-2",
       });
-      await runLernaCommandAsync("create package-3");
-      await addScriptsToPackageAsync("package-3", {
+      await runCLI("create package-3");
+      await addScriptsToPackage("package-3", {
         "print-name": "echo test-package-3",
       });
 
-      const output = await runLernaCommandAsync(`run print-name --npm-client=yarn`);
+      const output = await runCLI(`run print-name --npm-client=yarn`);
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
         yarn run v1.22.18
@@ -378,22 +375,22 @@ describe("lerna run", () => {
 
     it("should run script on all child packages using npm", async () => {
       createEmptyDirectoryForWorkspace("lerna-run-test");
-      await runLernaInitAsync();
+      await runCLI("init");
 
-      await runLernaCommandAsync("create package-1");
-      await addScriptsToPackageAsync("package-1", {
+      await runCLI("create package-1");
+      await addScriptsToPackage("package-1", {
         "print-name": "echo test-package-1",
       });
-      await runLernaCommandAsync("create package-2");
-      await addScriptsToPackageAsync("package-2", {
+      await runCLI("create package-2");
+      await addScriptsToPackage("package-2", {
         "print-name": "echo test-package-2",
       });
-      await runLernaCommandAsync("create package-3");
-      await addScriptsToPackageAsync("package-3", {
+      await runCLI("create package-3");
+      await addScriptsToPackage("package-3", {
         "print-name": "echo test-package-3",
       });
 
-      const output = await runLernaCommandAsync(`run print-name --npm-client=npm`);
+      const output = await runCLI(`run print-name --npm-client=npm`);
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
 
@@ -428,23 +425,23 @@ describe("lerna run", () => {
   describe("useNx", () => {
     it("should run script on all child packages using nx", async () => {
       createEmptyDirectoryForWorkspace("lerna-run-test");
-      await runLernaInitAsync();
+      await runCLI("init");
       await addNxToWorkspace();
 
-      await runLernaCommandAsync("create package-1");
-      await addScriptsToPackageAsync("package-1", {
+      await runCLI("create package-1");
+      await addScriptsToPackage("package-1", {
         "print-name": "echo test-package-1",
       });
-      await runLernaCommandAsync("create package-2");
-      await addScriptsToPackageAsync("package-2", {
+      await runCLI("create package-2");
+      await addScriptsToPackage("package-2", {
         "print-name": "echo test-package-2",
       });
-      await runLernaCommandAsync("create package-3");
-      await addScriptsToPackageAsync("package-3", {
+      await runCLI("create package-3");
+      await addScriptsToPackage("package-3", {
         "print-name": "echo test-package-3",
       });
 
-      const output = await runLernaCommandAsync(`run print-name`);
+      const output = await runCLI(`run print-name`);
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
 

--- a/e2e/lerna-run/lerna-run.spec.ts
+++ b/e2e/lerna-run/lerna-run.spec.ts
@@ -13,7 +13,9 @@ expect.addSnapshotSerializer({
     return str
       .replaceAll(/package-\d/g, "package-X")
       .replaceAll(/\d\.(\d{1}|\d{2})s/g, "X.Xs")
-      .replaceAll(/Lerna-Profile-\d{8}T\d{6}\.json/g, "Lerna-Profile-XXXXXXXXTXXXXXX.json");
+      .replaceAll(/Lerna-Profile-\d{8}T\d{6}\.json/g, "Lerna-Profile-XXXXXXXXTXXXXXX.json")
+      .replaceAll(/\/private\/tmp\//g, "/tmp/")
+      .replaceAll(/lerna info ci enabled\n/g, "");
   },
   test(val) {
     return val != null && typeof val === "string";
@@ -266,7 +268,7 @@ describe("lerna run", () => {
         lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
         lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
         lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
-        lerna info profiler Performance profile saved to /private/tmp/lerna-e2e/lerna-run-test/Lerna-Profile-XXXXXXXXTXXXXXX.json
+        lerna info profiler Performance profile saved to /tmp/lerna-e2e/lerna-run-test/Lerna-Profile-XXXXXXXXTXXXXXX.json
         lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
         lerna success - package-X
         lerna success - package-X
@@ -311,7 +313,7 @@ describe("lerna run", () => {
         lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
         lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
         lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
-        lerna info profiler Performance profile saved to /private/tmp/lerna-e2e/lerna-run-test/profiles/Lerna-Profile-XXXXXXXXTXXXXXX.json
+        lerna info profiler Performance profile saved to /tmp/lerna-e2e/lerna-run-test/profiles/Lerna-Profile-XXXXXXXXTXXXXXX.json
         lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
         lerna success - package-X
         lerna success - package-X
@@ -485,6 +487,17 @@ test-package-X
 lerna notice cli v999.9.9-e2e.0
 
 `);
+    });
+  });
+
+  describe("--ci", () => {
+    it("should log that ci is enabled", async () => {
+      createEmptyDirectoryForWorkspace("lerna-run-test");
+      await runCLI("init");
+
+      const output = await runCLI(`run print-name --ci`);
+
+      expect(output.combinedOutput).toContain("lerna info ci enabled");
     });
   });
 });

--- a/e2e/lerna-run/lerna-run.spec.ts
+++ b/e2e/lerna-run/lerna-run.spec.ts
@@ -1,0 +1,68 @@
+import {
+  addScriptsToPackageAsync,
+  createEmptyDirectoryForWorkspace,
+  removeWorkspace,
+  runLernaCommandAsync,
+  runLernaInitAsync,
+} from "../utils";
+
+expect.addSnapshotSerializer({
+  serialize(str) {
+    return str.replaceAll(/package-\d/g, "package-X").replaceAll(/\d\.\ds/g, "X.Xs");
+  },
+  test(val) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna run", () => {
+  afterEach(() => removeWorkspace());
+
+  it("should run script on all child packages", async () => {
+    createEmptyDirectoryForWorkspace("lerna-run-test");
+    await runLernaInitAsync();
+
+    await runLernaCommandAsync("create package-1");
+    await addScriptsToPackageAsync("package-1", {
+      "print-name": "echo test-package-1",
+    });
+    await runLernaCommandAsync("create package-2");
+    await addScriptsToPackageAsync("package-2", {
+      "print-name": "echo test-package-2",
+    });
+    await runLernaCommandAsync("create package-3");
+    await addScriptsToPackageAsync("package-3", {
+      "print-name": "echo test-package-3",
+    });
+
+    const output = await runLernaCommandAsync("run print-name");
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+      > package-X@0.0.0 print-name
+      > echo test-package-X
+
+      test-package-X
+
+      > package-X@0.0.0 print-name
+      > echo test-package-X
+
+      test-package-X
+
+      > package-X@0.0.0 print-name
+      > echo test-package-X
+
+      test-package-X
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Executing command in 3 packages: "npm run print-name"
+      lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+      lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+      lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+      lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
+      lerna success - package-X
+      lerna success - package-X
+      lerna success - package-X
+
+    `);
+  });
+});

--- a/e2e/lerna-run/lerna-run.spec.ts
+++ b/e2e/lerna-run/lerna-run.spec.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "fs-extra";
 import {
+  addNxToWorkspace,
   addScriptsToPackageAsync,
   createEmptyDirectoryForWorkspace,
   removeWorkspace,
@@ -421,6 +422,72 @@ describe("lerna run", () => {
         lerna success - package-X
 
       `);
+    });
+  });
+
+  describe("useNx", () => {
+    it("should run script on all child packages using nx", async () => {
+      createEmptyDirectoryForWorkspace("lerna-run-test");
+      await runLernaInitAsync();
+      await addNxToWorkspace();
+
+      await runLernaCommandAsync("create package-1");
+      await addScriptsToPackageAsync("package-1", {
+        "print-name": "echo test-package-1",
+      });
+      await runLernaCommandAsync("create package-2");
+      await addScriptsToPackageAsync("package-2", {
+        "print-name": "echo test-package-2",
+      });
+      await runLernaCommandAsync("create package-3");
+      await addScriptsToPackageAsync("package-3", {
+        "print-name": "echo test-package-3",
+      });
+
+      const output = await runLernaCommandAsync(`run print-name`);
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+
+`);
     });
   });
 });

--- a/e2e/lerna-run/lerna-run.spec.ts
+++ b/e2e/lerna-run/lerna-run.spec.ts
@@ -1,14 +1,19 @@
+import { existsSync } from "fs-extra";
 import {
   addScriptsToPackageAsync,
   createEmptyDirectoryForWorkspace,
   removeWorkspace,
   runLernaCommandAsync,
   runLernaInitAsync,
+  tmpProjPath,
 } from "../utils";
 
 expect.addSnapshotSerializer({
   serialize(str) {
-    return str.replaceAll(/package-\d/g, "package-X").replaceAll(/\d\.\ds/g, "X.Xs");
+    return str
+      .replaceAll(/package-\d/g, "package-X")
+      .replaceAll(/\d\.\ds/g, "X.Xs")
+      .replaceAll(/Lerna-Profile-\d{8}T\d{6}\.json/g, "Lerna-Profile-XXXXXXXXTXXXXXX.json");
   },
   test(val) {
     return val != null && typeof val === "string";
@@ -52,5 +57,275 @@ describe("lerna run", () => {
       lerna success - package-X
 
     `);
+  });
+
+  describe("--stream", () => {
+    it("should run script on all child packages with package name prefixes", async () => {
+      createEmptyDirectoryForWorkspace("lerna-run-test");
+      await runLernaInitAsync();
+
+      await runLernaCommandAsync("create package-1");
+      await addScriptsToPackageAsync("package-1", {
+        "print-name": "echo test-package-1",
+      });
+      await runLernaCommandAsync("create package-2");
+      await addScriptsToPackageAsync("package-2", {
+        "print-name": "echo test-package-2",
+      });
+      await runLernaCommandAsync("create package-3");
+      await addScriptsToPackageAsync("package-3", {
+        "print-name": "echo test-package-3",
+      });
+
+      const output = await runLernaCommandAsync("run print-name --stream -- --silent");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        package-X: test-package-X
+        package-X: test-package-X
+        package-X: test-package-X
+        lerna notice cli v999.9.9-e2e.0
+        lerna info Executing command in 3 packages: "npm run print-name --silent"
+        lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
+        lerna success - package-X
+        lerna success - package-X
+        lerna success - package-X
+
+      `);
+    });
+  });
+
+  describe("--parallel", () => {
+    it("should run script on all child packages with package name prefixes", async () => {
+      createEmptyDirectoryForWorkspace("lerna-run-test");
+      await runLernaInitAsync();
+
+      await runLernaCommandAsync("create package-1");
+      await addScriptsToPackageAsync("package-1", {
+        "print-name": "echo test-package-1",
+      });
+      await runLernaCommandAsync("create package-2");
+      await addScriptsToPackageAsync("package-2", {
+        "print-name": "echo test-package-2",
+      });
+      await runLernaCommandAsync("create package-3");
+      await addScriptsToPackageAsync("package-3", {
+        "print-name": "echo test-package-3",
+      });
+
+      const output = await runLernaCommandAsync("run print-name --parallel -- --silent");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        package-X: test-package-X
+        package-X: test-package-X
+        package-X: test-package-X
+        lerna notice cli v999.9.9-e2e.0
+        lerna info Executing command in 3 packages: "npm run print-name --silent"
+        lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
+        lerna success - package-X
+        lerna success - package-X
+        lerna success - package-X
+
+      `);
+    });
+  });
+
+  describe("--no-bail", () => {
+    it("should run script on all child packages and throw, but not abort, on script failure", async () => {
+      createEmptyDirectoryForWorkspace("lerna-run-test");
+      await runLernaInitAsync();
+
+      await runLernaCommandAsync("create package-1");
+      await addScriptsToPackageAsync("package-1", {
+        "print-name": "echo test-package-1",
+      });
+      await runLernaCommandAsync("create package-2");
+      await addScriptsToPackageAsync("package-2", {
+        "print-name": "echo test-package-2",
+      });
+      await runLernaCommandAsync("create package-3");
+      await addScriptsToPackageAsync("package-3", {
+        "print-name": "exit 100",
+      });
+
+      await expect(runLernaCommandAsync("run print-name --no-bail -- --silent")).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+              Command failed: npx --registry=http://localhost:4872/ --yes lerna@999.9.9-e2e.0 run print-name --no-bail -- --silent
+              lerna notice cli v999.9.9-e2e.0
+              lerna info Executing command in 3 packages: "npm run print-name --silent"
+              lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+              lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+              lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+              lerna ERR! Received non-zero exit code 100 during execution
+              lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
+              lerna success - package-X
+              lerna success - package-X
+              lerna success - package-X
+
+            `);
+    });
+  });
+
+  describe("--no-prefix", () => {
+    describe("--parallel", () => {
+      it("should run script on all child packages and suppress package name prefixes", async () => {
+        createEmptyDirectoryForWorkspace("lerna-run-test");
+        await runLernaInitAsync();
+
+        await runLernaCommandAsync("create package-1");
+        await addScriptsToPackageAsync("package-1", {
+          "print-name": "echo test-package-1",
+        });
+        await runLernaCommandAsync("create package-2");
+        await addScriptsToPackageAsync("package-2", {
+          "print-name": "echo test-package-2",
+        });
+        await runLernaCommandAsync("create package-3");
+        await addScriptsToPackageAsync("package-3", {
+          "print-name": "echo test-package-3",
+        });
+
+        const output = await runLernaCommandAsync("run print-name --no-prefix --parallel -- --silent");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          test-package-X
+          test-package-X
+          test-package-X
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Executing command in 3 packages: "npm run print-name --silent"
+          lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
+          lerna success - package-X
+          lerna success - package-X
+          lerna success - package-X
+
+        `);
+      });
+    });
+
+    describe("--stream", () => {
+      it("should run script on all child packages and suppress package name prefixes", async () => {
+        createEmptyDirectoryForWorkspace("lerna-run-test");
+        await runLernaInitAsync();
+
+        await runLernaCommandAsync("create package-1");
+        await addScriptsToPackageAsync("package-1", {
+          "print-name": "echo test-package-1",
+        });
+        await runLernaCommandAsync("create package-2");
+        await addScriptsToPackageAsync("package-2", {
+          "print-name": "echo test-package-2",
+        });
+        await runLernaCommandAsync("create package-3");
+        await addScriptsToPackageAsync("package-3", {
+          "print-name": "echo test-package-3",
+        });
+
+        const output = await runLernaCommandAsync("run print-name --no-prefix --stream -- --silent");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          test-package-X
+          test-package-X
+          test-package-X
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Executing command in 3 packages: "npm run print-name --silent"
+          lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
+          lerna success - package-X
+          lerna success - package-X
+          lerna success - package-X
+
+        `);
+      });
+    });
+  });
+
+  describe("--profile", () => {
+    it("should run script on all child packages and create a performance profile", async () => {
+      createEmptyDirectoryForWorkspace("lerna-run-test");
+      await runLernaInitAsync();
+
+      await runLernaCommandAsync("create package-1");
+      await addScriptsToPackageAsync("package-1", {
+        "print-name": "echo test-package-1",
+      });
+      await runLernaCommandAsync("create package-2");
+      await addScriptsToPackageAsync("package-2", {
+        "print-name": "echo test-package-2",
+      });
+      await runLernaCommandAsync("create package-3");
+      await addScriptsToPackageAsync("package-3", {
+        "print-name": "echo test-package-3",
+      });
+
+      const output = await runLernaCommandAsync("run print-name --profile -- --silent");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        test-package-X
+        test-package-X
+        test-package-X
+        lerna notice cli v999.9.9-e2e.0
+        lerna info Executing command in 3 packages: "npm run print-name --silent"
+        lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+        lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+        lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+        lerna info profiler Performance profile saved to /private/tmp/lerna-e2e/lerna-run-test/Lerna-Profile-XXXXXXXXTXXXXXX.json
+        lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
+        lerna success - package-X
+        lerna success - package-X
+        lerna success - package-X
+
+      `);
+
+      const lernaProfileSavedOutputLine = output.combinedOutput.split("\n")[8];
+
+      const lernaProfileFileName = lernaProfileSavedOutputLine.split("lerna-run-test/")[1];
+
+      expect(existsSync(tmpProjPath(lernaProfileFileName))).toBe(true);
+    });
+  });
+
+  describe("--profile --profile-location", () => {
+    it("should run script on all child packages and create a performance profile at provided location", async () => {
+      createEmptyDirectoryForWorkspace("lerna-run-test");
+      await runLernaInitAsync();
+
+      await runLernaCommandAsync("create package-1");
+      await addScriptsToPackageAsync("package-1", {
+        "print-name": "echo test-package-1",
+      });
+      await runLernaCommandAsync("create package-2");
+      await addScriptsToPackageAsync("package-2", {
+        "print-name": "echo test-package-2",
+      });
+      await runLernaCommandAsync("create package-3");
+      await addScriptsToPackageAsync("package-3", {
+        "print-name": "echo test-package-3",
+      });
+
+      const output = await runLernaCommandAsync(
+        `run print-name --profile --profile-location=profiles -- --silent`
+      );
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        test-package-X
+        test-package-X
+        test-package-X
+        lerna notice cli v999.9.9-e2e.0
+        lerna info Executing command in 3 packages: "npm run print-name --silent"
+        lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+        lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+        lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+        lerna info profiler Performance profile saved to /private/tmp/lerna-e2e/lerna-run-test/profiles/Lerna-Profile-XXXXXXXXTXXXXXX.json
+        lerna success run Ran npm script 'print-name' in 3 packages in X.Xs:
+        lerna success - package-X
+        lerna success - package-X
+        lerna success - package-X
+
+      `);
+
+      const lernaProfileSavedOutputLine = output.combinedOutput.split("\n")[8];
+
+      const lernaProfileFileName = lernaProfileSavedOutputLine.split("lerna-run-test/")[1];
+
+      expect(existsSync(tmpProjPath(lernaProfileFileName))).toBe(true);
+    });
   });
 });

--- a/e2e/lerna-run/lerna-run.spec.ts
+++ b/e2e/lerna-run/lerna-run.spec.ts
@@ -35,26 +35,14 @@ describe("lerna run", () => {
       "print-name": "echo test-package-3",
     });
 
-    const output = await runLernaCommandAsync("run print-name");
+    const output = await runLernaCommandAsync("run print-name -- --silent");
 
     expect(output.combinedOutput).toMatchInlineSnapshot(`
-
-      > package-X@0.0.0 print-name
-      > echo test-package-X
-
       test-package-X
-
-      > package-X@0.0.0 print-name
-      > echo test-package-X
-
       test-package-X
-
-      > package-X@0.0.0 print-name
-      > echo test-package-X
-
       test-package-X
       lerna notice cli v999.9.9-e2e.0
-      lerna info Executing command in 3 packages: "npm run print-name"
+      lerna info Executing command in 3 packages: "npm run print-name --silent"
       lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
       lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
       lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:

--- a/e2e/lerna-run/lerna-run.spec.ts
+++ b/e2e/lerna-run/lerna-run.spec.ts
@@ -3,6 +3,7 @@ import {
   addNxToWorkspace,
   addScriptsToPackage,
   createEmptyDirectoryForWorkspace,
+  e2eRoot,
   removeWorkspace,
   runCLI,
   tmpProjPath,
@@ -15,7 +16,8 @@ expect.addSnapshotSerializer({
       .replaceAll(/\d\.(\d{1}|\d{2})s/g, "X.Xs")
       .replaceAll(/Lerna-Profile-\d{8}T\d{6}\.json/g, "Lerna-Profile-XXXXXXXXTXXXXXX.json")
       .replaceAll(/\/private\/tmp\//g, "/tmp/")
-      .replaceAll(/lerna info ci enabled\n/g, "");
+      .replaceAll(/lerna info ci enabled\n/g, "")
+      .replaceAll(e2eRoot, "/tmp/lerna-e2e");
   },
   test(val) {
     return val != null && typeof val === "string";

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -47,7 +47,7 @@ export function readFile(f: string) {
   return readFileSync(ff, "utf-8");
 }
 
-export async function addScriptsToPackageAsync(name: string, scripts: { [key: string]: string }) {
+export async function addScriptsToPackage(name: string, scripts: { [key: string]: string }) {
   await updateJson(`packages/${name}/package.json`, (json) => ({
     ...json,
     scripts: {
@@ -72,7 +72,7 @@ export async function addNxToWorkspace() {
     },
   });
 
-  await runCommandAsync("npm --registry=http://localhost:4872/ install -D nx@latest");
+  await runCommand("npm --registry=http://localhost:4872/ install -D nx@latest");
 }
 
 async function updateJson<T = any>(path: string, updateFn: (json: T) => T) {
@@ -82,7 +82,7 @@ async function updateJson<T = any>(path: string, updateFn: (json: T) => T) {
   await writeJSON(jsonPath, updateFn(json));
 }
 
-export function runCommandAsync(
+export function runCommand(
   command: string,
   opts: RunCmdOpts = {
     silenceError: false,
@@ -114,22 +114,8 @@ export function runCommandAsync(
   });
 }
 
-export function runLernaCommandAsync(args: string) {
-  return runCommandAsync(
-    `npx --registry=http://localhost:4872/ --yes lerna@${getPublishedVersion()} ${args}`
-  );
-}
-
-export function runLernaInitAsync(args?: string) {
-  const argsString = args ? ` ${args}` : "";
-
-  /**
-   * There is nothing about lerna init that is package manager specific, as no installation occurs
-   * as part of the command, so we simply use npx here and resolve from verdaccio.
-   */
-  return runCommandAsync(
-    `npx --registry=http://localhost:4872/ --yes lerna@${getPublishedVersion()} init${argsString}`
-  );
+export function runCLI(args: string) {
+  return runCommand(`npx --registry=http://localhost:4872/ --yes lerna@${getPublishedVersion()} ${args}`);
 }
 
 /**

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -92,10 +92,8 @@ export function runCommandAsync(
 }
 
 export function runLernaCommandAsync(args: string) {
-  const argsString = args ? ` ${args}` : "";
-
   return runCommandAsync(
-    `npx --registry=http://localhost:4872/ --yes lerna@${getPublishedVersion()}${argsString}`
+    `npx --registry=http://localhost:4872/ --yes lerna@${getPublishedVersion()} ${args}`
   );
 }
 

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,5 +1,5 @@
 import { exec } from "child_process";
-import { ensureDirSync, readFileSync, removeSync } from "fs-extra";
+import { ensureDirSync, readFileSync, readJSON, removeSync, writeJSON } from "fs-extra";
 import isCI from "is-ci";
 import { dirSync } from "tmp";
 
@@ -47,6 +47,18 @@ export function readFile(f: string) {
   return readFileSync(ff, "utf-8");
 }
 
+export async function addScriptsToPackageAsync(name: string, scripts: { [key: string]: string }) {
+  const packageJsonPath = tmpProjPath(`packages/${name}/package.json`);
+
+  const json = await readJSON(packageJsonPath);
+
+  json.scripts = {
+    ...json.scripts,
+    ...scripts,
+  };
+  await writeJSON(packageJsonPath, json);
+}
+
 export function runCommandAsync(
   command: string,
   opts: RunCmdOpts = {
@@ -77,6 +89,14 @@ export function runCommandAsync(
       }
     );
   });
+}
+
+export function runLernaCommandAsync(args: string) {
+  const argsString = args ? ` ${args}` : "";
+
+  return runCommandAsync(
+    `npx --registry=http://localhost:4872/ --yes lerna@${getPublishedVersion()}${argsString}`
+  );
 }
 
 export function runLernaInitAsync(args?: string) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add e2e tests to cover `lerna run`.

## Description
<!--- Describe your changes in detail -->
- Add end to end test cases for the `lerna run` command.
- Extract a util function "runCLI" for running any lerna command.
- Refactor `lerna init` e2e tests to use the runCLI util.
- Update the PR template to include the "chore" change type

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change adds additional confidence in the consistent performance of lerna run over time.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I began with failing e2e test cases, added the appropriate flag to the command run in the test, then confirmed that the test succeeded. I also confirmed that the init tests succeeded after refactoring them to use the runCLI utility.

macOS Monterey v12.4, zsh shell
The testing environment is set up automatically by the e2e tests via scripts run by npm run e2e.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
