### PR TITLE
chore: clear pnpm store on publish to verdaccio

### DIFF
--- a/e2e/publish-to-verdaccio.sh
+++ b/e2e/publish-to-verdaccio.sh
@@ -45,3 +45,17 @@ npx lerna publish from-package --registry="http://localhost:4872/" --yes
 echo ""
 
 echo "Publishing complete"
+
+echo ""
+
+# Only prune the pnpm store if pnpm is installed. If it's not, then delegate 
+# to the pnpm e2e tests to fail with a clear error of "pnpm: command not found".
+if command -v pnpm &> /dev/null
+then
+  echo "Clearing pnpm store"
+
+  pnpm store prune
+  rm -rf ~/Library/pnpm/store/v3/files/
+
+  echo "pnpm store cleared"
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Clear the pnpm store when publishing a new version of lerna to verdaccio for e2e testing.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
pnpm caches dependency versions. Lerna publishes the same semantic version every time for each run of the e2e tests. When pnpm goes to download that version of lerna, it fails the "integrity check", since the assets it got were different from what is in its cache for that same version.

This change prunes the pnpm store and clears out old pnpm store files before publishing to prevent this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All automated tests still pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
