### PR TITLE
fix(run): fully defer to Nx for dep detection when nx.json exists

### DIFF
--- a/commands/run/index.js
+++ b/commands/run/index.js
@@ -219,15 +219,10 @@ class RunCommand extends Command {
   }
 
   prepNxOptions() {
-    const { readNxJson } = require("nx/src/config/configuration");
-    const nxJson = readNxJson();
     const nxJsonExists = existsSync(path.join(this.project.rootPath, "nx.json"));
-    const useParallel = this.options.parallel && !nxJsonExists;
 
-    const targetDependenciesAreDefined =
-      Object.keys(nxJson.targetDependencies || nxJson.targetDefaults || {}).length > 0;
     const targetDependencies =
-      this.toposort && !useParallel && !targetDependenciesAreDefined
+      this.toposort && !this.options.parallel && !nxJsonExists
         ? {
             [this.script]: [
               {
@@ -250,7 +245,7 @@ class RunCommand extends Command {
        * To match lerna's own behavior (via pMap's default concurrency), we set parallel to a very large number if
        * the flag has been set (we can't use Infinity because that would cause issues with the task runner).
        */
-      parallel: useParallel ? 999 : this.concurrency,
+      parallel: this.options.parallel && !nxJsonExists ? 999 : this.concurrency,
       nxBail: this.bail,
       nxIgnoreCycles: !this.options.rejectCycles,
       skipNxCache: this.options.skipNxCache,
@@ -261,10 +256,17 @@ class RunCommand extends Command {
     if (nxJsonExists) {
       this.logger.verbose(this.name, "nx.json was found. Task dependencies will be automatically included.");
 
-      if (this.options.parallel || this.options.sort !== undefined || this.options.includeDependencies) {
+      if (this.options.parallel || this.options.sort !== undefined) {
         this.logger.warn(
           this.name,
-          `"parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.`
+          `"parallel", "sort", and "no-sort" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.`
+        );
+      }
+
+      if (this.options.includeDependencies) {
+        this.logger.info(
+          this.name,
+          `Using "include-dependencies" option when nx.json exists will include both task dependencies detected by Nx and project dependencies detected by Lerna. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--include-dependencies for details.`
         );
       }
     } else {

--- a/e2e/tests/lerna-run/lerna-run-nx-include-dependencies.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run-nx-include-dependencies.spec.ts
@@ -89,10 +89,8 @@ describe("lerna-run-nx-include-dependencies", () => {
 
         > package-X:print-name --silent
 
-
         > package-X@0.0.0 print-name
         > echo test-package-X "--silent"
-
         test-package-X --silent
 
          
@@ -111,39 +109,17 @@ describe("lerna-run-nx-include-dependencies", () => {
   });
 
   describe("with nx enabled and with nx.json", () => {
-    it("should include dependencies by default", async () => {
+    it("should not include package dependencies by default", async () => {
       await fixture.addNxToWorkspace();
 
       const output = await fixture.lerna("run print-name --scope package-3 -- --silent");
 
       expect(output.combinedOutput).toMatchInlineSnapshot(`
 
- >  Lerna (powered by Nx)   Running target print-name for project package-X and 2 task(s) it depends on
-
- 
-
-> package-X:print-name
-
-
-> package-X@0.0.0 print-name
-> echo test-package-X
-
-test-package-X
-
-> package-X:print-name
-
-
-> package-X@0.0.0 print-name
-> echo test-package-X
-
-test-package-X
-
 > package-X:print-name --silent
-
 
 > package-X@0.0.0 print-name
 > echo test-package-X "--silent"
-
 test-package-X --silent
 
  
@@ -156,6 +132,61 @@ lerna verb rootPath /tmp/lerna-e2e/lerna-run-nx-include-dependencies/lerna-works
 lerna notice filter including "package-X"
 lerna info filter [ 'package-X' ]
 lerna verb run nx.json was found. Task dependencies will be automatically included.
+
+`);
+    });
+
+    it("should include package dependencies with --include-dependencies", async () => {
+      await fixture.addNxToWorkspace();
+
+      const output = await fixture.lerna("run print-name --scope package-3 --include-dependencies");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+
+ >  Lerna (powered by Nx)   Running target print-name for 3 project(s):
+
+    - package-X
+    - package-X
+    - package-X
+
+ 
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+> package-X:print-name
+
+
+> package-X@0.0.0 print-name
+> echo test-package-X
+
+test-package-X
+
+ 
+
+ >  Lerna (powered by Nx)   Successfully ran target print-name for 3 projects
+
+
+lerna notice cli v999.9.9-e2e.0
+lerna verb rootPath /tmp/lerna-e2e/lerna-run-nx-include-dependencies/lerna-workspace
+lerna notice filter including "package-X"
+lerna notice filter including dependencies
+lerna info filter [ 'package-X' ]
+lerna verb run nx.json was found. Task dependencies will be automatically included.
+lerna info run Using "include-dependencies" option when nx.json exists will include both task dependencies detected by Nx and project dependencies detected by Lerna. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--include-dependencies for details.
 
 `);
     });

--- a/e2e/tests/lerna-run/lerna-run-nx-incompatible-options.spec.ts
+++ b/e2e/tests/lerna-run/lerna-run-nx-incompatible-options.spec.ts
@@ -145,7 +145,7 @@ test-package-X
 
 
 lerna notice cli v999.9.9-e2e.0
-lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
+lerna WARN run "parallel", "sort", and "no-sort" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
 
 `);
   });
@@ -193,7 +193,7 @@ test-package-X
 
 
 lerna notice cli v999.9.9-e2e.0
-lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
+lerna WARN run "parallel", "sort", and "no-sort" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
 
 `);
   });
@@ -241,7 +241,7 @@ test-package-X
 
 
 lerna notice cli v999.9.9-e2e.0
-lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
+lerna WARN run "parallel", "sort", and "no-sort" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
 
 `);
   });
@@ -290,7 +290,7 @@ test-package-X
 
 lerna notice cli v999.9.9-e2e.0
 lerna notice filter including dependencies
-lerna WARN run "parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.
+lerna info run Using "include-dependencies" option when nx.json exists will include both task dependencies detected by Nx and project dependencies detected by Lerna. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--include-dependencies for details.
 
 `);
   });

--- a/website/docs/lerna-and-nx.md
+++ b/website/docs/lerna-and-nx.md
@@ -8,7 +8,7 @@ type: explainer
 
 Nrwl (the company behind the open source build system Nx) has taken over [stewardship of Lerna](https://dev.to/nrwl/lerna-is-dead-long-live-lerna-3jal). [Nx](https://nx.dev) is a build system developed by ex-Googlers and utilizes many of the techniques used by internal Google tools. Lerna v5 is the first release under this new stewardship, updating outdated packages and starting to do some cleanup on the repository itself. Starting with v5.1+, Lerna comes with the new possibility to integrate Nx and defer a lot of the task scheduling work to it.
 
-The following is a high level overview of what each tool provides.  Note that all of the existing Lerna commands will continue to function as they have.  Adding Nx or Nx Cloud simply improves what you're already doing.
+The following is a high level overview of what each tool provides. Note that all of the existing Lerna commands will continue to function as they have. Adding Nx or Nx Cloud simply improves what you're already doing.
 
 ## Lerna
 
@@ -27,7 +27,7 @@ Free and open source
 - `npm install lerna`
 - `npx lerna init`
 
------
+---
 
 ## Nx
 
@@ -50,7 +50,11 @@ Free and open source
 - Set `"useNx": true` in `lerna.json`
 - Continue using Lerna as usual
 
-------
+:::note
+When Lerna is set to use Nx and detects `nx.json` in the workspace, it will defer to Nx to detect task dependencies. Some options for `lerna run` will behave differently. See [Using Lerna (Powered by Nx) to Run Tasks](./recipes/using-lerna-powered-by-nx-to-run-tasks) for more details.
+:::
+
+---
 
 ## Nx Cloud
 
@@ -63,7 +67,7 @@ Free and open source
 
 Free for open source projects
 
-For closed source repositories, the first 500 computation hours per month are free.  Most repositories do not exceed this limit. $1 per computation hour after that.
+For closed source repositories, the first 500 computation hours per month are free. Most repositories do not exceed this limit. $1 per computation hour after that.
 
 ### Set up
 

--- a/website/docs/recipes/using-lerna-powered-by-nx-to-run-tasks.md
+++ b/website/docs/recipes/using-lerna-powered-by-nx-to-run-tasks.md
@@ -27,7 +27,7 @@ If you want to limit the concurrency of tasks, you can still use the [concurrenc
 
 Lerna by itself does not have knowledge of which tasks depend on others, so it defaults to excluding tasks on dependent projects when using [filter options](https://github.com/lerna/lerna/tree/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/core/filter-options#lernafilter-options) and relies on `--include-dependencies` to manually specify that dependent projects' tasks should be included.
 
-This is no longer a problem when Lerna uses Nx to run tasks. Nx, utilizing its [task graph](https://nx.dev/concepts/mental-model#the-task-graph), will automatically run dependent tasks first when necessary, so `--include-dependencies` is obsolete.
+This is no longer a problem when Lerna uses Nx to run tasks. Nx, utilizing its [task graph](https://nx.dev/concepts/mental-model#the-task-graph), will automatically run dependent tasks first when necessary, so `--include-dependencies` is obsolete. However, it can still be used to include project dependencies that Lerna detects but Nx does not deem necessary and would otherwise exclude.
 
 :::tip
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Only sends "targetDependencies" from Lerna to Nx when nx.json does not exist.
- Updates the warning when using `--include-dependencies` to indicate that Lerna will send Nx additional dependencies to run. 
- Updates docs to be more clear on the differing behavior.
- Adds a note to the docs when installing Nx that `lerna run` will behave differently and links to the page describing the differences.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change has been covered by e2e tests and tested manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
