### PR TITLE
fix(core): fix "cannot read property 'version' of undefined" for pnpm + independent versioning

### DIFF
--- a/core/package-graph/__tests__/package-graph.test.js
+++ b/core/package-graph/__tests__/package-graph.test.js
@@ -94,6 +94,71 @@ describe("PackageGraph", () => {
     });
 
     describe("with spec containing workspace: prefix", () => {
+      describe("without depNode for sibling package", () => {
+        it("replaces workspace alias ~ with * and adds sibling to external dependencies", () => {
+          const packages = [
+            new Package(
+              {
+                name: "test-2",
+                version: "1.0.0",
+                dependencies: {
+                  "test-1": "workspace:~",
+                },
+              },
+              "/test/test-2"
+            ),
+          ];
+          const graph = new PackageGraph(packages, "allDependencies");
+          const package2 = graph.get("test-2");
+
+          expect(package2.externalDependencies.has("test-1")).toBe(true);
+          expect(package2.externalDependencies.get("test-1").workspaceSpec).toBe("workspace:~");
+          expect(package2.externalDependencies.get("test-1").workspaceAlias).toBe("~");
+        });
+
+        it("replaces workspace alias * with * and adds sibling to external dependencies", () => {
+          const packages = [
+            new Package(
+              {
+                name: "test-2",
+                version: "1.0.0",
+                dependencies: {
+                  "test-1": "workspace:*",
+                },
+              },
+              "/test/test-2"
+            ),
+          ];
+          const graph = new PackageGraph(packages, "allDependencies");
+          const package2 = graph.get("test-2");
+
+          expect(package2.externalDependencies.has("test-1")).toBe(true);
+          expect(package2.externalDependencies.get("test-1").workspaceSpec).toBe("workspace:*");
+          expect(package2.externalDependencies.get("test-1").workspaceAlias).toBe("*");
+        });
+
+        it("replaces workspace alias ^ with * and adds sibling to external dependencies", () => {
+          const packages = [
+            new Package(
+              {
+                name: "test-2",
+                version: "1.0.0",
+                dependencies: {
+                  "test-1": "workspace:^",
+                },
+              },
+              "/test/test-2"
+            ),
+          ];
+          const graph = new PackageGraph(packages, "allDependencies");
+          const package2 = graph.get("test-2");
+
+          expect(package2.externalDependencies.has("test-1")).toBe(true);
+          expect(package2.externalDependencies.get("test-1").workspaceSpec).toBe("workspace:^");
+          expect(package2.externalDependencies.get("test-1").workspaceAlias).toBe("^");
+        });
+      });
+
       describe("creates graph links for sibling package when semver is satisfied", () => {
         it("with exact match", () => {
           const packages = [

--- a/core/package-graph/index.js
+++ b/core/package-graph/index.js
@@ -76,9 +76,13 @@ class PackageGraph extends Map {
           // replace aliases (https://pnpm.io/workspaces#referencing-workspace-packages-through-aliases)
           if (spec === "*" || spec === "^" || spec === "~") {
             workspaceAlias = spec;
-            const prefix = spec === "*" ? "" : spec;
-            const version = depNode.version;
-            spec = `${prefix}${version}`;
+            if (depNode?.version) {
+              const prefix = spec === "*" ? "" : spec;
+              const version = depNode.version;
+              spec = `${prefix}${version}`;
+            } else {
+              spec = "*";
+            }
           }
         }
 

--- a/e2e/tests/lerna-version/independent-pnpm.spec.ts
+++ b/e2e/tests/lerna-version/independent-pnpm.spec.ts
@@ -1,0 +1,105 @@
+import { Fixture } from "../../utils/fixture";
+import { normalizeCommitSHAs, normalizeEnvironment } from "../../utils/snapshot-serializer-utils";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommitSHAs(normalizeEnvironment(str));
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-version-independent-pnpm", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      name: "lerna-version-independent",
+      packageManager: "pnpm",
+      initializeGit: true,
+      runLernaInit: true,
+      installDependencies: true,
+    });
+  });
+  afterEach(() => fixture.destroy());
+
+  it("should support versioning package-b independent of package-a when using the workspace prefix", async () => {
+    await fixture.lerna("create package-a -y");
+    await fixture.lerna("create package-b -y --dependencies package-a");
+    await fixture.updateJson("lerna.json", (json) => ({
+      ...json,
+      version: "independent",
+    }));
+    await fixture.createInitialGitCommit();
+    await fixture.exec("git push origin test-main");
+    await fixture.lerna("version 0.0.0 -y");
+
+    await fixture.addDependencyToPackage({
+      packagePath: "packages/package-b",
+      dependencyName: "package-a",
+      version: "workspace:*",
+    });
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: update package-b dependency'");
+
+    const output = await fixture.lerna("version 3.3.3 -y");
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info versioning independent
+      lerna info Looking for changed packages since package-a@0.0.0
+
+      Changes:
+       - package-b: 0.0.0 => 3.3.3
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
+
+  it("should support versioning package-a and package-b when using the workspace prefix", async () => {
+    await fixture.lerna("create package-a -y");
+    await fixture.lerna("create package-b -y --dependencies package-a");
+    await fixture.updateJson("lerna.json", (json) => ({
+      ...json,
+      version: "independent",
+    }));
+    await fixture.addDependencyToPackage({
+      packagePath: "packages/package-b",
+      dependencyName: "package-a",
+      version: "workspace:*",
+    });
+
+    await fixture.createInitialGitCommit();
+    await fixture.exec("git push origin test-main");
+    await fixture.lerna("version 0.0.0 -y");
+
+    await fixture.addDependencyToPackage({
+      packagePath: "packages/package-a",
+      dependencyName: "yargs",
+      version: "*",
+    });
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: update package-a dependency'");
+
+    const output = await fixture.lerna("version 3.3.3 -y");
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info versioning independent
+      lerna info Looking for changed packages since package-a@0.0.0
+
+      Changes:
+       - package-a: 0.0.0 => 3.3.3
+       - package-b: 0.0.0 => 3.3.3
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Prevent "cannot read property 'version' of undefined" when using pnpm with independent versioning. 

## Description
<!--- Describe your changes in detail -->
Update the package graph so that if it encounters a workspace alias (workspace:\*/~/^) and cannot find the package in its provided packages, it will default to "*" instead of erroring.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are times when the package graph needs is created without the full list of all packages in the workspace, such as when using `runTopologically` to perform versioning actions when versioning independently.

Though "*" is not equivalent to the real version of the package being referenced, it should not matter for these cases, since the package-graph is only being used to determine the order in which to perform actions on the packages.

#3343 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually as well as covered by e2e tests and unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
