### PR TITLE
fix(publish): ensure zero exit code when EWORKINGTREE warning occurs

### DIFF
--- a/integration/__tests__/lerna-publish-relative-file-spec.spec.ts
+++ b/integration/__tests__/lerna-publish-relative-file-spec.spec.ts
@@ -46,8 +46,8 @@ index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -3 +3 @@
--	"version": "1.0.0",
-+	"version": "2.0.0",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json

--- a/integration/__tests__/lerna-publish-transitive.spec.ts
+++ b/integration/__tests__/lerna-publish-transitive.spec.ts
@@ -47,8 +47,8 @@ index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -4 +4 @@
--	"version": "1.0.0",
-+	"version": "2.0.0",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -386,7 +386,7 @@ class PublishCommand extends Command {
           // (we tried)
           this.logger.silly("EWORKINGTREE", err.message);
           this.logger.notice("FYI", "Unable to verify working tree, proceed at your own risk");
-          process.exitCode=0;
+          process.exitCode = 0;
         } else {
           // validation errors should be preserved
           throw err;

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -386,6 +386,7 @@ class PublishCommand extends Command {
           // (we tried)
           this.logger.silly("EWORKINGTREE", err.message);
           this.logger.notice("FYI", "Unable to verify working tree, proceed at your own risk");
+          process.exitCode=0;
         } else {
           // validation errors should be preserved
           throw err;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixed  error when run "lerna publish from-package"  in package.json scripts
## Description
<!--- Describe your changes in detail -->
when verifyWorkingTreeClean error happend set exitCode to 0
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
1、add  publish:'lerna publish from-package" to package.json->"scripts"
2、exec "npm run publish" in terminal
3、everything well done

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
