### PR TITLE
fix(version): only apply prettier if it was explicitly installed

### DIFF
--- a/commands/version/lib/git-add.js
+++ b/commands/version/lib/git-add.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const log = require("npmlog");
 const path = require("path");
 const slash = require("slash");
-const { workspaceRoot } = require("@nrwl/devkit");
+const { workspaceRoot, readJsonFile } = require("@nrwl/devkit");
 const childProcess = require("@lerna/child-process");
 
 module.exports.gitAdd = gitAdd;
@@ -13,7 +13,12 @@ let resolvedPrettier;
 function resolvePrettier() {
   if (!resolvedPrettier) {
     try {
-      // If the workspace has prettier installed, apply it to the updated files
+      // If the workspace has prettier (explicitly) installed, apply it to the updated files
+      const packageJson = readJsonFile(path.join(workspaceRoot, "package.json"));
+      const hasPrettier = packageJson.devDependencies?.prettier || packageJson.dependencies?.prettier;
+      if (!hasPrettier) {
+        return;
+      }
       const prettierPath = path.join(workspaceRoot, "node_modules", "prettier");
       // eslint-disable-next-line import/no-dynamic-require, global-require
       resolvedPrettier = require(prettierPath);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Only invoke `prettier` on changed files if the user has explicitly listed it in their root `package.json`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is theoretically possible that a user could end up with a copy of `prettier` in their `node_modules` despite not being a direct user of it. This situation might cause unwanted formatting changes to their files when running `lerna version`.

Nobody has explicitly reported this case to us, but it is theoretically possible and we might have seen it be indirectly reported via a community blog post.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
