### PR TITLE
fix(run): add double quotes around script target containing colon

### DIFF
--- a/commands/run/__tests__/__fixtures__/powered-by-nx/packages/package-1/package.json
+++ b/commands/run/__tests__/__fixtures__/powered-by-nx/packages/package-1/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "fail": "exit 1",
-    "my-script": "echo package-1"
+    "my-script": "echo package-1",
+    "another-script:but-with-colons": "echo package-1-script-with-colons"
   }
 }

--- a/commands/run/__tests__/run-command.test.js
+++ b/commands/run/__tests__/run-command.test.js
@@ -331,6 +331,13 @@ describe("RunCommand", () => {
       expect(collectedOutput).toContain("Successfully ran target");
     });
 
+    it("runs a script with a colon in the script name", async () => {
+      collectedOutput = "";
+      await lernaRun(testDir)("another-script:but-with-colons");
+      expect(collectedOutput).toContain("package-1-script-with-colons");
+      expect(collectedOutput).toContain("Successfully ran target");
+    });
+
     it("runs a script only in scoped packages", async () => {
       collectedOutput = "";
       await lernaRun(testDir)("my-script", "--scope", "package-1");

--- a/commands/run/index.js
+++ b/commands/run/index.js
@@ -179,7 +179,7 @@ class RunCommand extends Command {
     const { targetDependencies, options } = this.prepNxOptions();
     if (this.packagesWithScript.length === 1) {
       const { runOne } = require("nx/src/command-line/run-one");
-      const fullQualifiedTarget = this.packagesWithScript.map((p) => p.name)[0] + ":\"" + this.script+ "\"";
+      const fullQualifiedTarget = this.packagesWithScript.map((p) => p.name)[0] + ':"' + this.script + '"';
       return runOne(
         process.cwd(),
         {

--- a/commands/run/index.js
+++ b/commands/run/index.js
@@ -172,7 +172,7 @@ class RunCommand extends Command {
 
   addQuotesAroundScriptNameIfItHasAColon(scriptName) {
     // Nx requires quotes around script names of the form script:name
-    if(scriptName.includes(':')) {
+    if (scriptName.includes(":")) {
       return `"${scriptName}"`;
     } else {
       return scriptName;
@@ -188,7 +188,10 @@ class RunCommand extends Command {
     const { targetDependencies, options } = this.prepNxOptions();
     if (this.packagesWithScript.length === 1) {
       const { runOne } = require("nx/src/command-line/run-one");
-      const fullQualifiedTarget = this.packagesWithScript.map((p) => p.name)[0] + ':' + this.addQuotesAroundScriptNameIfItHasAColon(this.script);
+      const fullQualifiedTarget =
+        this.packagesWithScript.map((p) => p.name)[0] +
+        ":" +
+        this.addQuotesAroundScriptNameIfItHasAColon(this.script);
       return runOne(
         process.cwd(),
         {

--- a/commands/run/index.js
+++ b/commands/run/index.js
@@ -170,6 +170,15 @@ class RunCommand extends Command {
     return chain;
   }
 
+  addQuotesAroundScriptNameIfItHasAColon(scriptName) {
+    // Nx requires quotes around script names of the form script:name
+    if(scriptName.includes(':')) {
+      return `"${scriptName}"`;
+    } else {
+      return scriptName;
+    }
+  }
+
   runScriptsUsingNx() {
     if (this.options.ci) {
       process.env.CI = "true";
@@ -179,7 +188,7 @@ class RunCommand extends Command {
     const { targetDependencies, options } = this.prepNxOptions();
     if (this.packagesWithScript.length === 1) {
       const { runOne } = require("nx/src/command-line/run-one");
-      const fullQualifiedTarget = this.packagesWithScript.map((p) => p.name)[0] + ':"' + this.script + '"';
+      const fullQualifiedTarget = this.packagesWithScript.map((p) => p.name)[0] + ':' + this.addQuotesAroundScriptNameIfItHasAColon(this.script);
       return runOne(
         process.cwd(),
         {

--- a/commands/run/index.js
+++ b/commands/run/index.js
@@ -179,7 +179,7 @@ class RunCommand extends Command {
     const { targetDependencies, options } = this.prepNxOptions();
     if (this.packagesWithScript.length === 1) {
       const { runOne } = require("nx/src/command-line/run-one");
-      const fullQualifiedTarget = this.packagesWithScript.map((p) => p.name)[0] + ":" + this.script;
+      const fullQualifiedTarget = this.packagesWithScript.map((p) => p.name)[0] + ":\"" + this.script+ "\"";
       return runOne(
         process.cwd(),
         {

--- a/e2e/tests/lerna-run/lerna-run.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run.spec.ts
@@ -317,6 +317,7 @@ describe("useNx", () => {
       packagePath: "packages/package-4",
       scripts: {
         "print:name": "echo test-package-4",
+        "print:name:run-one-only": "echo test-package-4-run-one-only",
       },
     });
     await fixture.lerna("create package-5 -y");
@@ -369,6 +370,35 @@ test-package-X
  
 
  >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+
+`);
+  });
+
+  it("should run script with colon on single child package using nx", async () => {
+    const output = await fixture.lerna(`run print:name:run-one-only`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print:name:run-one-only for 1 project(s):
+
+    - package-X
+
+ 
+
+> package-X:"print:name:run-one-only"
+
+
+> package-X@0.0.0 print:name:run-one-only
+> echo test-package-X-run-one-only
+
+test-package-X-run-one-only
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print:name for 1 projects
 
 
 lerna notice cli v999.9.9-e2e.0

--- a/e2e/tests/lerna-run/lerna-run.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run.spec.ts
@@ -378,10 +378,9 @@ lerna notice cli v999.9.9-e2e.0
 `);
   });
 
-  describe('run one', () => {
+  describe("run one", () => {
     it("should run script on single child package using nx", async () => {
       const output = await fixture.lerna(`run print-name-run-one-only`);
-      
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
   
@@ -402,10 +401,10 @@ lerna notice cli v999.9.9-e2e.0
   
   `);
     });
-  
+
     it("should run script with colon on single child package using nx", async () => {
       const output = await fixture.lerna(`run print:name:run-one-only`);
-  
+
       expect(output.combinedOutput).toMatchInlineSnapshot(`
 
   > package-X:"print:name:run-one-only"
@@ -425,7 +424,7 @@ lerna notice cli v999.9.9-e2e.0
   
   `);
     });
-  })
+  });
 
   it("should run script with colon on all child package using nx", async () => {
     const output = await fixture.lerna(`run print:name`);

--- a/e2e/tests/lerna-run/lerna-run.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run.spec.ts
@@ -312,6 +312,20 @@ describe("useNx", () => {
         "print-name": "echo test-package-3",
       },
     });
+    await fixture.lerna("create package-4 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-4",
+      scripts: {
+        "print:name": "echo test-package-4",
+      },
+    });
+    await fixture.lerna("create package-5 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-5",
+      scripts: {
+        "print:name": "echo test-package-5",
+      },
+    });
   });
   afterAll(() => fixture.destroy());
 
@@ -355,6 +369,44 @@ test-package-X
  
 
  >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+
+`);
+  });
+
+  it("should run script with colon on all child package using nx", async () => {
+    const output = await fixture.lerna(`run print:name`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print:name for 2 project(s):
+
+    - package-X
+    - package-X
+
+ 
+
+> package-X:"print:name"
+
+
+> package-X@0.0.0 print:name
+> echo test-package-X
+
+test-package-X
+
+> package-X:"print:name"
+
+
+> package-X@0.0.0 print:name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print:name for 2 projects
 
 
 lerna notice cli v999.9.9-e2e.0

--- a/e2e/tests/lerna-run/lerna-run.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run.spec.ts
@@ -317,7 +317,8 @@ describe("useNx", () => {
       packagePath: "packages/package-4",
       scripts: {
         "print:name": "echo test-package-4",
-        "print:name:run-one-only": "echo test-package-4-run-one-only",
+        "print-name-run-one-only": "echo test-package-4-run-one-only",
+        "print:name:run-one-only": "echo test-package-4-run-one-only-with-colon",
       },
     });
     await fixture.lerna("create package-5 -y");
@@ -377,34 +378,54 @@ lerna notice cli v999.9.9-e2e.0
 `);
   });
 
-  it("should run script with colon on single child package using nx", async () => {
-    const output = await fixture.lerna(`run print:name:run-one-only`);
+  describe('run one', () => {
+    it("should run script on single child package using nx", async () => {
+      const output = await fixture.lerna(`run print-name-run-one-only`);
+      
 
-    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+  
+  > package-X:print-name-run-one-only
+  
+  
+  > package-X@0.0.0 print-name-run-one-only
+  > echo test-package-X-run-one-only
+  
+  test-package-X-run-one-only
+  
+   
+  
+   >  Lerna (powered by Nx)   Successfully ran target print-name-run-one-only for project package-X
+  
+  
+  lerna notice cli v999.9.9-e2e.0
+  
+  `);
+    });
+  
+    it("should run script with colon on single child package using nx", async () => {
+      const output = await fixture.lerna(`run print:name:run-one-only`);
+  
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
 
- >  Lerna (powered by Nx)   Running target print:name:run-one-only for 1 project(s):
-
-    - package-X
-
- 
-
-> package-X:"print:name:run-one-only"
-
-
-> package-X@0.0.0 print:name:run-one-only
-> echo test-package-X-run-one-only
-
-test-package-X-run-one-only
-
- 
-
- >  Lerna (powered by Nx)   Successfully ran target print:name for 1 projects
-
-
-lerna notice cli v999.9.9-e2e.0
-
-`);
-  });
+  > package-X:"print:name:run-one-only"
+  
+  
+  > package-X@0.0.0 print:name:run-one-only
+  > echo test-package-X-run-one-only-with-colon
+  
+  test-package-X-run-one-only-with-colon
+  
+   
+  
+   >  Lerna (powered by Nx)   Successfully ran target print:name:run-one-only for project package-X
+  
+  
+  lerna notice cli v999.9.9-e2e.0
+  
+  `);
+    });
+  })
 
   it("should run script with colon on all child package using nx", async () => {
     const output = await fixture.lerna(`run print:name`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds double-quotes around script target when running with Nx.
Closes #3215 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Issue #3215](https://github.com/lerna/lerna/issues/3215)
[References issue in Nx](https://github.com/nrwl/nx/pull/10400)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test added to test suite for command/run.  Tested with node 16, npm 8

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
