### PR TITLE
chore: fix local publish

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,6 +4,8 @@
   "description": "e2e tests for lerna packages",
   "scripts": {
     "start-verdaccio": "verdaccio --config ./local-registry/config.yml --listen 4872",
-    "kill-verdaccio": "kill $(lsof -t -i:4872) || true"
+    "kill-verdaccio": "kill $(lsof -t -i:4872) || true",
+    "prepare-local-publish": "./prepare-local-publish.sh",
+    "publish-to-verdaccio": "npm_config_registry=\"http://localhost:4872/\" ./publish-to-verdaccio.sh"
   }
 }

--- a/e2e/project.json
+++ b/e2e/project.json
@@ -14,12 +14,12 @@
             "forwardAllArgs": false
           },
           {
-            "command": "./prepare-local-publish.sh",
+            "command": "npm run prepare-local-publish",
             "description": "Prepare the dist/ directory ready for publishing to verdaccio",
             "forwardAllArgs": false
           },
           {
-            "command": "npm_config_registry=\"http://localhost:4872/\" ./publish-to-verdaccio.sh 999.9.9-e2e.0",
+            "command": "npm run publish-to-verdaccio -- 999.9.9-e2e.0",
             "description": "Publish all the lerna packages to the verdaccio instance",
             "forwardAllArgs": false
           },


### PR DESCRIPTION
Some necessary npm scripts were missing when performing an ad hoc local publish outside of the e2e test flow, per our CONTRIBUTING.md guidelines