### PR TITLE
fix(create): Default test script no longer errors

### DIFF
--- a/commands/create/__tests__/__snapshots__/create-command.test.js.snap
+++ b/commands/create/__tests__/__snapshots__/create-command.test.js.snap
@@ -43,7 +43,7 @@ index SHA..SHA
 +'use strict';
 +
 +const myCli = require('..');
-+const assert = require('node:assert').strict;
++const assert = require('assert').strict;
 +
 +assert.strictEqual(myCli(), 'Hello from myCli');
 +console.info("myCli tests passed");
@@ -185,7 +185,7 @@ index SHA..SHA
 +++ b/packages/my-es-cli/__tests__/my-es-cli.test.js
 @@ -0,0 +1,5 @@
 +import myEsCli from '../src/my-es-cli.js';
-+import { strict as assert } from 'node:assert';
++import { strict as assert } from 'assert';
 +
 +assert.strictEqual(myEsCli(), 'Hello from myEsCli');
 +console.info("myEsCli tests passed");
@@ -311,7 +311,7 @@ index SHA..SHA
 +'use strict';
 +
 +const myPkg = require('..');
-+const assert = require('node:assert').strict;
++const assert = require('assert').strict;
 +
 +assert.strictEqual(myPkg(), 'Hello from myPkg');
 +console.info("myPkg tests passed");
@@ -388,7 +388,7 @@ index SHA..SHA
 +++ b/packages/my-pkg/__tests__/my-pkg.test.js
 @@ -0,0 +1,5 @@
 +import myPkg from '../src/my-pkg.js';
-+import { strict as assert } from 'node:assert';
++import { strict as assert } from 'assert';
 +
 +assert.strictEqual(myPkg(), 'Hello from myPkg');
 +console.info("myPkg tests passed");

--- a/commands/create/__tests__/__snapshots__/create-command.test.js.snap
+++ b/commands/create/__tests__/__snapshots__/create-command.test.js.snap
@@ -134,7 +134,7 @@ index SHA..SHA
 +    "url": "git+https://github.com/test/test.git"
 +  },
 +  "scripts": {
-+    "test": "node \\"./__tests__/my-cli.test.js\\""
++    "test": "node ./__tests__/my-cli.test.js"
 +  },
 +  "dependencies": {
 +    "yargs": "^1.0.0-mocked"
@@ -232,7 +232,7 @@ index SHA..SHA
 +    "url": "git+https://github.com/test/test.git"
 +  },
 +  "scripts": {
-+    "test": "node \\"./__tests__/my-es-cli.test.js\\""
++    "test": "node ./__tests__/my-es-cli.test.js"
 +  },
 +  "dependencies": {
 +    "yargs": "^1.0.0-mocked"
@@ -354,7 +354,7 @@ index SHA..SHA
 +    "url": "git+https://github.com/test/test.git"
 +  },
 +  "scripts": {
-+    "test": "node \\"./__tests__/my-pkg.test.js\\""
++    "test": "node ./__tests__/my-pkg.test.js"
 +  },
 +  "bugs": {
 +    "url": "https://github.com/test/test/issues"
@@ -419,7 +419,7 @@ index SHA..SHA
 +    "url": "git+https://github.com/test/test.git"
 +  },
 +  "scripts": {
-+    "test": "node \\"./__tests__/my-pkg.test.js\\""
++    "test": "node ./__tests__/my-pkg.test.js"
 +  },
 +  "type": "module",
 +  "bugs": {

--- a/commands/create/__tests__/__snapshots__/create-command.test.js.snap
+++ b/commands/create/__tests__/__snapshots__/create-command.test.js.snap
@@ -43,10 +43,10 @@ index SHA..SHA
 +'use strict';
 +
 +const myCli = require('..');
++const assert = require('node:assert').strict;
 +
-+describe('my-cli', () => {
-+    it('needs tests');
-+});
++assert.strictEqual(myCli(), 'Hello from myCli');
++console.info("myCli tests passed");
 diff --git a/packages/my-cli/bin/my-cli b/packages/my-cli/bin/my-cli
 new file mode 100755
 index SHA..SHA
@@ -102,7 +102,7 @@ index SHA..SHA
 +module.exports = myCli;
 +
 +function myCli() {
-+    // TODO
++    return "Hello from myCli";
 +}
 diff --git a/packages/my-cli/package.json b/packages/my-cli/package.json
 new file mode 100644
@@ -134,7 +134,7 @@ index SHA..SHA
 +    "url": "git+https://github.com/test/test.git"
 +  },
 +  "scripts": {
-+    "test": "echo \\"Error: run tests from root\\" && exit 1"
++    "test": "node \\"./__tests__/my-cli.test.js\\""
 +  },
 +  "dependencies": {
 +    "yargs": "^1.0.0-mocked"
@@ -184,11 +184,11 @@ index SHA..SHA
 --- /dev/null
 +++ b/packages/my-es-cli/__tests__/my-es-cli.test.js
 @@ -0,0 +1,5 @@
-+import myEsCli from '../src/my-es-cli';
++import myEsCli from '../src/my-es-cli.js';
++import { strict as assert } from 'node:assert';
 +
-+describe('my-es-cli', () => {
-+    it('needs tests');
-+});
++assert.strictEqual(myEsCli(), 'Hello from myEsCli');
++console.info("myEsCli tests passed");
 diff --git a/packages/my-es-cli/bin/my-es-cli b/packages/my-es-cli/bin/my-es-cli
 new file mode 100755
 index SHA..SHA
@@ -206,7 +206,7 @@ new file mode 100644
 index SHA..SHA
 --- /dev/null
 +++ b/packages/my-es-cli/package.json
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,36 @@
 +{
 +  "name": "my-es-cli",
 +  "version": "1.2.3",
@@ -232,11 +232,12 @@ index SHA..SHA
 +    "url": "git+https://github.com/test/test.git"
 +  },
 +  "scripts": {
-+    "test": "echo \\"Error: run tests from root\\" && exit 1"
++    "test": "node \\"./__tests__/my-es-cli.test.js\\""
 +  },
 +  "dependencies": {
 +    "yargs": "^1.0.0-mocked"
 +  },
++  "type": "module",
 +  "bugs": {
 +    "url": "https://github.com/test/test/issues"
 +  },
@@ -279,7 +280,7 @@ index SHA..SHA
 +++ b/packages/my-es-cli/src/my-es-cli.js
 @@ -0,0 +1,3 @@
 +export default function myEsCli() {
-+    // TODO
++    return "Hello from myEsCli";
 +}
 `;
 
@@ -310,10 +311,10 @@ index SHA..SHA
 +'use strict';
 +
 +const myPkg = require('..');
++const assert = require('node:assert').strict;
 +
-+describe('my-pkg', () => {
-+    it('needs tests');
-+});
++assert.strictEqual(myPkg(), 'Hello from myPkg');
++console.info("myPkg tests passed");
 diff --git a/packages/my-pkg/lib/my-pkg.js b/packages/my-pkg/lib/my-pkg.js
 new file mode 100644
 index SHA..SHA
@@ -325,7 +326,7 @@ index SHA..SHA
 +module.exports = myPkg;
 +
 +function myPkg() {
-+    // TODO
++    return "Hello from myPkg";
 +}
 diff --git a/packages/my-pkg/package.json b/packages/my-pkg/package.json
 new file mode 100644
@@ -353,7 +354,7 @@ index SHA..SHA
 +    "url": "git+https://github.com/test/test.git"
 +  },
 +  "scripts": {
-+    "test": "echo \\"Error: run tests from root\\" && exit 1"
++    "test": "node \\"./__tests__/my-pkg.test.js\\""
 +  },
 +  "bugs": {
 +    "url": "https://github.com/test/test/issues"
@@ -386,17 +387,17 @@ index SHA..SHA
 --- /dev/null
 +++ b/packages/my-pkg/__tests__/my-pkg.test.js
 @@ -0,0 +1,5 @@
-+import myPkg from '../src/my-pkg';
++import myPkg from '../src/my-pkg.js';
++import { strict as assert } from 'node:assert';
 +
-+describe('my-pkg', () => {
-+    it('needs tests');
-+});
++assert.strictEqual(myPkg(), 'Hello from myPkg');
++console.info("myPkg tests passed");
 diff --git a/packages/my-pkg/package.json b/packages/my-pkg/package.json
 new file mode 100644
 index SHA..SHA
 --- /dev/null
 +++ b/packages/my-pkg/package.json
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,29 @@
 +{
 +  "name": "my-pkg",
 +  "version": "1.2.3",
@@ -418,8 +419,9 @@ index SHA..SHA
 +    "url": "git+https://github.com/test/test.git"
 +  },
 +  "scripts": {
-+    "test": "echo \\"Error: run tests from root\\" && exit 1"
++    "test": "node \\"./__tests__/my-pkg.test.js\\""
 +  },
++  "type": "module",
 +  "bugs": {
 +    "url": "https://github.com/test/test/issues"
 +  },
@@ -432,6 +434,6 @@ index SHA..SHA
 +++ b/packages/my-pkg/src/my-pkg.js
 @@ -0,0 +1,3 @@
 +export default function myPkg() {
-+    // TODO
++    return "Hello from myPkg";
 +}
 `;

--- a/commands/create/__tests__/create-command.test.js
+++ b/commands/create/__tests__/create-command.test.js
@@ -356,4 +356,20 @@ describe("CreateCommand", () => {
 
     expect(await manifestCreated(cwd)).not.toHaveProperty("repository");
   });
+
+  it("adds type field when using esModule", async () => {
+    const cwd = await initFixture("basic");
+
+    await lernaCreate(cwd)("a-pkg", "--es-module");
+
+    expect(await manifestCreated(cwd)).toHaveProperty("type", "module");
+  });
+
+  it("skips type field when not using esModule", async () => {
+    const cwd = await initFixture("basic");
+
+    await lernaCreate(cwd)("a-pkg");
+
+    expect(await manifestCreated(cwd)).not.toHaveProperty("type");
+  });
 });

--- a/commands/create/index.js
+++ b/commands/create/index.js
@@ -399,7 +399,7 @@ class CreateCommand extends Command {
     const libContent = this.options.esModule
       ? dedent`
         export default function ${this.camelName}() {
-            // TODO
+            return "Hello from ${this.camelName}";
         }
       `
       : dedent`
@@ -408,7 +408,7 @@ class CreateCommand extends Command {
         module.exports = ${this.camelName};
 
         function ${this.camelName}() {
-            // TODO
+            return "Hello from ${this.camelName}";
         }
     `;
 
@@ -418,20 +418,20 @@ class CreateCommand extends Command {
   writeTestFile() {
     const testContent = this.options.esModule
       ? dedent`
-        import ${this.camelName} from '../src/${this.dirName}';
+        import ${this.camelName} from '../src/${this.dirName}.js';
+        import { strict as assert } from 'node:assert';
 
-        describe('${this.pkgName}', () => {
-            it('needs tests');
-        });
+        assert.strictEqual(${this.camelName}(), 'Hello from ${this.camelName}');
+        console.info("${this.camelName} tests passed");
       `
       : dedent`
         'use strict';
 
         const ${this.camelName} = require('..');
+        const assert = require('node:assert').strict;
 
-        describe('${this.pkgName}', () => {
-            it('needs tests');
-        });
+        assert.strictEqual(${this.camelName}(), 'Hello from ${this.camelName}');
+        console.info("${this.camelName} tests passed");
       `;
 
     return catFile(this.testDir, this.testFileName, testContent);

--- a/commands/create/index.js
+++ b/commands/create/index.js
@@ -419,7 +419,7 @@ class CreateCommand extends Command {
     const testContent = this.options.esModule
       ? dedent`
         import ${this.camelName} from '../src/${this.dirName}.js';
-        import { strict as assert } from 'node:assert';
+        import { strict as assert } from 'assert';
 
         assert.strictEqual(${this.camelName}(), 'Hello from ${this.camelName}');
         console.info("${this.camelName} tests passed");
@@ -428,7 +428,7 @@ class CreateCommand extends Command {
         'use strict';
 
         const ${this.camelName} = require('..');
-        const assert = require('node:assert').strict;
+        const assert = require('assert').strict;
 
         assert.strictEqual(${this.camelName}(), 'Hello from ${this.camelName}');
         console.info("${this.camelName} tests passed");

--- a/commands/create/lib/lerna-module-data.js
+++ b/commands/create/lib/lerna-module-data.js
@@ -193,10 +193,14 @@ if (!this.package.repository) {
 
 if (!this.package.scripts) {
   exports.scripts = {
-    test: 'echo "Error: run tests from root" && exit 1',
+    test: `node "./__tests__/${name}.test.js"`,
   };
 }
 
 if (!this.package.dependencies && this.config.get("dependencies")) {
   exports.dependencies = this.config.get("dependencies");
+}
+
+if (this.config.get("esModule")) {
+  exports.type = "module";
 }

--- a/commands/create/lib/lerna-module-data.js
+++ b/commands/create/lib/lerna-module-data.js
@@ -193,7 +193,7 @@ if (!this.package.repository) {
 
 if (!this.package.scripts) {
   exports.scripts = {
-    test: `node "./__tests__/${name}.test.js"`,
+    test: `node ./__tests__/${name}.test.js`,
   };
 }
 

--- a/e2e/tests/lerna-diff/lerna-diff.spec.ts
+++ b/e2e/tests/lerna-diff/lerna-diff.spec.ts
@@ -52,7 +52,7 @@ describe("lerna-diff", () => {
       @@ -19,5 +19,8 @@
          },
          "scripts": {
-           "test": "echo \\"Error: run tests from root\\" && exit 1"
+           "test": "node \\"./__tests__/package-a.test.js\\""
       +  },
       +  "dependencies": {
       +    "package-b": "0.0.0"
@@ -65,7 +65,7 @@ describe("lerna-diff", () => {
       @@ -19,5 +19,8 @@
          },
          "scripts": {
-           "test": "echo \\"Error: run tests from root\\" && exit 1"
+           "test": "node \\"./__tests__/package-b.test.js\\""
       +  },
       +  "dependencies": {
       +    "package-a": "0.0.0"
@@ -98,7 +98,7 @@ describe("lerna-diff", () => {
       @@ -19,5 +19,8 @@
          },
          "scripts": {
-           "test": "echo \\"Error: run tests from root\\" && exit 1"
+           "test": "node \\"./__tests__/package-a.test.js\\""
       +  },
       +  "dependencies": {
       +    "package-b": "0.0.0"

--- a/e2e/tests/lerna-diff/lerna-diff.spec.ts
+++ b/e2e/tests/lerna-diff/lerna-diff.spec.ts
@@ -52,7 +52,7 @@ describe("lerna-diff", () => {
       @@ -19,5 +19,8 @@
          },
          "scripts": {
-           "test": "node \\"./__tests__/package-a.test.js\\""
+           "test": "node ./__tests__/package-a.test.js"
       +  },
       +  "dependencies": {
       +    "package-b": "0.0.0"
@@ -65,7 +65,7 @@ describe("lerna-diff", () => {
       @@ -19,5 +19,8 @@
          },
          "scripts": {
-           "test": "node \\"./__tests__/package-b.test.js\\""
+           "test": "node ./__tests__/package-b.test.js"
       +  },
       +  "dependencies": {
       +    "package-a": "0.0.0"
@@ -98,7 +98,7 @@ describe("lerna-diff", () => {
       @@ -19,5 +19,8 @@
          },
          "scripts": {
-           "test": "node \\"./__tests__/package-a.test.js\\""
+           "test": "node ./__tests__/package-a.test.js"
       +  },
       +  "dependencies": {
       +    "package-b": "0.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When running `lerna create`, the generated files will now include a test that is actually runnable via `lerna run test`. 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, running `lerna run test` on a newly created package would produce an error that told the user to "run tests from the root", which makes no sense. This change improves developer experience when using `lerna create` by leaving the user's workspace in a runnable state immediately after package creation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually, with and without --es-module, on a test lerna workspace. New unit tests have also been added as well as existing ones updated appropriately.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
