### PR TITLE
fix(core): prevent validation error in version/publish with `workspace:` prefix

### DIFF
--- a/core/package-graph/__tests__/package-graph.test.js
+++ b/core/package-graph/__tests__/package-graph.test.js
@@ -300,31 +300,6 @@ describe("PackageGraph", () => {
           `"Package specification \\"test-1@^1.1.0\\" could not be resolved within the workspace. To reference a non-matching, remote version of a local dependency, remove the 'workspace:' prefix."`
         );
       });
-
-      it("throws an error when sibling package does not exist in the workspace, regardless of version specification", () => {
-        const packages = [
-          new Package(
-            {
-              name: "test-1",
-              version: "1.0.0",
-            },
-            "/test/test-1"
-          ),
-          new Package(
-            {
-              name: "test-2",
-              version: "1.0.0",
-              dependencies: {
-                "test-3": "workspace:^1.0.0",
-              },
-            },
-            "/test/test-2"
-          ),
-        ];
-        expect(() => new PackageGraph(packages)).toThrowErrorMatchingInlineSnapshot(
-          `"Package specification \\"test-3@^1.0.0\\" could not be resolved within the workspace. To use the 'workspace:' protocol, ensure that a package with name \\"test-3\\" exists in the current workspace."`
-        );
-      });
     });
   });
 
@@ -620,14 +595,6 @@ Set {
     });
   });
 });
-
-// eslint-disable-next-line no-unused-vars
-function deepInspect(obj) {
-  // jest console mutilates console.dir() options argument,
-  // so sidestep it by requiring the non-shimmed method directly.
-  // eslint-disable-next-line global-require
-  require("console").dir(obj, { depth: 10, compact: false });
-}
 
 function topoPackages() {
   return [

--- a/core/package-graph/index.js
+++ b/core/package-graph/index.js
@@ -73,13 +73,6 @@ class PackageGraph extends Map {
           fullWorkspaceSpec = spec;
           spec = spec.replace(/^workspace:/, "");
 
-          if (!depNode) {
-            throw new ValidationError(
-              "EWORKSPACE",
-              `Package specification "${depName}@${spec}" could not be resolved within the workspace. To use the 'workspace:' protocol, ensure that a package with name "${depName}" exists in the current workspace.`
-            );
-          }
-
           // replace aliases (https://pnpm.io/workspaces#referencing-workspace-packages-through-aliases)
           if (spec === "*" || spec === "^" || spec === "~") {
             workspaceAlias = spec;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prevents the validation error when the Package Graph is constructed without all of the dependencies listed by all packages.

This PR also removes an unused function from the package-graph unit tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During the changelog update of `version` and `publish`, the package graph is constructed with only the changed packages, so it can't make assumptions based on the existence of other packages in the workspace. In short, there is not enough information to properly validate what the validation error was asserting in all use cases of PackageGraph.

https://github.com/lerna/lerna/issues/3317

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change reverts a previously-added validation error. Tests checking for that validation error have been removed and all other unit/integration/e2e tests have passed. Lerna version and publish have also been run manually to verify that this change solves the issue above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
