### PR TITLE
ci(core): use ssh-agent 0.5.4 in github actions

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.5.0
+      - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
       - uses: actions/setup-node@v3


### PR DESCRIPTION
It updates the version of `ssh-agent` to `0.5.4` used in the Github Actions workflow to deploy Lerna's website on `lerna/website` repository.