### PR TITLE
feat(filter-options): add `--ignore-dev-dependencies`

### DIFF
--- a/core/filter-options/README.md
+++ b/core/filter-options/README.md
@@ -92,3 +92,7 @@ $ lerna exec --since --include-merged-tags -- ls -la
 ```
 
 Include tags from merged branches when running a command with `--since`. This is only useful if you do a lot of publishing from feature branches, which is not generally recommended.
+
+### `--ignore-dev-dependencies`
+
+Exclude all transitive devDependencies when running a command regardless of `--include-dependencies` or `--include-dependents`.

--- a/core/filter-options/__tests__/get-filtered-packages.test.js
+++ b/core/filter-options/__tests__/get-filtered-packages.test.js
@@ -199,3 +199,25 @@ test("--include-dependencies", async () => {
   expect(result.map((pkg) => pkg.name)).toEqual(["package-3", "package-2", "package-1"]);
   expect(collectUpdates).not.toHaveBeenCalled();
 });
+
+test("--include-dependents --ignore-dev-dependencies", async () => {
+  const packageGraph = await buildGraph(cwd);
+  const execOpts = { cwd };
+  const options = parseOptions("--scope", "package-2", "--include-dependents", "--ignore-dev-dependencies");
+
+  const result = await getFilteredPackages(packageGraph, execOpts, options);
+
+  expect(result.map((pkg) => pkg.name)).toEqual(["package-2"]);
+  expect(collectUpdates).not.toHaveBeenCalled();
+});
+
+test("--include-dependencies --ignore-dev-dependencies", async () => {
+  const packageGraph = await buildGraph(cwd);
+  const execOpts = { cwd };
+  const options = parseOptions("--scope", "package-3", "--include-dependencies", "--ignore-dev-dependencies");
+
+  const result = await getFilteredPackages(packageGraph, execOpts, options);
+
+  expect(result.map((pkg) => pkg.name)).toEqual(["package-3"]);
+  expect(collectUpdates).not.toHaveBeenCalled();
+});

--- a/core/filter-options/index.js
+++ b/core/filter-options/index.js
@@ -68,6 +68,13 @@ function filterOptions(yargs) {
       hidden: true,
       type: "boolean",
     },
+    "ignore-dev-dependencies": {
+      describe: dedent`
+        Exclude all transitive devDependencies when running a command
+        regardless of --include-dependencies or --include-dependents.
+      `,
+      type: "boolean",
+    },
   };
 
   return yargs

--- a/core/filter-options/package.json
+++ b/core/filter-options/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@lerna/collect-updates": "file:../../utils/collect-updates",
     "@lerna/filter-packages": "file:../../utils/filter-packages",
+    "@lerna/package-graph": "file:../../core/package-graph",
     "dedent": "^0.7.0",
     "npmlog": "^6.0.2"
   }

--- a/e2e/tests/lerna-list/lerna-list-filter-options.spec.ts
+++ b/e2e/tests/lerna-list/lerna-list-filter-options.spec.ts
@@ -40,7 +40,7 @@ describe("lerna-list-filter-options", () => {
       dependencyName: "package-c",
       version: "0.0.0",
     });
-    await fixture.addDependencyToPackage({
+    await fixture.addDevDependencyToPackage({
       packagePath: "modules/package-a",
       dependencyName: "package-d",
       version: "0.0.0",
@@ -106,6 +106,23 @@ describe("lerna-list-filter-options", () => {
         package-a
         package-c
         lerna success found 2 packages
+
+      `);
+    });
+  });
+
+  describe("--include-dependents --ignore-dev-dependencies", () => {
+    it("should list all packages, narrowed to only those that match the scope glob, but with all of their dependents, excluding devDependecies", async () => {
+      const output = await fixture.lerna("list --all --scope package-d --include-dependents --ignore-dev-dependencies");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna notice filter including "package-d"
+        lerna notice filter excluding devDependencies
+        lerna notice filter including dependents
+        lerna info filter [ 'package-d' ]
+        package-d (PRIVATE)
+        lerna success found 1 package
 
       `);
     });

--- a/e2e/utils/fixture.ts
+++ b/e2e/utils/fixture.ts
@@ -229,6 +229,24 @@ export class Fixture {
     }));
   }
 
+  async addDevDependencyToPackage({
+    packagePath,
+    dependencyName,
+    version,
+  }: {
+    packagePath: string;
+    dependencyName: string;
+    version: string;
+  }): Promise<void> {
+    await this.updateJson(`${packagePath}/package.json`, (json) => ({
+      ...json,
+      devDependencies: {
+        ...(json.devDependencies as Record<string, string>),
+        [dependencyName]: version,
+      },
+    }));
+  }
+
   async addScriptsToPackage({
     packagePath,
     scripts,

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,6 +510,7 @@
       "dependencies": {
         "@lerna/collect-updates": "file:../../utils/collect-updates",
         "@lerna/filter-packages": "file:../../utils/filter-packages",
+        "@lerna/package-graph": "file:../../core/package-graph",
         "dedent": "^0.7.0",
         "npmlog": "^6.0.2"
       },
@@ -19573,6 +19574,7 @@
       "requires": {
         "@lerna/collect-updates": "file:../../utils/collect-updates",
         "@lerna/filter-packages": "file:../../utils/filter-packages",
+        "@lerna/package-graph": "file:../../core/package-graph",
         "dedent": "^0.7.0",
         "npmlog": "^6.0.2"
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This feature adds the filter option `--ignore-dev-dependencies` to exclude all transitive devDependencies when running a command regardless of `--include-dependencies` or `--include-dependents`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This feature is useful when creating custom and deployment scripts as it makes it possible to filter code dependencies from development environment dependencies.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes were manually tested in multiple test workspaces. Comprehensive end-to-end and unit tests have also been added around the new feature. The changes don't affect other areas of the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
