### PR TITLE
feat(publish): disable legacy `verifyAccess` behavior by default

### DIFF
--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -199,7 +199,9 @@ The root-level configuration is intentional, as this also covers the [identicall
 
 ### `--verify-access`
 
-By default, `lerna` will not verify the logged-in npm user's access to the packages about to be published. Passing this flag will cause `lerna` to proactively perform this verification before it attempts to publish any packages.
+Historically, `lerna` attempted to fast-fail on authorization/authentication issues by performing some preemptive npm API requests using the given token. These days, however, there are multiple types of tokens that npm supports and they have varying levels of access rights, so there is no one-size fits all solution for this preemptive check and it is more appropriate to allow requests to npm to simply fail with appropriate errors for the given token. For this reason, the legacy `--verify-access` behavior is disabled by default and will likely be removed in a future major version.
+
+For now, though, if you pass this flag you can opt into the legacy behavior and `lerna` will preemptively perform this verification before it attempts to publish any packages.
 
 You should NOT use this option if:
 

--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -26,8 +26,6 @@ During all publish operations, appropriate [lifecycle scripts](#lifecycle-script
 
 Check out [Per-Package Configuration](#per-package-configuration) for more details about publishing scoped packages, custom registries, and custom dist-tags.
 
-> If you're using [npm automation access token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-access-tokens) please remember to [disable lerna access verification feature](#--no-verify-access). Automation token doesn't grant permissions needed for the verification to be successful. [Click here to read more about this issue](https://github.com/lerna/lerna/issues/2788).
-
 ## Positionals
 
 ### bump `from-git`
@@ -59,7 +57,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 - [`--legacy-auth`](#--legacy-auth)
 - [`--no-git-reset`](#--no-git-reset)
 - [`--no-granular-pathspec`](#--no-granular-pathspec)
-- [`--no-verify-access`](#--no-verify-access)
+- [`--verify-access`](#--verify-access)
 - [`--otp`](#--otp)
 - [`--preid`](#--preid)
 - [`--pre-dist-tag <tag>`](#--pre-dist-tag-tag)
@@ -199,15 +197,14 @@ This option makes the most sense configured in lerna.json, as you really don't w
 
 The root-level configuration is intentional, as this also covers the [identically-named option in `lerna version`](https://github.com/lerna/lerna/tree/main/commands/version#--no-granular-pathspec).
 
-### `--no-verify-access`
+### `--verify-access`
 
-By default, `lerna` will verify the logged-in npm user's access to the packages about to be published. Passing this flag will disable that check.
+By default, `lerna` will not verify the logged-in npm user's access to the packages about to be published. Passing this flag will cause `lerna` to proactively perform this verification before it attempts to publish any packages.
 
-If you are using a third-party registry that does not support `npm access ls-packages`, you will need to pass this flag (or set `command.publish.verifyAccess` to `false` in lerna.json).
+You should NOT use this option if:
 
-> Please use with caution
-
-> For the time being, use this flag/option always when you're handling NPM authorization with the use of [automation access token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-access-tokens). [Click here to read more about this issue](https://github.com/lerna/lerna/issues/2788).
+1.  You are using a third-party registry that does not support `npm access ls-packages`
+2.  You are using an authentication token without read access, such as a [npm automation access token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-access-tokens)
 
 ### `--otp`
 
@@ -296,6 +293,10 @@ When run with this flag, `lerna publish` will skip all confirmation prompts.
 Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous_integration) to automatically answer the publish confirmation prompt.
 
 ## Deprecated Options
+
+### `--no-verify-access`
+
+Access verification is now off by default, so `--no-verify-access` is not needed. To opt-in to access verification, use [`--verify-access`](#--verify-access).
 
 ### `--skip-npm`
 

--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -296,7 +296,7 @@ Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous
 
 ### `--no-verify-access`
 
-Access verification is now off by default, so `--no-verify-access` is not needed. To opt-in to access verification, use [`--verify-access`](#--verify-access).
+The legacy preemptive access verification is now off by default, so `--no-verify-access` is not needed. Requests will fail with appropriate errors when not authorized correctly. To opt-in to the legacy access verification, use [`--verify-access`](#--verify-access).
 
 ### `--skip-npm`
 

--- a/commands/publish/__tests__/get-npm-username.test.js
+++ b/commands/publish/__tests__/get-npm-username.test.js
@@ -68,6 +68,25 @@ describe("getNpmUsername", () => {
     expect(console.error).toHaveBeenCalledWith("third-party whoami fail");
   });
 
+  test("logs failure message when npm automation token is suspected", async () => {
+    fetch.json.mockImplementationOnce(() => {
+      const err = new Error("npm profile fail due to automation token's insufficient permissions");
+
+      err.code = "E403";
+
+      return Promise.reject(err);
+    });
+
+    const opts = { registry: "https://registry.npmjs.org/" };
+
+    await expect(getNpmUsername(opts)).rejects.toThrow(
+      "Cannot verify access when authenticating with a npm automation token. Set `command.publish.verifyAccess=false` in your lerna.json to skip this verification, or use a different type of npm access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      "npm profile fail due to automation token's insufficient permissions"
+    );
+  });
+
   test("allows third-party registries to fail with a stern warning", async () => {
     fetch.json.mockImplementationOnce(() => {
       const err = new Error("many third-party registries do not support npm whoami");

--- a/commands/publish/__tests__/get-npm-username.test.js
+++ b/commands/publish/__tests__/get-npm-username.test.js
@@ -68,9 +68,9 @@ describe("getNpmUsername", () => {
     expect(console.error).toHaveBeenCalledWith("third-party whoami fail");
   });
 
-  test("logs failure message when npm automation token is suspected", async () => {
+  test("logs failure message when npm returns forbidden response", async () => {
     fetch.json.mockImplementationOnce(() => {
-      const err = new Error("npm profile fail due to automation token's insufficient permissions");
+      const err = new Error("npm profile fail due to insufficient permissions");
 
       err.code = "E403";
 
@@ -80,11 +80,9 @@ describe("getNpmUsername", () => {
     const opts = { registry: "https://registry.npmjs.org/" };
 
     await expect(getNpmUsername(opts)).rejects.toThrow(
-      "Cannot verify access when authenticating with a npm automation token. Set `command.publish.verifyAccess=false` in your lerna.json to skip this verification, or use a different type of npm access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
+      "Access verification failed. If you are authenticating with a npm automation token, set `command.publish.verifyAccess=false` in your lerna.json to skip this verification, or use a different type of npm access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
     );
-    expect(console.error).toHaveBeenCalledWith(
-      "npm profile fail due to automation token's insufficient permissions"
-    );
+    expect(console.error).toHaveBeenCalledWith("npm profile fail due to insufficient permissions");
   });
 
   test("allows third-party registries to fail with a stern warning", async () => {

--- a/commands/publish/__tests__/get-npm-username.test.js
+++ b/commands/publish/__tests__/get-npm-username.test.js
@@ -80,7 +80,7 @@ describe("getNpmUsername", () => {
     const opts = { registry: "https://registry.npmjs.org/" };
 
     await expect(getNpmUsername(opts)).rejects.toThrow(
-      "Access verification failed. If you are authenticating with a npm automation token, set `command.publish.verifyAccess=false` in your lerna.json to skip this verification, or use a different type of npm access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
+      "Access verification failed. Ensure that your npm access token has both read and write access, or remove the verifyAccess option to skip this verification. Note that npm automation tokens do NOT have read access (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
     );
     expect(console.error).toHaveBeenCalledWith("npm profile fail due to insufficient permissions");
   });

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -371,7 +371,7 @@ Map {
 
       const logMessages = loggingOutput("warn");
       expect(logMessages).toContain(
-        "--verify-access=false and --no-verify-access are no longer needed, since skipping access verification is now the default behavior."
+        "--verify-access=false and --no-verify-access are no longer needed, because the legacy preemptive access verification is now disabled by default. Requests will fail with appropriate errors when not authorized correctly."
       );
     });
 

--- a/commands/publish/command.js
+++ b/commands/publish/command.js
@@ -102,19 +102,14 @@ exports.builder = (yargs) => {
       type: "boolean",
     },
     "no-verify-access": {
+      // proxy for --verify-access
       describe: "Do not verify package read-write access for current npm user.",
       type: "boolean",
     },
     "verify-access": {
-      // proxy for --no-verify-access
-      hidden: true,
+      describe: "Verify package read-write access for current npm user.",
       type: "boolean",
     },
-    // y: {
-    //   describe: "Skip all confirmation prompts.",
-    //   alias: "yes",
-    //   type: "boolean",
-    // },
   };
 
   composeVersionOptions(yargs);

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -82,10 +82,11 @@ class PublishCommand extends Command {
 
     // inverted boolean options are only respected if prefixed with `--no-`, e.g. `--no-verify-access`
     this.gitReset = gitReset !== false;
-    this.verifyAccess = verifyAccess !== false;
 
     // consumed by npm-registry-fetch (via libnpmpublish)
     this.npmSession = crypto.randomBytes(8).toString("hex");
+
+    this.verifyAccess = verifyAccess;
   }
 
   get userAgent() {
@@ -94,6 +95,13 @@ class PublishCommand extends Command {
   }
 
   initialize() {
+    if (this.options.verifyAccess === false) {
+      this.logger.warn(
+        "verify-access",
+        "--verify-access=false and --no-verify-access are no longer needed, since skipping access verification is now the default behavior."
+      );
+    }
+
     if (this.options.skipNpm) {
       // TODO: remove in next major release
       this.logger.warn("deprecated", "Instead of --skip-npm, call `lerna version` directly");

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -98,7 +98,7 @@ class PublishCommand extends Command {
     if (this.options.verifyAccess === false) {
       this.logger.warn(
         "verify-access",
-        "--verify-access=false and --no-verify-access are no longer needed, since skipping access verification is now the default behavior."
+        "--verify-access=false and --no-verify-access are no longer needed, because the legacy preemptive access verification is now disabled by default. Requests will fail with appropriate errors when not authorized correctly."
       );
     }
 

--- a/commands/publish/lib/get-npm-username.js
+++ b/commands/publish/lib/get-npm-username.js
@@ -54,6 +54,13 @@ function getNpmUsername(options) {
     opts.log.resume();
 
     if (opts.registry === "https://registry.npmjs.org/") {
+      if (err.code === "E403") {
+        throw new ValidationError(
+          "ENEEDAUTH",
+          "Cannot verify access when authenticating with a npm automation token. Set `command.publish.verifyAccess=false` in your lerna.json to skip this verification, or use a different type of npm access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
+        );
+      }
+
       throw new ValidationError("EWHOAMI", "Authentication error. Use `npm whoami` to troubleshoot.");
     }
 

--- a/commands/publish/lib/get-npm-username.js
+++ b/commands/publish/lib/get-npm-username.js
@@ -57,7 +57,7 @@ function getNpmUsername(options) {
       if (err.code === "E403") {
         throw new ValidationError(
           "ENEEDAUTH",
-          "Access verification failed. If you are authenticating with a npm automation token, set `command.publish.verifyAccess=false` in your lerna.json to skip this verification, or use a different type of npm access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
+          "Access verification failed. Ensure that your npm access token has both read and write access, or remove the verifyAccess option to skip this verification. Note that npm automation tokens do NOT have read access (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
         );
       }
 

--- a/commands/publish/lib/get-npm-username.js
+++ b/commands/publish/lib/get-npm-username.js
@@ -57,7 +57,7 @@ function getNpmUsername(options) {
       if (err.code === "E403") {
         throw new ValidationError(
           "ENEEDAUTH",
-          "Cannot verify access when authenticating with a npm automation token. Set `command.publish.verifyAccess=false` in your lerna.json to skip this verification, or use a different type of npm access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
+          "Access verification failed. If you are authenticating with a npm automation token, set `command.publish.verifyAccess=false` in your lerna.json to skip this verification, or use a different type of npm access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)."
         );
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Default `verifyAccess` to false for `publish`. Improve error message when encountering a npm automation token with verifyAccess=true.

## Description
<!--- Describe your changes in detail -->
Lerna will no longer try to verify the user's access (to the npm packages they are publishing) by default during `lerna publish`. Setting the verifyAccess option will still perform the verification as before. This also removes the need to ever use `--no-verify-access`, since that is now the default behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is important because the standard for authentication to npm in a CI/CD pipeline is using a [npm automation token](https://docs.npmjs.com/creating-and-viewing-access-tokens). These tokens do not support the `verifyAccess` option, due to the automation token's lack of read permissions. This PR also adds a more detailed error for the user when this case is encountered.

See https://github.com/lerna/lerna/issues/2788 for discussion on lerna & npm automation tokens.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I manually tested publishing a new lerna repo with a npm automation token and observed the behavior, both with verifyAccess=true and verifyAccess=false. I also performed this same test using a npm "publish" token. Unit tests have been added to cover the new behavior and the changed default behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
