### PR TITLE
fix(package-graph): ensure to touch all nodes

### DIFF
--- a/core/package-graph/index.js
+++ b/core/package-graph/index.js
@@ -232,10 +232,11 @@ class PackageGraph extends Map {
       }
 
       // Otherwise the same node is checked multiple times which is very wasteful in a large repository
-      if (alreadyVisited.has(topLevelDependent)) {
+      const identifier = `${baseNode.name}:${topLevelDependent.name}`;
+      if (alreadyVisited.has(identifier)) {
         return;
       }
-      alreadyVisited.add(topLevelDependent);
+      alreadyVisited.add(identifier);
 
       if (
         topLevelDependent === baseNode ||


### PR DESCRIPTION
## Description
the fix of not touching a node twice (https://github.com/lerna/lerna/pull/2874) has a side effect so that not all scirpts are executed anymore.

this fixes it by still improving / keeping the performance benefits of the other pr.

fixes https://github.com/lerna/lerna/issues/3233
