### PR TITLE
fix(run): always set env LERNA_PACKAGE_NAME environment variable

### DIFF
--- a/utils/get-npm-exec-opts/get-npm-exec-opts.js
+++ b/utils/get-npm-exec-opts/get-npm-exec-opts.js
@@ -6,7 +6,9 @@ module.exports.getNpmExecOpts = getNpmExecOpts;
 
 function getNpmExecOpts(pkg, registry) {
   // execa automatically extends process.env
-  const env = {};
+  const env = {
+    LERNA_PACKAGE_NAME: pkg.name,
+  };
 
   if (registry) {
     env.npm_config_registry = registry;

--- a/utils/npm-install/__tests__/npm-install.test.js
+++ b/utils/npm-install/__tests__/npm-install.test.js
@@ -45,6 +45,7 @@ describe("npm-install", () => {
         {
           cwd: pkg.location,
           env: {
+            LERNA_PACKAGE_NAME: "test-npm-install",
             LERNA_EXEC_PATH: pkg.location,
             LERNA_ROOT_PATH: pkg.rootPath,
           },

--- a/utils/npm-run-script/__tests__/npm-run-script.test.js
+++ b/utils/npm-run-script/__tests__/npm-run-script.test.js
@@ -98,7 +98,9 @@ describe("npm-run-script", () => {
         ["run", script, "--bar", "baz"],
         {
           cwd: config.pkg.location,
-          env: {},
+          env: {
+            LERNA_PACKAGE_NAME: "qux",
+          },
           pkg: config.pkg,
           reject: true,
           windowsHide: false,
@@ -126,7 +128,9 @@ describe("npm-run-script", () => {
         ["run", script],
         {
           cwd: config.pkg.location,
-          env: {},
+          env: {
+            LERNA_PACKAGE_NAME: "qux",
+          },
           pkg: config.pkg,
           reject: false,
           windowsHide: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The modern task runner powered by Nx has already been setting `LERNA_PACKAGE_NAME` for a while, but the legacy task runner never had this support added.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Community PR #3107 added the initial code change, but without tests, and it went a little stale so added here just so we can land it ASAP.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
