### PR TITLE
fix(run): warn on incompatible arguments with useNx

### DIFF
--- a/commands/run/index.js
+++ b/commands/run/index.js
@@ -264,7 +264,7 @@ class RunCommand extends Command {
       if (this.options.parallel || this.options.sort !== undefined || this.options.includeDependencies) {
         this.logger.warn(
           this.name,
-          `"parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.`
+          `"parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.`
         );
       }
     } else {

--- a/commands/run/index.js
+++ b/commands/run/index.js
@@ -222,7 +222,7 @@ class RunCommand extends Command {
     const { readNxJson } = require("nx/src/config/configuration");
     const nxJson = readNxJson();
     const nxJsonExists = existsSync(path.join(this.project.rootPath, "nx.json"));
-    const useParallel = this.options.parallel && nxJsonExists;
+    const useParallel = this.options.parallel && !nxJsonExists;
 
     const targetDependenciesAreDefined =
       Object.keys(nxJson.targetDependencies || nxJson.targetDefaults || {}).length > 0;

--- a/commands/run/index.js
+++ b/commands/run/index.js
@@ -221,10 +221,13 @@ class RunCommand extends Command {
   prepNxOptions() {
     const { readNxJson } = require("nx/src/config/configuration");
     const nxJson = readNxJson();
+    const nxJsonExists = existsSync(path.join(this.project.rootPath, "nx.json"));
+    const useParallel = this.options.parallel && nxJsonExists;
+
     const targetDependenciesAreDefined =
       Object.keys(nxJson.targetDependencies || nxJson.targetDefaults || {}).length > 0;
     const targetDependencies =
-      this.toposort && !this.options.parallel && !targetDependenciesAreDefined
+      this.toposort && !useParallel && !targetDependenciesAreDefined
         ? {
             [this.script]: [
               {
@@ -247,7 +250,7 @@ class RunCommand extends Command {
        * To match lerna's own behavior (via pMap's default concurrency), we set parallel to a very large number if
        * the flag has been set (we can't use Infinity because that would cause issues with the task runner).
        */
-      parallel: this.options.parallel ? 999 : this.concurrency,
+      parallel: useParallel ? 999 : this.concurrency,
       nxBail: this.bail,
       nxIgnoreCycles: !this.options.rejectCycles,
       skipNxCache: this.options.skipNxCache,
@@ -255,18 +258,24 @@ class RunCommand extends Command {
       __overrides__: this.args.map((t) => t.toString()),
     };
 
-    const excludeTaskDependencies = !existsSync(path.join(this.project.rootPath, "nx.json"));
-    if (excludeTaskDependencies) {
+    if (nxJsonExists) {
+      this.logger.verbose(this.name, "nx.json was found. Task dependencies will be automatically included.");
+
+      if (this.options.parallel || this.options.sort !== undefined || this.options.includeDependencies) {
+        this.logger.warn(
+          this.name,
+          `"parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.`
+        );
+      }
+    } else {
       this.logger.verbose(
         this.name,
         "nx.json was not found. Task dependencies will not be automatically included."
       );
-    } else {
-      this.logger.verbose(this.name, "nx.json was found. Task dependencies will be automatically included.");
     }
 
     const extraOptions = {
-      excludeTaskDependencies,
+      excludeTaskDependencies: !nxJsonExists,
     };
 
     return { targetDependencies, options, extraOptions };

--- a/e2e/tests/lerna-run/lerna-run-nx-incompatible-options.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run-nx-incompatible-options.spec.ts
@@ -1,0 +1,579 @@
+import { remove } from "fs-extra";
+import { Fixture } from "../../utils/fixture";
+import { normalizeCommandOutput, normalizeEnvironment } from "../../utils/snapshot-serializer-utils";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommandOutput(normalizeEnvironment(str));
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-run-nx-incompatible-options", () => {
+  let fixture: Fixture;
+
+  beforeAll(async () => {
+    fixture = await Fixture.create({
+      name: "lerna-run-nx-incompatible-options",
+      packageManager: "npm",
+      initializeGit: true,
+      runLernaInit: true,
+      installDependencies: true,
+      /**
+       * Because lerna run involves spawning further child processes, the tests would be too flaky
+       * if we didn't force deterministic terminal output by appending stderr to stdout instead
+       * of interleaving them.
+       */
+      forceDeterministicTerminalOutput: true,
+    });
+
+    await fixture.addNxToWorkspace();
+
+    await fixture.lerna("create package-1 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-1",
+      scripts: {
+        "print-name": "echo test-package-1",
+      },
+    });
+    await fixture.lerna("create package-2 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-2",
+      scripts: {
+        "print-name": "echo test-package-2",
+      },
+    });
+    await fixture.lerna("create package-3 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-3",
+      scripts: {
+        "print-name": "echo test-package-3",
+      },
+    });
+  });
+  afterAll(() => fixture.destroy());
+
+  it("should run script on all child packages using nx", async () => {
+    const output = await fixture.lerna(`run print-name`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+
+`);
+  });
+
+  it("--parallel should warn", async () => {
+    const output = await fixture.lerna(`run print-name --parallel`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.
+
+`);
+  });
+
+  it("--sort should warn", async () => {
+    const output = await fixture.lerna(`run print-name --sort`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.
+
+`);
+  });
+
+  it("--no-sort should warn", async () => {
+    const output = await fixture.lerna(`run print-name --no-sort`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.
+
+`);
+  });
+
+  it("--include-dependencies should warn", async () => {
+    const output = await fixture.lerna(`run print-name --include-dependencies`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+lerna notice filter including dependencies
+lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.
+
+`);
+  });
+});
+
+describe("lerna-run-nx-incompatible-options without nx.json", () => {
+  let fixture: Fixture;
+
+  beforeAll(async () => {
+    fixture = await Fixture.create({
+      name: "lerna-run-nx-incompatible-options",
+      packageManager: "npm",
+      initializeGit: true,
+      runLernaInit: true,
+      installDependencies: true,
+      /**
+       * Because lerna run involves spawning further child processes, the tests would be too flaky
+       * if we didn't force deterministic terminal output by appending stderr to stdout instead
+       * of interleaving them.
+       */
+      forceDeterministicTerminalOutput: true,
+    });
+
+    await fixture.addNxToWorkspace();
+    await remove(fixture.getWorkspacePath("nx.json"));
+
+    await fixture.lerna("create package-1 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-1",
+      scripts: {
+        "print-name": "echo test-package-1",
+      },
+    });
+    await fixture.lerna("create package-2 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-2",
+      scripts: {
+        "print-name": "echo test-package-2",
+      },
+    });
+    await fixture.lerna("create package-3 -y");
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/package-3",
+      scripts: {
+        "print-name": "echo test-package-3",
+      },
+    });
+  });
+  afterAll(() => fixture.destroy());
+
+  it("should run script on all child packages using nx", async () => {
+    const output = await fixture.lerna(`run print-name`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+
+`);
+  });
+
+  it("--parallel should not warn", async () => {
+    const output = await fixture.lerna(`run print-name --parallel`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+
+`);
+  });
+
+  it("--sort should not warn", async () => {
+    const output = await fixture.lerna(`run print-name --sort`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+
+`);
+  });
+
+  it("--no-sort should not warn", async () => {
+    const output = await fixture.lerna(`run print-name --no-sort`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+
+`);
+  });
+
+  it("--include-dependencies should not warn", async () => {
+    const output = await fixture.lerna(`run print-name --include-dependencies`);
+
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+lerna notice filter including dependencies
+
+`);
+  });
+});

--- a/e2e/tests/lerna-run/lerna-run-nx-incompatible-options.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run-nx-incompatible-options.spec.ts
@@ -145,7 +145,7 @@ test-package-X
 
 
 lerna notice cli v999.9.9-e2e.0
-lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.
+lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
 
 `);
   });
@@ -193,7 +193,7 @@ test-package-X
 
 
 lerna notice cli v999.9.9-e2e.0
-lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.
+lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
 
 `);
   });
@@ -241,7 +241,7 @@ test-package-X
 
 
 lerna notice cli v999.9.9-e2e.0
-lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.
+lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
 
 `);
   });
@@ -290,7 +290,7 @@ test-package-X
 
 lerna notice cli v999.9.9-e2e.0
 lerna notice filter including dependencies
-lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are not valid options when nx.json exists.
+lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
 
 `);
   });

--- a/website/docs/recipes/using-lerna-powered-by-nx-to-run-tasks.md
+++ b/website/docs/recipes/using-lerna-powered-by-nx-to-run-tasks.md
@@ -1,0 +1,36 @@
+# Using Lerna (Powered by Nx) to Run Tasks
+
+Nx and Lerna work together seamlessly in the same workspace.
+
+When `nx.json` is detected in the current workspace and `useNx` is set to `true` in `lerna.json`, Lerna will respect `nx.json` configuration during `lerna run` and delegate to the Nx task runner.
+
+Nx will run tasks in an order and with a concurrency that it determines appropriate based on the task graph that it creates. For more information, see [Nx Mental Model: The Task Graph](https://nx.dev/concepts/mental-model#the-task-graph).
+
+**This behavior allows Nx to run tasks in the most efficient way possible, but it also means that some existing options for `lerna run` become obsolete.
+**
+
+## Obsolete Options
+
+### `--sort` and `--no-sort`
+
+Nx will always run tasks in the order it deems is correct based on its knowledge of project and task dependencies, so `--sort` and `--no-sort` have no effect.
+
+### `--parallel`
+
+Nx will use the task graph to determine which tasks can be run in parallel and do so automatically, so `--parallel` has no effect.
+
+:::note
+If you want to limit the concurrency of tasks, you can still use the [concurrency global option](https://github.com/lerna/lerna/blob/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/core/global-options/README.md#--concurrency) to accomplish this.
+:::
+
+### `--include-dependencies`
+
+Lerna by itself does not have knowledge of which tasks depend on others, so it defaults to excluding tasks on dependent projects when using [filter options](https://github.com/lerna/lerna/tree/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/core/filter-options#lernafilter-options) and relies on `--include-dependencies` to manually specify that dependent projects' tasks should be included.
+
+This is no longer a problem when Lerna uses Nx to run tasks. Nx, utilizing its [task graph](https://nx.dev/concepts/mental-model#the-task-graph), will automatically run dependent tasks first when necessary, so `--include-dependencies` is obsolete.
+
+:::tip
+
+The effects on the options above will only apply if `nx.json` exists in the root. If `nx.json` does not exist and `useNx` is `true`, then they will behave just as they would with Lerna's base task runner (if `useNx` is `false`).
+
+:::

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -61,7 +61,7 @@ const sidebars = {
     {
       type: "category",
       label: "Recipes",
-      items: ["recipes/using-pnpm-with-lerna"],
+      items: ["recipes/using-pnpm-with-lerna", "recipes/using-lerna-powered-by-nx-to-run-tasks"],
     },
     {
       type: "category",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makes `lerna run` warn the user when --sort, --no-sort, --include-dependencies, and --parallel are used with a nx.json file.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is necessary to communicate that specific options are not available when using nx with a custom nx.json file. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and covered by e2e tests. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
