### PR TITLE
fix(version): Ignore npm lifecycle scripts on package lock update

### DIFF
--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -618,9 +618,11 @@ class VersionCommand extends Command {
       if (fs.existsSync(lockfilePath)) {
         chain = chain.then(() => {
           this.logger.verbose("version", "Updating root package-lock.json");
-          return childProcess.exec("npm", ["install", "--package-lock-only"], this.execOpts).then(() => {
-            changedFiles.add(lockfilePath);
-          });
+          return childProcess
+            .exec("npm", ["install", "--package-lock-only", "--ignore-scripts"], this.execOpts)
+            .then(() => {
+              changedFiles.add(lockfilePath);
+            });
         });
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an issue where npm install lifecycle scripts were being run during the version command.

## Description
<!--- Describe your changes in detail -->
This change passes the --ignore-scripts option to the `npm install` command used to update the lockfile during the version command. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This prevents npm lifecycle scripts from running, which can cause CI workflows to fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
An end to end test has been created to cover the case of having failing lifecycle scripts during a version command. I also manually tested the change against a local environment with install scripts and git commit hooks (with [husky](https://typicode.github.io/husky/#/)).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
