### PR TITLE
feat(publish): include all dependencies in package graph by default, allow no-sort

### DIFF
--- a/commands/publish/__tests__/publish-canary.test.js
+++ b/commands/publish/__tests__/publish-canary.test.js
@@ -79,9 +79,9 @@ test("publish --canary", async () => {
   expect(npmPublish.registry).toMatchInlineSnapshot(`
 Map {
   "package-1" => "canary",
-  "package-3" => "canary",
   "package-4" => "canary",
   "package-2" => "canary",
+  "package-3" => "canary",
 }
 `);
   expect(writePkg.updatedVersions()).toMatchInlineSnapshot(`

--- a/commands/publish/__tests__/publish-from-git.test.js
+++ b/commands/publish/__tests__/publish-from-git.test.js
@@ -43,9 +43,29 @@ describe("publish from-git", () => {
     expect(output.logged()).toMatch("Found 4 packages to publish:");
     expect(npmPublish.order()).toEqual([
       "package-1",
-      "package-3",
       "package-4",
       "package-2",
+      "package-3",
+      // package-5 is private
+    ]);
+  });
+
+  it("publishes tagged packages, lexically sorted when --no-sort is present", async () => {
+    const cwd = await initFixture("normal");
+
+    await gitTag(cwd, "v1.0.0");
+    await lernaPublish(cwd)("from-git", "--no-sort");
+
+    // called from chained describeRef()
+    expect(throwIfUncommitted).toHaveBeenCalled();
+
+    expect(promptConfirmation).toHaveBeenLastCalledWith("Are you sure you want to publish these packages?");
+    expect(output.logged()).toMatch("Found 4 packages to publish:");
+    expect(npmPublish.order()).toEqual([
+      "package-1",
+      "package-2",
+      "package-3",
+      "package-4",
       // package-5 is private
     ]);
   });
@@ -64,9 +84,9 @@ describe("publish from-git", () => {
 
     expect(npmPublish.order()).toEqual([
       "package-1",
-      "package-3",
       "package-4",
       "package-2",
+      "package-3",
       // package-5 is private
     ]);
   });
@@ -79,9 +99,9 @@ describe("publish from-git", () => {
 
     expect(npmPublish.order()).toEqual([
       "package-1",
-      "package-3",
       "package-4",
       "package-2",
+      "package-3",
       // package-5 is private
     ]);
   });

--- a/commands/publish/__tests__/publish-from-package.test.js
+++ b/commands/publish/__tests__/publish-from-package.test.js
@@ -55,9 +55,25 @@ describe("publish from-package", () => {
 
     expect(npmPublish.order()).toEqual([
       "package-1",
-      "package-3",
       "package-4",
       "package-2",
+      "package-3",
+      // package-5 is private
+    ]);
+  });
+
+  it("publishes unpublished independent packages, lexically sorted when --no-sort is present", async () => {
+    const cwd = await initFixture("independent");
+
+    getUnpublishedPackages.mockImplementationOnce((packageGraph) => Array.from(packageGraph.values()));
+
+    await lernaPublish(cwd)("from-package", "--no-sort");
+
+    expect(npmPublish.order()).toEqual([
+      "package-1",
+      "package-2",
+      "package-3",
+      "package-4",
       // package-5 is private
     ]);
   });

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -58,6 +58,9 @@ class PublishCommand extends Command {
   configureProperties() {
     super.configureProperties();
 
+    // For publish we want to enable topological sorting by default, but allow users to override with --no-sort
+    this.toposort = this.options.sort !== false;
+
     // Defaults are necessary here because yargs defaults
     // override durable options provided by a config file
     const {
@@ -99,6 +102,13 @@ class PublishCommand extends Command {
       this.logger.warn(
         "verify-access",
         "--verify-access=false and --no-verify-access are no longer needed, because the legacy preemptive access verification is now disabled by default. Requests will fail with appropriate errors when not authorized correctly."
+      );
+    }
+
+    if (this.options.graphType === "dependencies") {
+      this.logger.warn(
+        "graph-type",
+        "--graph-type=dependencies is deprecated and will be removed in lerna v6. If you have a use-case you feel requires it please open an issue to discuss: https://github.com/lerna/lerna/issues/new/choose"
       );
     }
 
@@ -626,15 +636,21 @@ class PublishCommand extends Command {
   }
 
   topoMapPackages(mapper) {
-    // we don't respect --no-sort here, sorry
     return runTopologically(this.packagesToPublish, mapper, {
       concurrency: this.concurrency,
       rejectCycles: this.options.rejectCycles,
-      // By default, do not include devDependencies in the graph because it would
-      // increase the chance of dependency cycles, causing less-than-ideal order.
-      // If the user has opted-in to --graph-type=all (or "graphType": "all" in lerna.json),
-      // devDependencies _will_ be included in the graph construction.
-      graphType: this.options.graphType === "all" ? "allDependencies" : "dependencies",
+      /**
+       * Previously `publish` had unique default behavior for graph creation vs other commands: it would only consider dependencies when finding
+       * edges by default (i.e. relationships between packages specified via devDependencies would be ignored). It was documented to be the case
+       * in order to try and reduce the chance of dependency cycles.
+       *
+       * We are removing this behavior altogether in v6 because we do not want to have different ways of constructing the graph,
+       * only different ways of utilizing it (e.g. --no-sort vs topological sort).
+       *
+       * Therefore until we remove graphType altogether in v6, we provide a way for users to opt into the old default behavior
+       * by setting the `graphType` option to `dependencies`.
+       */
+      graphType: this.options.graphType === "dependencies" ? "dependencies" : "allDependencies",
     });
   }
 
@@ -676,7 +692,12 @@ class PublishCommand extends Command {
       ].filter(Boolean)
     );
 
-    chain = chain.then(() => this.topoMapPackages(mapper));
+    chain = chain.then(() => {
+      if (this.toposort) {
+        return this.topoMapPackages(mapper);
+      }
+      return pMap(this.packagesToPublish, mapper, { concurrency: this.concurrency });
+    });
 
     chain = chain.then(() => removeTempLicenses(this.packagesToBeLicensed));
 
@@ -729,7 +750,12 @@ class PublishCommand extends Command {
       ].filter(Boolean)
     );
 
-    chain = chain.then(() => this.topoMapPackages(mapper));
+    chain = chain.then(() => {
+      if (this.toposort) {
+        return this.topoMapPackages(mapper);
+      }
+      return pMap(this.packagesToPublish, mapper, { concurrency: this.concurrency });
+    });
 
     if (!this.hasRootedLeaf) {
       // cyclical "publish" lifecycles are automatically skipped
@@ -772,7 +798,12 @@ class PublishCommand extends Command {
         });
     };
 
-    chain = chain.then(() => this.topoMapPackages(mapper));
+    chain = chain.then(() => {
+      if (this.toposort) {
+        return this.topoMapPackages(mapper);
+      }
+      return pMap(this.packagesToPublish, mapper, { concurrency: this.concurrency });
+    });
 
     return chain.finally(() => tracker.finish());
   }

--- a/core/lerna/schemas/lerna-schema.json
+++ b/core/lerna/schemas/lerna-schema.json
@@ -1600,8 +1600,10 @@
         },
         "graphType": {
           "type": "string",
-          "enum": ["all", "depencencies"],
-          "description": "For `lerna publish`, the type of dependency to use when determining package hierarchy."
+          "enum": ["all", "dependencies"],
+          "description": "DEPRECATED: For `lerna publish`, if you want to ignore devDependencies when considering the package graph you can set this property equal to 'dependencies'. This will be removed in v6 of lerna.",
+          "default": "all",
+          "deprecated": true
         },
         "otp": {
           "type": "string",


### PR DESCRIPTION
Users can still opt into the old behavior of ignoring `devDependencies` until v6 by passing `--graph-type=dependencies`, or setting it in their `lerna.json`.

---

Note: For the unit test _updates_ it's down to the fact that in the relevant fixture, `package-3` has a devDependency on `package-2`, so it now comes after it in the ordering.