### PR TITLE
docs(core): readmes for add-caching and repair

### DIFF
--- a/core/lerna/commands/add-caching/README.md
+++ b/core/lerna/commands/add-caching/README.md
@@ -1,0 +1,76 @@
+# `lerna add-caching`
+
+> Runs a wizard that sets up basic caching options.
+
+Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` CLI.
+
+## Usage
+
+```sh
+$ lerna add-caching
+```
+
+## Questions
+
+Each question the wizard asks will inform how the `nx.json` file is updated.
+
+### Which of the following scripts need to be run in deterministic/topological order?
+
+Each script selected will be marked to run dependency scripts of the same name before running the script itself.
+
+If you mark `build` as needing topological order, the `nx.json` file will look like this:
+
+```jsonc
+{
+  "targetDefaults": {
+    "build": {
+      "dependsOn": [
+        "^build" // build all dependencies before building this project
+      ]
+    }
+  }
+}
+```
+
+### Which of the following scripts are cacheable?
+
+Each script selected will be cached by Lerna.  Only select scripts that do not depend on any external inputs (like network calls).  `build` and `test` are usually cacheable.  `start` and `serve` are usually not cacheable.  Sometimes `e2e` is cacheable.
+
+If you mark `build` as cacheable, the `nx.json` file will look like this:
+
+```jsonc
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": [
+          "build" // cache the build script
+        ]
+      }
+    }
+  }
+}
+```
+
+### Does the "[script_name]" script create any outputs?
+
+For each script selected as cacheable, the wizard will ask for an output path.  For builds this would be the build output.  For tests this would be any coverage reports.  The output path is relative to the project root.
+
+If you specify `dist` as the output path for the `build` script, the `nx.json` file will look like this:
+
+```jsonc
+{
+  "targetDefaults": {
+    "build": {
+      "outputs": [
+        "{projectRoot}/dist"
+      ]
+    }
+  }
+}
+```
+
+## More information
+
+For more details on how to fine tune your caching set up, read about [Task Pipeline Configuration](https://lerna.js.org/docs/concepts/task-pipeline-configuration) and [How Caching Works](https://lerna.js.org/docs/concepts/how-caching-works)

--- a/core/lerna/commands/add-caching/index.js
+++ b/core/lerna/commands/add-caching/index.js
@@ -51,7 +51,7 @@ class AddCachingCommand extends Command {
       {
         type: "checkbox",
         name: "targetDefaults",
-        message: "Which of the following scripts need to be run in deterministic/topoglogical order?\n",
+        message: "Which of the following scripts need to be run in deterministic/topological order?\n",
         choices: this.uniqueScriptNames,
       },
     ]);

--- a/core/lerna/commands/repair/README.md
+++ b/core/lerna/commands/repair/README.md
@@ -1,0 +1,20 @@
+# `lerna repair`
+
+> Update configuration files to match the currently installed version of lerna
+
+Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` CLI.
+
+## Usage
+
+```sh
+$ lerna repair
+```
+
+### Upgrading
+
+`lerna repair` is most useful after an upgrade to ensure that any configuration file changes for the new version of `lerna` are applied.
+
+```sh
+$ npm i lerna@latest
+$ lerna repair
+```

--- a/website/docs/api-reference/commands.md
+++ b/website/docs/api-reference/commands.md
@@ -21,6 +21,8 @@ type: reference
 - [`lerna link`](https://github.com/lerna/lerna/tree/main/commands/link#readme)
 - [`lerna create`](https://github.com/lerna/lerna/tree/main/commands/create#readme)
 - [`lerna info`](https://github.com/lerna/lerna/tree/main/commands/info#readme)
+- [`lerna add-caching`](https://github.com/lerna/lerna/tree/main/core/lerna/commands/add-caching#readme)
+- [`lerna repair`](https://github.com/lerna/lerna/tree/main/core/lerna/commands/repair#readme)
 
 ## Filter Options
 


### PR DESCRIPTION
Adds readme files for `lerna add-caching` and `lerna repair`

And fixes a typo in the `add-caching` wizard