### PR TITLE
chore: remove unnecessary whatwg-url dependency

### DIFF
--- a/commands/create/index.js
+++ b/commands/create/index.js
@@ -3,7 +3,6 @@
 const fs = require("fs-extra");
 const path = require("path");
 const os = require("os");
-const { URL } = require("whatwg-url");
 const { camelCase } = require("yargs-parser");
 const dedent = require("dedent");
 const initPackageJson = require("pify")(require("init-package-json"));

--- a/commands/create/package.json
+++ b/commands/create/package.json
@@ -49,7 +49,6 @@
     "slash": "^3.0.0",
     "validate-npm-package-license": "^3.0.4",
     "validate-npm-package-name": "^4.0.0",
-    "whatwg-url": "^8.4.0",
     "yargs-parser": "20.2.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
         "upath": "^2.0.1",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^4.0.0",
-        "whatwg-url": "^8.4.0",
         "write-file-atomic": "^4.0.1",
         "write-json-file": "^4.3.0",
         "write-pkg": "^4.0.0",
@@ -231,7 +230,6 @@
         "slash": "^3.0.0",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^4.0.0",
-        "whatwg-url": "^8.4.0",
         "yargs-parser": "20.2.4"
       },
       "engines": {
@@ -12185,7 +12183,8 @@
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -14429,6 +14428,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -16259,6 +16259,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
       "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -17094,6 +17095,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
       "engines": {
         "node": ">=10.4"
       }
@@ -17117,6 +17119,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
       "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+      "dev": true,
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",
@@ -17614,8 +17617,7 @@
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",
-        "npmlog": "^6.0.2",
-        "whatwg-url": "^8.4.0"
+        "npmlog": "^6.0.2"
       },
       "engines": {
         "node": "^14.15.0 || >=16.0.0"
@@ -19524,7 +19526,6 @@
         "slash": "^3.0.0",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^4.0.0",
-        "whatwg-url": "^8.4.0",
         "yargs-parser": "20.2.4"
       }
     },
@@ -19612,8 +19613,7 @@
       "version": "file:utils/gitlab-client",
       "requires": {
         "node-fetch": "^2.6.1",
-        "npmlog": "^6.0.2",
-        "whatwg-url": "^8.4.0"
+        "npmlog": "^6.0.2"
       }
     },
     "@lerna/global-options": {
@@ -27508,7 +27508,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -29192,7 +29193,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -30595,6 +30597,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
       "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -31229,7 +31232,8 @@
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -31250,6 +31254,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
       "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "upath": "^2.0.1",
     "validate-npm-package-license": "^3.0.4",
     "validate-npm-package-name": "^4.0.0",
-    "whatwg-url": "^8.4.0",
     "write-file-atomic": "^4.0.1",
     "write-json-file": "^4.3.0",
     "write-pkg": "^4.0.0",

--- a/utils/gitlab-client/__tests__/GitLabClient.test.js
+++ b/utils/gitlab-client/__tests__/GitLabClient.test.js
@@ -9,7 +9,7 @@ const { GitLabClient } = require("../lib/GitLabClient");
 describe("GitLabClient", () => {
   describe("constructor", () => {
     it("sets `baseUrl` and `token`", () => {
-      const client = new GitLabClient("http://some/host", "TOKEN");
+      const client = new GitLabClient("TOKEN", "http://some/host");
 
       expect(client.baseUrl).toEqual("http://some/host");
       expect(client.token).toEqual("TOKEN");
@@ -18,7 +18,7 @@ describe("GitLabClient", () => {
 
   describe("releasesUrl", () => {
     it("returns a GitLab releases API URL", () => {
-      const client = new GitLabClient("http://some/host", "TOKEN");
+      const client = new GitLabClient("TOKEN", "http://some/host");
       const url = client.releasesUrl("the-namespace", "the-project");
 
       expect(url).toEqual("http://some/host/projects/the-namespace%2Fthe-project/releases");
@@ -27,7 +27,7 @@ describe("GitLabClient", () => {
 
   describe("createRelease", () => {
     it("requests releases api with release", () => {
-      const client = new GitLabClient("http://some/host", "TOKEN");
+      const client = new GitLabClient("TOKEN", "http://some/host");
       fetch.mockResolvedValue({ ok: true });
       const release = {
         owner: "the-owner",

--- a/utils/gitlab-client/__tests__/gitlab-client.test.js
+++ b/utils/gitlab-client/__tests__/gitlab-client.test.js
@@ -32,7 +32,7 @@ describe("createGitLabClient", () => {
 
     createGitLabClient();
 
-    expect(GitLabClient).toHaveBeenCalledWith("http://some/host", "TOKEN");
+    expect(GitLabClient).toHaveBeenCalledWith("TOKEN", "http://some/host");
   });
 
   it("has a createRelease method like ocktokit", () => {

--- a/utils/gitlab-client/index.js
+++ b/utils/gitlab-client/index.js
@@ -19,7 +19,7 @@ function createGitLabClient() {
     throw new Error("A GL_TOKEN environment variable is required.");
   }
 
-  const client = new GitLabClient(GL_API_URL, GL_TOKEN);
+  const client = new GitLabClient(GL_TOKEN, GL_API_URL);
 
   return OcktokitAdapter(client);
 }

--- a/utils/gitlab-client/lib/GitLabClient.js
+++ b/utils/gitlab-client/lib/GitLabClient.js
@@ -2,12 +2,11 @@
 
 const path = require("path");
 
-const { URL } = require("whatwg-url");
 const log = require("npmlog");
 const fetch = require("node-fetch");
 
 class GitLabClient {
-  constructor(baseUrl = "https://gitlab.com/api/v4", token) {
+  constructor(token, baseUrl = "https://gitlab.com/api/v4") {
     this.baseUrl = baseUrl;
     this.token = token;
   }

--- a/utils/gitlab-client/package.json
+++ b/utils/gitlab-client/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "node-fetch": "^2.6.1",
-    "npmlog": "^6.0.2",
-    "whatwg-url": "^8.4.0"
+    "npmlog": "^6.0.2"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove the `whatwg-url` dependency that is no longer needed. Also fixes a lint error with the GitLabClient constructor.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Node v10 and above has native support for the WHATWG url specification via the global "URL" class, so a dedicated package for it is no longer needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests cover the creation of all URLs that were affected by this change (`GitLabClient.test.js` and `create-command.test.js`). Unit tests also cover the creation of the GitLabClient, whose arguments were rearranged for the lint fix. GitLabClient itself is not exported from the utility library, so it has no public consumers to worry about.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
