### PR TITLE
chore(e2e): add e2e tests for list options of `changed`

### DIFF
--- a/e2e/lerna-changed/lerna-changed.spec.ts
+++ b/e2e/lerna-changed/lerna-changed.spec.ts
@@ -3,6 +3,7 @@ import {
   addPackagesDirectory,
   createEmptyDirectoryForWorkspace,
   createInitialGitCommit,
+  e2eRoot,
   removeWorkspace,
   runCLI,
   runCommand,
@@ -15,7 +16,10 @@ jest.setTimeout(60000);
 
 expect.addSnapshotSerializer({
   serialize(str) {
-    return str.replaceAll(/lerna info ci enabled\n/g, "");
+    return str
+      .replaceAll(/\/private\/tmp\//g, "/tmp/")
+      .replaceAll(e2eRoot, "/tmp/lerna-e2e")
+      .replaceAll(/lerna info ci enabled\n/g, "");
   },
   test(val) {
     return val != null && typeof val === "string";
@@ -98,13 +102,13 @@ describe("lerna changed", () => {
               "name": "package-a",
               "version": "0.0.0",
               "private": false,
-              "location": "/private/tmp/lerna-e2e/lerna-changed-test/modules/package-a"
+              "location": "/tmp/lerna-e2e/lerna-changed-test/modules/package-a"
             },
             {
               "name": "package-c",
               "version": "0.0.0-alpha.1",
               "private": false,
-              "location": "/private/tmp/lerna-e2e/lerna-changed-test/packages/package-c"
+              "location": "/tmp/lerna-e2e/lerna-changed-test/packages/package-c"
             }
           ]
           lerna notice cli v999.9.9-e2e.0
@@ -120,8 +124,8 @@ describe("lerna changed", () => {
         const output = await runCLI("changed --ndjson");
 
         expect(output.combinedOutput).toMatchInlineSnapshot(`
-          {"name":"package-a","version":"0.0.0","private":false,"location":"/private/tmp/lerna-e2e/lerna-changed-test/modules/package-a"}
-          {"name":"package-c","version":"0.0.0-alpha.1","private":false,"location":"/private/tmp/lerna-e2e/lerna-changed-test/packages/package-c"}
+          {"name":"package-a","version":"0.0.0","private":false,"location":"/tmp/lerna-e2e/lerna-changed-test/modules/package-a"}
+          {"name":"package-c","version":"0.0.0-alpha.1","private":false,"location":"/tmp/lerna-e2e/lerna-changed-test/packages/package-c"}
           lerna notice cli v999.9.9-e2e.0
           lerna info Looking for changed packages since 0.0.0
           lerna success found 2 packages ready to publish
@@ -197,8 +201,8 @@ describe("lerna changed", () => {
         const output = await runCLI("changed --parseable");
 
         expect(output.combinedOutput).toMatchInlineSnapshot(`
-          /private/tmp/lerna-e2e/lerna-changed-test/modules/package-a
-          /private/tmp/lerna-e2e/lerna-changed-test/packages/package-c
+          /tmp/lerna-e2e/lerna-changed-test/modules/package-a
+          /tmp/lerna-e2e/lerna-changed-test/packages/package-c
           lerna notice cli v999.9.9-e2e.0
           lerna info Looking for changed packages since 0.0.0
           lerna success found 2 packages ready to publish
@@ -212,8 +216,8 @@ describe("lerna changed", () => {
         const output = await runCLI("changed -p");
 
         expect(output.combinedOutput).toMatchInlineSnapshot(`
-          /private/tmp/lerna-e2e/lerna-changed-test/modules/package-a
-          /private/tmp/lerna-e2e/lerna-changed-test/packages/package-c
+          /tmp/lerna-e2e/lerna-changed-test/modules/package-a
+          /tmp/lerna-e2e/lerna-changed-test/packages/package-c
           lerna notice cli v999.9.9-e2e.0
           lerna info Looking for changed packages since 0.0.0
           lerna success found 2 packages ready to publish
@@ -227,9 +231,9 @@ describe("lerna changed", () => {
         const output = await runCLI("changed -pla");
 
         expect(output.combinedOutput).toMatchInlineSnapshot(`
-          /private/tmp/lerna-e2e/lerna-changed-test/modules/package-a:package-a:0.0.0
-          /private/tmp/lerna-e2e/lerna-changed-test/packages/package-b:package-b:0.0.0:PRIVATE
-          /private/tmp/lerna-e2e/lerna-changed-test/packages/package-c:package-c:0.0.0-alpha.1
+          /tmp/lerna-e2e/lerna-changed-test/modules/package-a:package-a:0.0.0
+          /tmp/lerna-e2e/lerna-changed-test/packages/package-b:package-b:0.0.0:PRIVATE
+          /tmp/lerna-e2e/lerna-changed-test/packages/package-c:package-c:0.0.0-alpha.1
           lerna notice cli v999.9.9-e2e.0
           lerna info Looking for changed packages since 0.0.0
           lerna success found 3 packages ready to publish

--- a/e2e/lerna-changed/lerna-changed.spec.ts
+++ b/e2e/lerna-changed/lerna-changed.spec.ts
@@ -280,16 +280,17 @@ describe("lerna changed", () => {
     });
   });
 
+  // the purpose of the --include-merged-tags option is outlined in detail in this PR: https://github.com/lerna/lerna/pull/1712
   describe("--include-merged-tags", () => {
     beforeAll(async () => {
       await initializeLernaChangedDirectory();
-      await runCommand("git tag -a 1.0.0 -m 1.0.0");
+      await runCommand("git tag 1.0.0 -m 1.0.0");
 
       await runCommand("git checkout -b changed-package-c");
       await addDependencyToPackage("packages/package-c", "package-d");
       await runCommand("git add .");
       await runCommand('git commit -m "modify package-c"');
-      await runCommand("git tag -a 2.0.0 -m 2.0.0");
+      await runCommand("git tag 2.0.0 -m 2.0.0");
 
       await runCommand("git checkout test-main");
       await addDependencyToPackage("modules/package-e", "package-d");

--- a/e2e/lerna-changed/lerna-changed.spec.ts
+++ b/e2e/lerna-changed/lerna-changed.spec.ts
@@ -1,0 +1,278 @@
+import {
+  addDependencyToPackage,
+  addPackagesDirectory,
+  createEmptyDirectoryForWorkspace,
+  createInitialGitCommit,
+  removeWorkspace,
+  runCLI,
+  runCommand,
+  runLernaInit,
+  runNpmInstall,
+  updatePackageVersion,
+} from "../utils";
+
+jest.setTimeout(60000);
+
+expect.addSnapshotSerializer({
+  serialize(str) {
+    return str.replaceAll(/lerna info ci enabled\n/g, "");
+  },
+  test(val) {
+    return val != null && typeof val === "string";
+  },
+});
+
+const initializeLernaChangedDirectory = async () => {
+  createEmptyDirectoryForWorkspace("lerna-changed-test");
+  await runLernaInit();
+  await runNpmInstall();
+
+  await runCLI("create package-c -y");
+  await updatePackageVersion("packages/package-c", "0.0.0-alpha.1");
+  await runCLI("create package-b --private -y");
+
+  await addPackagesDirectory("modules");
+  await runCLI("create package-a modules -y");
+  await runCLI("create package-e modules -y");
+  await runCLI("create package-d modules --private -y");
+
+  await addDependencyToPackage("modules/package-a", "package-c", "0.0.0-alpha.1");
+  await addDependencyToPackage("packages/package-b", "package-c", "0.0.0-alpha.1");
+  await addDependencyToPackage("modules/package-a", "package-d");
+
+  await createInitialGitCommit();
+};
+
+describe("lerna changed", () => {
+  describe("with no prior release tags", () => {
+    beforeAll(() => initializeLernaChangedDirectory());
+
+    afterAll(() => removeWorkspace());
+
+    it("should assume all public packages have changed", async () => {
+      const output = await runCLI("changed");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        package-a
+        package-e
+        package-c
+        lerna notice cli v999.9.9-e2e.0
+        lerna info Assuming all packages changed
+        lerna success found 3 packages ready to publish
+
+      `);
+    });
+  });
+
+  describe("with a change to package-c since the last release", () => {
+    beforeAll(async () => {
+      await initializeLernaChangedDirectory();
+      await runCommand("git tag 0.0.0 -m 0.0.0");
+      await addDependencyToPackage("packages/package-c", "package-d");
+      await runCommand("git add .");
+      await runCommand('git commit -m "modify package-c"');
+    });
+
+    afterAll(() => removeWorkspace());
+
+    it("should list package-a and package-c as changed", async () => {
+      const output = await runCLI("changed");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        package-a
+        package-c
+        lerna notice cli v999.9.9-e2e.0
+        lerna info Looking for changed packages since 0.0.0
+        lerna success found 2 packages ready to publish
+
+      `);
+    });
+
+    describe("--json", () => {
+      it("should list package-a and package-c as changed in json format", async () => {
+        const output = await runCLI("changed --json");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          [
+            {
+              "name": "package-a",
+              "version": "0.0.0",
+              "private": false,
+              "location": "/private/tmp/lerna-e2e/lerna-changed-test/modules/package-a"
+            },
+            {
+              "name": "package-c",
+              "version": "0.0.0-alpha.1",
+              "private": false,
+              "location": "/private/tmp/lerna-e2e/lerna-changed-test/packages/package-c"
+            }
+          ]
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 2 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("--ndjson", () => {
+      it("should list package-a and package-c as changed in newline-delimited json format", async () => {
+        const output = await runCLI("changed --ndjson");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          {"name":"package-a","version":"0.0.0","private":false,"location":"/private/tmp/lerna-e2e/lerna-changed-test/modules/package-a"}
+          {"name":"package-c","version":"0.0.0-alpha.1","private":false,"location":"/private/tmp/lerna-e2e/lerna-changed-test/packages/package-c"}
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 2 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("--all", () => {
+      it("should list package-a, package-b, and package-c as changed", async () => {
+        const output = await runCLI("changed --all");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          package-a
+          package-b (PRIVATE)
+          package-c
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 3 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("-a", () => {
+      it("should list package-a, package-b, and package-c as changed", async () => {
+        const output = await runCLI("changed -a");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          package-a
+          package-b (PRIVATE)
+          package-c
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 3 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("--long", () => {
+      it("should list package-a and package-c as changed with additional information", async () => {
+        const output = await runCLI("changed --long");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          package-a         v0.0.0 modules/package-a
+          package-c v0.0.0-alpha.1 packages/package-c
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 2 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("-l", () => {
+      it("should list package-a and package-c as changed with additional information", async () => {
+        const output = await runCLI("changed -l");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          package-a         v0.0.0 modules/package-a
+          package-c v0.0.0-alpha.1 packages/package-c
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 2 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("--parseable", () => {
+      it("should list package-a and package-c as changed with parseable output instead of columnified view", async () => {
+        const output = await runCLI("changed --parseable");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          /private/tmp/lerna-e2e/lerna-changed-test/modules/package-a
+          /private/tmp/lerna-e2e/lerna-changed-test/packages/package-c
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 2 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("-p", () => {
+      it("should list package-a and package-c as changed with parseable output instead of columnified view", async () => {
+        const output = await runCLI("changed -p");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          /private/tmp/lerna-e2e/lerna-changed-test/modules/package-a
+          /private/tmp/lerna-e2e/lerna-changed-test/packages/package-c
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 2 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("-pla", () => {
+      it("should list package-a, package-b, and package-c as changed, with version and package info, in a parseable output", async () => {
+        const output = await runCLI("changed -pla");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          /private/tmp/lerna-e2e/lerna-changed-test/modules/package-a:package-a:0.0.0
+          /private/tmp/lerna-e2e/lerna-changed-test/packages/package-b:package-b:0.0.0:PRIVATE
+          /private/tmp/lerna-e2e/lerna-changed-test/packages/package-c:package-c:0.0.0-alpha.1
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 3 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("--toposort", () => {
+      it("should list package-a and package-c as changed, but in topological order", async () => {
+        const output = await runCLI("changed --toposort");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          package-c
+          package-a
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 2 packages ready to publish
+
+        `);
+      });
+    });
+
+    describe("--graph", () => {
+      it("should list package-a and package-c as changed with their dependencies in a json list", async () => {
+        const output = await runCLI("changed --graph");
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          {
+            "package-a": [
+              "package-c",
+              "package-d"
+            ],
+            "package-c": [
+              "package-d"
+            ]
+          }
+          lerna notice cli v999.9.9-e2e.0
+          lerna info Looking for changed packages since 0.0.0
+          lerna success found 2 packages ready to publish
+
+        `);
+      });
+    });
+  });
+});

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -71,6 +71,13 @@ export async function addDependencyToPackage(
   }));
 }
 
+export async function updatePackageVersion(packagePath: string, newVersion: string) {
+  await updateJson(`${packagePath}/package.json`, (json) => ({
+    ...json,
+    version: newVersion,
+  }));
+}
+
 export async function addNxToWorkspace() {
   await updateJson("lerna.json", (json) => ({
     ...json,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add e2e tests to cover list options for the changed command.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change adds additional confidence in the consistent performance of lerna over time.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I began with failing e2e test cases, added the appropriate flag to the command run in the test, then confirmed that the test succeeded.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
