### PR TITLE
feat(version, publish): Added support for `--dry-run` option

### DIFF
--- a/commands/publish/README.md
+++ b/commands/publish/README.md
@@ -65,6 +65,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 - [`--tag-version-prefix`](#--tag-version-prefix)
 - [`--temp-tag`](#--temp-tag)
 - [`--yes`](#--yes)
+- [`--dry-run`](#--dry-run)
 
 ### `--canary`
 
@@ -293,6 +294,16 @@ lerna publish --canary --yes
 
 When run with this flag, `lerna publish` will skip all confirmation prompts.
 Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous_integration) to automatically answer the publish confirmation prompt.
+
+### `--dry-run`
+
+```sh
+lerna publish --dry-run
+# auto-rejects `Are you sure you want to publish the above changes?`
+```
+
+When run with this flag, `lerna publish` will skip all confirmation prompts.
+Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous_integration) to automatically answer the publish confirmation prompt. (In this case, with "no").
 
 ## Deprecated Options
 

--- a/commands/publish/__tests__/publish-command.test.js
+++ b/commands/publish/__tests__/publish-command.test.js
@@ -550,4 +550,16 @@ Map {
       await expect(command).rejects.toThrow("Dependency cycles detected, you should fix these!");
     });
   });
+
+  describe("--dry-run", () => {
+    it("auto-rejects the confirmation prompt", async () => {
+      const testDir = await initFixture("normal");
+      await lernaPublish(testDir)("--dry-run");
+
+      expect(promptConfirmation).not.toHaveBeenCalled();
+
+      const consoleMessages = await loggingOutput();
+      expect(consoleMessages).toContain("Auto-rejected. This is a dry-run.");
+    });
+  });
 });

--- a/commands/publish/command.js
+++ b/commands/publish/command.js
@@ -110,6 +110,10 @@ exports.builder = (yargs) => {
       describe: "Verify package read-write access for current npm user.",
       type: "boolean",
     },
+    "dry-run": {
+      describe: "Preview of packages to be published.",
+      type: "boolean",
+    },
   };
 
   composeVersionOptions(yargs);

--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -444,6 +444,11 @@ class PublishCommand extends Command {
       return true;
     }
 
+    if (this.options.dryRun) {
+      this.logger.info("Auto-rejected. This is a dry-run.");
+      return false;
+    }
+
     return promptConfirmation("Are you sure you want to publish these packages?");
   }
 

--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -75,6 +75,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--force-git-tag`](#--force-git-tag)
     - [`--tag-version-prefix`](#--tag-version-prefix)
     - [`--yes`](#--yes)
+    - [`--dry-run`](#--dry-run)
   - [Deprecated Options](#deprecated-options)
     - [`--cd-version`](#--cd-version)
     - [`--repo-version`](#--repo-version)
@@ -430,6 +431,16 @@ lerna version --yes
 
 When run with this flag, `lerna version` will skip all confirmation prompts.
 Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous_integration) to automatically answer the publish confirmation prompt.
+
+### `--dry-run`
+
+```sh
+lerna version --dry-run
+# auto-rejects `Are you sure you want to publish these packages?`
+```
+
+When run with this flag, `lerna version` will auto-reject confirmation prompts.
+Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous_integration) to automatically answer the publish confirmation prompt. (In this case, with "no").
 
 ## Deprecated Options
 

--- a/commands/version/__tests__/version-command.test.js
+++ b/commands/version/__tests__/version-command.test.js
@@ -779,4 +779,16 @@ describe("VersionCommand", () => {
       expect(logMessages).toContain("Arguments after -- are no longer passed to subprocess executions.");
     });
   });
+
+  describe("--dry-run", () => {
+    it("auto-rejects the confirmation prompt", async () => {
+      const testDir = await initFixture("normal");
+      await lernaVersion(testDir)("--dry-run");
+
+      expect(promptConfirmation).not.toHaveBeenCalled();
+
+      const consoleMessages = await loggingOutput();
+      expect(consoleMessages).toContain("Auto-rejected. This is a dry-run.");
+    });
+  });
 });

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -165,6 +165,10 @@ exports.builder = (yargs, composed) => {
       alias: "yes",
       type: "boolean",
     },
+    "dry-run": {
+      describe: "Preview versions to be created.",
+      type: "boolean",
+    },
   };
 
   if (composed) {

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -487,6 +487,11 @@ class VersionCommand extends Command {
       return true;
     }
 
+    if (this.options.dryRun) {
+      this.logger.info("Auto-rejected. This is a dry-run.");
+      return false;
+    }
+
     // When composed from `lerna publish`, use this opportunity to confirm publishing
     const message = this.composed
       ? "Are you sure you want to publish these packages?"


### PR DESCRIPTION
Added support for `--dry-run` option in `lerna version` and `lerna publish`.

## Description
Declared a new `--dry-run` option of type `boolean`.
Whenever this option is used with one of the above commands (either `version` or `publish`), the confirmations ([`confirmVersions()`](https://github.com/lerna/lerna/blob/e33be4b043f4392311a1b12a1e3de4bdd5e0f42d/commands/version/index.js#L471) and [`confirmPublish()`](https://github.com/lerna/lerna/blob/e33be4b043f4392311a1b12a1e3de4bdd5e0f42d/commands/publish/index.js#L431) functions) automatically get rejected and an info log with `Auto-rejected. This is a dry-run.` appears in the console.

## Motivation and Context
Folkes that would like to use lerna in CIs would enjoy this change (I would).
It will be nice to have a pipeline step that would preview the versions to be changed and add some sort of manual validation to really make sure we're publishing the right versions (that's actually a use case I want to implement in one of the pipelines I work on).

There has been an ongoing discussion since 2016 regarding this feature but not any concrete action from someone.
Maybe this PR turns things around a bit 🤓

closes #51 
and maybe also a step closer to address #1094 

## How Has This Been Tested?
Added 2 unit tests for each command. They passed.
Locally tested with a locally published lerna version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
