### PR TITLE
fix(run): Exclude dependencies with --scope when nx.json is not present

### DIFF
--- a/commands/run/command.js
+++ b/commands/run/command.js
@@ -73,6 +73,11 @@ exports.builder = (yargs) => {
         hidden: true,
         type: "boolean",
       },
+      verbose: {
+        group: "Command Options:",
+        describe: "When useNx is true, show verbose output from dependent tasks.",
+        type: "boolean",
+      },
     });
 
   return filterOptions(yargs);

--- a/core/command/__tests__/command.test.js
+++ b/core/command/__tests__/command.test.js
@@ -407,4 +407,103 @@ describe("core-command", () => {
       );
     });
   });
+
+  describe("loglevel with verbose option true", () => {
+    it("should be set to verbose if loglevel is error", async () => {
+      const command = testFactory({
+        loglevel: "error",
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("verbose");
+    });
+
+    it("should be set to verbose if loglevel is warn", async () => {
+      const command = testFactory({
+        loglevel: "warn",
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("verbose");
+    });
+
+    it("should be set to verbose if loglevel is info", async () => {
+      const command = testFactory({
+        loglevel: "info",
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("verbose");
+    });
+
+    it("should remain set to verbose if loglevel is verbose", async () => {
+      const command = testFactory({
+        loglevel: "verbose",
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("verbose");
+    });
+
+    it("should not be set to verbose if loglevel is silly", async () => {
+      const command = testFactory({
+        loglevel: "silly",
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("silly");
+    });
+  });
+
+  describe("loglevel without verbose option", () => {
+    it("should remain set to error if loglevel is error", async () => {
+      const command = testFactory({
+        loglevel: "error",
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("error");
+    });
+
+    it("should remain set to warn if loglevel is warn", async () => {
+      const command = testFactory({
+        loglevel: "warn",
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("warn");
+    });
+
+    it("should remain set to info if loglevel is info", async () => {
+      const command = testFactory({
+        loglevel: "info",
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("info");
+    });
+
+    it("should remain set to verbose if loglevel is verbose", async () => {
+      const command = testFactory({
+        loglevel: "verbose",
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("verbose");
+    });
+
+    it("should remain set to silly if loglevel is silly", async () => {
+      const command = testFactory({
+        loglevel: "silly",
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual("silly");
+    });
+  });
 });

--- a/core/command/index.js
+++ b/core/command/index.js
@@ -191,7 +191,7 @@ class Command {
   }
 
   configureLogging() {
-    const { loglevel, verbose } = this.options;
+    const { loglevel } = this.options;
 
     if (loglevel) {
       log.level = loglevel;

--- a/core/command/index.js
+++ b/core/command/index.js
@@ -171,6 +171,10 @@ class Command {
       // Environmental defaults prepared in previous step
       this.envDefaults
     );
+
+    if (this.options.verbose && this.options.loglevel !== "silly") {
+      this.options.loglevel = "verbose";
+    }
   }
 
   configureProperties() {
@@ -187,7 +191,7 @@ class Command {
   }
 
   configureLogging() {
-    const { loglevel } = this.options;
+    const { loglevel, verbose } = this.options;
 
     if (loglevel) {
       log.level = loglevel;

--- a/core/lerna/schemas/lerna-schema.json
+++ b/core/lerna/schemas/lerna-schema.json
@@ -1638,6 +1638,10 @@
         "skipNxCache": {
           "type": "boolean",
           "description": "During `lerna run`, when true, skip the nx cache."
+        },
+        "verbose": {
+          "type": "boolean",
+          "description": "When useNx is true, show verbose output from dependent tasks."
         }
       },
       "version": {

--- a/core/lerna/schemas/lerna-schema.json
+++ b/core/lerna/schemas/lerna-schema.json
@@ -905,6 +905,9 @@
             "profileLocation": {
               "$ref": "#/$defs/commandOptions/shared/profileLocation"
             },
+            "verbose": {
+              "$ref": "#/$defs/commandOptions/shared/verbose"
+            },
             "skipNxCache": {
               "$ref": "#/$defs/commandOptions/run/skipNxCache"
             },
@@ -1395,6 +1398,9 @@
     },
     "ignorePrepublish": {
       "$ref": "#/$defs/commandOptions/shared/ignorePrepublish"
+    },
+    "verbose": {
+      "$ref": "#/$defs/commandOptions/shared/verbose"
     }
   },
   "$defs": {
@@ -1638,10 +1644,6 @@
         "skipNxCache": {
           "type": "boolean",
           "description": "During `lerna run`, when true, skip the nx cache."
-        },
-        "verbose": {
-          "type": "boolean",
-          "description": "When useNx is true, show verbose output from dependent tasks."
         }
       },
       "version": {
@@ -1832,6 +1834,10 @@
         "ignorePrepublish": {
           "type": "boolean",
           "description": "During `lerna publish` and `lerna bootstrap`, when true, disable deprecated 'prepublish' lifecycle script."
+        },
+        "verbose": {
+          "type": "boolean",
+          "description": "When true, escalates loglevel to 'verbose' and shows nx verbose output if useNx is true."
         }
       }
     }

--- a/e2e/tests/lerna-run/lerna-run-nx-include-dependencies.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run-nx-include-dependencies.spec.ts
@@ -1,0 +1,163 @@
+import { remove } from "fs-extra";
+import { Fixture } from "../../utils/fixture";
+import { normalizeCommandOutput, normalizeEnvironment } from "../../utils/snapshot-serializer-utils";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommandOutput(normalizeEnvironment(str));
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-run-nx-include-dependencies", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      name: "lerna-run-nx-include-dependencies",
+      packageManager: "npm",
+      initializeGit: true,
+      runLernaInit: true,
+      installDependencies: true,
+      /**
+       * Because lerna run involves spawning further child processes, the tests would be too flaky
+       * if we didn't force deterministic terminal output by appending stderr to stdout instead
+       * of interleaving them.
+       */
+      forceDeterministicTerminalOutput: true,
+    });
+
+    await fixture.lerna("create package-1 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-1",
+      scripts: {
+        "print-name": "echo test-package-1",
+      },
+    });
+    await fixture.lerna("create package-2 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-2",
+      scripts: {
+        "print-name": "echo test-package-2",
+      },
+    });
+    await fixture.lerna("create package-3 -y --dependencies package-1 package-2");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-3",
+      scripts: {
+        "print-name": "echo test-package-3",
+      },
+    });
+
+    await fixture.updateJson("lerna.json", (json) => ({
+      ...json,
+      loglevel: "verbose",
+    }));
+  });
+  afterEach(() => fixture.destroy());
+
+  describe("without nx enabled", () => {
+    it("should exclude dependencies by default", async () => {
+      const output = await fixture.lerna("run print-name --scope package-3 -- --silent");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        test-package-X
+        lerna notice cli v999.9.9-e2e.0
+        lerna verb rootPath /tmp/lerna-e2e/lerna-run-nx-include-dependencies/lerna-workspace
+        lerna notice filter including "package-X"
+        lerna info filter [ 'package-X' ]
+        lerna info Executing command in 1 package: "npm run print-name --silent"
+        lerna info run Ran npm script 'print-name' in 'package-X' in X.Xs:
+        lerna success run Ran npm script 'print-name' in 1 package in X.Xs:
+        lerna success - package-X
+
+      `);
+    });
+  });
+
+  describe("with nx enabled, but no nx.json", () => {
+    it("should exclude dependencies by default", async () => {
+      await fixture.addNxToWorkspace();
+
+      await remove(fixture.getWorkspacePath("nx.json"));
+
+      const output = await fixture.lerna("run print-name --scope package-3 -- --silent");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+        > package-X:print-name --silent
+
+
+        > package-X@0.0.0 print-name
+        > echo test-package-X "--silent"
+
+        test-package-X --silent
+
+         
+
+         >  Lerna (powered by Nx)   Successfully ran target print-name for project package-X
+
+
+        lerna notice cli v999.9.9-e2e.0
+        lerna verb rootPath /tmp/lerna-e2e/lerna-run-nx-include-dependencies/lerna-workspace
+        lerna notice filter including "package-X"
+        lerna info filter [ 'package-X' ]
+        lerna verb run nx.json was not found. Task dependencies will not be automatically included.
+
+      `);
+    });
+  });
+
+  describe("with nx enabled and with nx.json", () => {
+    it("should include dependencies by default", async () => {
+      await fixture.addNxToWorkspace();
+
+      const output = await fixture.lerna("run print-name --scope package-3 -- --silent");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+         >  Lerna (powered by Nx)   Running target print-name for project package-X and 2 task(s) it depends on
+
+         
+
+        > package-X:print-name
+
+
+        > package-X@0.0.0 print-name
+        > echo test-package-X
+
+        test-package-X
+
+        > package-X:print-name
+
+
+        > package-X@0.0.0 print-name
+        > echo test-package-X
+
+        test-package-X
+
+        > package-X:print-name --silent
+
+
+        > package-X@0.0.0 print-name
+        > echo test-package-X "--silent"
+
+        test-package-X --silent
+
+         
+
+         >  Lerna (powered by Nx)   Successfully ran target print-name for project package-X
+
+
+        lerna notice cli v999.9.9-e2e.0
+        lerna verb rootPath /tmp/lerna-e2e/lerna-run-nx-include-dependencies/lerna-workspace
+        lerna notice filter including "package-X"
+        lerna info filter [ 'package-X' ]
+        lerna verb run nx.json was found. Task dependencies will be automatically included.
+
+      `);
+    });
+  });
+});

--- a/e2e/tests/lerna-run/lerna-run-nx-include-dependencies.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run-nx-include-dependencies.spec.ts
@@ -118,46 +118,46 @@ describe("lerna-run-nx-include-dependencies", () => {
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
 
-         >  Lerna (powered by Nx)   Running target print-name for project package-X and 2 task(s) it depends on
+ >  Lerna (powered by Nx)   Running target print-name for project package-X and 2 task(s) it depends on
 
-         
+ 
 
-        > package-X:print-name
-
-
-        > package-X@0.0.0 print-name
-        > echo test-package-X
-
-        test-package-X
-
-        > package-X:print-name
+> package-X:print-name
 
 
-        > package-X@0.0.0 print-name
-        > echo test-package-X
+> package-X@0.0.0 print-name
+> echo test-package-X
 
-        test-package-X
+test-package-X
 
-        > package-X:print-name --silent
-
-
-        > package-X@0.0.0 print-name
-        > echo test-package-X "--silent"
-
-        test-package-X --silent
-
-         
-
-         >  Lerna (powered by Nx)   Successfully ran target print-name for project package-X
+> package-X:print-name
 
 
-        lerna notice cli v999.9.9-e2e.0
-        lerna verb rootPath /tmp/lerna-e2e/lerna-run-nx-include-dependencies/lerna-workspace
-        lerna notice filter including "package-X"
-        lerna info filter [ 'package-X' ]
-        lerna verb run nx.json was found. Task dependencies will be automatically included.
+> package-X@0.0.0 print-name
+> echo test-package-X
 
-      `);
+test-package-X
+
+> package-X:print-name --silent
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X "--silent"
+
+test-package-X --silent
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for project package-X
+
+
+lerna notice cli v999.9.9-e2e.0
+lerna verb rootPath /tmp/lerna-e2e/lerna-run-nx-include-dependencies/lerna-workspace
+lerna notice filter including "package-X"
+lerna info filter [ 'package-X' ]
+lerna verb run nx.json was found. Task dependencies will be automatically included.
+
+`);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When nx.json is not present, packages being run will no longer include their dependencies when those dependencies would be filtered out by --scope. Using the flag `--include-dependencies` will cause them to be included again, as expected.

## Description
<!--- Describe your changes in detail -->
This preserves the default behavior of `lerna run --scope` when `useNx` is `true` and nx.json does not exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/lerna/lerna/issues/3289
https://github.com/lerna/lerna/issues/3298

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
End to end tests have been added that cover this behavior. The functionality was also manually tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
