### PR TITLE
docs(website): add lerna upgrade page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -113,7 +113,7 @@ const config = {
             position: "left",
             label: "Get Started",
           },
-          // { to: "/blog", label: "Blog", position: "left" },
+          { to: "/upgrade", label: "Upgrade", position: "left" },
           // {
           //   href: "https://nx.dev",
           //   className: "header-nxdev-link",

--- a/website/src/components/about-lerna.module.css
+++ b/website/src/components/about-lerna.module.css
@@ -44,3 +44,8 @@
 .callout:hover .callout__bottom {
   width: 100%;
 }
+
+.video {
+  box-shadow: 0 2px 6px var(--ifm-background-surface-color-dark);
+  border-radius: 0.375rem;
+}

--- a/website/src/components/hero-upgrade.module.css
+++ b/website/src/components/hero-upgrade.module.css
@@ -1,0 +1,143 @@
+.callout {
+  align-items: center;
+  background: var(--ifm-background-surface-color);
+  border-radius: 9999px;
+  color: inherit;
+  display: inline-flex;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  padding: 0.25rem 0.5rem;
+  transition-property: color, background-color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+.callout:hover {
+  background: var(--ifm-background-surface-color-dark);
+  text-decoration: none;
+  color: inherit;
+}
+.callout__badge {
+}
+.callout__text {
+  margin-left: 1rem;
+}
+.callout__icon {
+  color: #6b7280;
+  height: 1.25rem;
+  margin-left: 0.5rem;
+  width: 1.25rem;
+}
+
+.slogan {
+  margin-top: 2rem;
+  font-size: 3rem;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+.slogan span {
+  display: block;
+}
+span.slogan__highlight {
+  background: var(--ifm-color-primary);
+  border-radius: 0.375rem;
+  color: var(--ifm-color-content-inverse);
+  display: inline-block;
+  font-size: 3.75rem;
+  padding: 0.375rem 0.5rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .slogan {
+    font-size: 3.75rem;
+  }
+  .slogan__highlight {
+    font-size: 4.5rem;
+  }
+}
+
+.description {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  margin-top: 2rem;
+}
+
+.command {
+  margin-top: 2rem;
+}
+@media only screen and (min-width: 768px) {
+  .command {
+    margin-top: 0;
+  }
+}
+.command__text {
+  font-family: monospace;
+  font-weight: normal;
+  line-height: 1.5rem;
+  font-size: 0.875rem;
+}
+.command__icon {
+  height: 1.5rem;
+  margin-left: 1.5rem;
+  opacity: 0.7;
+  vertical-align: middle;
+  width: 1.5rem;
+}
+
+.commands_wrapper {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+}
+
+.commands_container {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  width: 100%;
+}
+.commands_container h3 {
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+.commands_icon {
+  height: 1.5rem;
+  margin-right: 0.5rem;
+  width: 1.5rem;
+}
+.commands_container .button--secondary {
+  background: var(--ifm-background-color);
+}
+
+.reaching_out {
+  border: 1px solid var(--ifm-background-surface-color);
+  border-radius: 1rem;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  margin-top: 1rem;
+  padding: 1rem;
+}
+.reaching_out h4 {
+  margin-bottom: 0.5rem;
+}
+.reaching_out p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+.reaching_out__link_container {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 1.5rem;
+}
+.reaching_out__link_container a {
+  align-items: center;
+  color: var(--ifm-font-color-base);
+  display: flex;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+@media only screen and (min-width: 1024px) {
+}

--- a/website/src/components/hero-upgrade.tsx
+++ b/website/src/components/hero-upgrade.tsx
@@ -1,0 +1,165 @@
+import {
+  ArrowDownTrayIcon,
+  Cog8ToothIcon,
+  CogIcon,
+  DocumentDuplicateIcon,
+  InboxArrowDownIcon,
+} from "@heroicons/react/24/outline";
+import LernaIcon from "@site/src/components/lerna-icon";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+import React, { useEffect, useState } from "react";
+import clsx from "clsx";
+import styles from "./hero-upgrade.module.css";
+export default function HeroUpgrade(): JSX.Element {
+  const upgradeCommand = "npx i lerna@latest -D -W";
+  const cachingCommand = "npx lerna add-caching";
+
+  const [copied, setCopied] = useState(false);
+  useEffect(() => {
+    let t: NodeJS.Timeout;
+    if (copied) {
+      t = setTimeout(() => {
+        setCopied(false);
+      }, 3000);
+    }
+    return () => {
+      t && clearTimeout(t);
+    };
+  }, [copied]);
+
+  return (
+    <section className="padding-vert--xl">
+      <div className="container">
+        <div className="row">
+          <div className="col col--7 margin-vert--xl">
+            <h1 className={styles.slogan}>
+              <span>
+                <span className={styles.slogan__highlight}>Upgrade</span> your
+              </span>
+              <span>Lerna experience</span>
+            </h1>
+            <p className={styles.description}>
+              Don't miss out on the latest features: local caching by default, remote distribution, task
+              pipelines, PNPM support, dynamic terminal output, Prettier support, "lerna repair" command and
+              more.
+            </p>
+            <p className={styles.description}>
+              Read more in our{" "}
+              <a href="https://dev.to/nx/upgrade-your-lerna-workspace-make-it-fast-and-modern-3c0g">
+                blog post.
+              </a>
+            </p>
+          </div>
+          <div className="col col--1" />
+          <div className="col col--4">
+            <div className={styles.commands_wrapper}>
+              <div className={styles.commands_container}>
+                <h3>
+                  <ArrowDownTrayIcon
+                    className={styles.commands_icon}
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  />{" "}
+                  Upgrade
+                </h3>
+                <CopyToClipboard
+                  text={upgradeCommand}
+                  onCopy={() => {
+                    setCopied(true);
+                  }}
+                >
+                  <button
+                    className={clsx(
+                      "button button--lg button--block button--outline button--secondary",
+                      styles.command
+                    )}
+                  >
+                    <span className={styles.command__text}>
+                      <span aria-hidden="true">$</span> {upgradeCommand}
+                    </span>
+                    <DocumentDuplicateIcon className={styles.command__icon} />
+                  </button>
+                </CopyToClipboard>
+              </div>
+              <div className={styles.commands_container}>
+                <h3>
+                  <CogIcon className={styles.commands_icon} stroke="currentColor" aria-hidden="true" /> Add
+                  caching
+                </h3>
+                <CopyToClipboard
+                  text={cachingCommand}
+                  onCopy={() => {
+                    setCopied(true);
+                  }}
+                >
+                  <button
+                    className={clsx(
+                      "button button--lg button--block button--outline button--secondary",
+                      styles.command
+                    )}
+                  >
+                    <span className={styles.command__text}>
+                      <span aria-hidden="true">$</span> {cachingCommand}
+                    </span>
+                    <DocumentDuplicateIcon className={styles.command__icon} />
+                  </button>
+                </CopyToClipboard>
+              </div>
+              <div className={styles.reaching_out}>
+                <h4>Stuck? Need some help?</h4>
+                <p>
+                  Reach out to us! We help open source respositories with their upgrade to make sure they get
+                  most out of their Lerna setup.
+                </p>
+                <div className={styles.reaching_out__link_container}>
+                  <a href="https://go.nrwl.io/join-slack?utm_source=lerna.js.org" target="_blank">
+                    <svg
+                      style={{ height: "1rem", width: "1rem" }}
+                      fill="currentColor"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="margin-right--sm"
+                    >
+                      <title>Slack</title>
+                      <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" />
+                    </svg>
+                    Slack
+                  </a>
+                  <a href="https://twitter.com/lernajs?utm_source=lerna.js.org" target="_blank">
+                    <svg
+                      style={{ height: "1rem", width: "1rem" }}
+                      fill="currentColor"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="margin-right--sm"
+                    >
+                      <title>Twitter</title>
+                      <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
+                    </svg>
+                    Twitter
+                  </a>
+                  <a href="https://github.com/lerna/lerna" target="_blank">
+                    <svg
+                      style={{ height: "1rem", width: "1rem" }}
+                      fill="currentColor"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="margin-right--sm"
+                    >
+                      <title>GitHub</title>
+                      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+                    </svg>
+                    Github
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/how-to-upgrade.module.css
+++ b/website/src/components/how-to-upgrade.module.css
@@ -1,0 +1,11 @@
+.video {
+  box-shadow: 0 2px 6px var(--ifm-background-surface-color-dark);
+  border-radius: 0.375rem;
+}
+
+.description {
+  font-style: italic;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-align: center;
+}

--- a/website/src/components/how-to-upgrade.tsx
+++ b/website/src/components/how-to-upgrade.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import styles from "./how-to-upgrade.module.css";
+export default function HowToUpgrade(): JSX.Element {
+  return (
+    <section className="padding-vert--xl container">
+      <div className="row">
+        <div className="col col--6">
+          <iframe
+            width="100%"
+            height="315"
+            src="https://www.youtube.com/embed/MwGPMvhJS0A"
+            title="How to upgrade Lerna in 3 minutes"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className={styles.video}
+          ></iframe>
+          <p className={styles.description}>How to upgrade Lerna in 3 minutes</p>
+        </div>
+        <div className="col col--6">
+          <iframe
+            width="100%"
+            height="315"
+            src="https://www.youtube.com/embed/jaH2BqWo-Pc"
+            title="How to add caching to Lerna in once command"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className={styles.video}
+          ></iframe>
+          <p className={styles.description}>How to add caching to Lerna in one command</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/modern-lerna.module.css
+++ b/website/src/components/modern-lerna.module.css
@@ -11,3 +11,11 @@
 .item__inner div {
   padding: 3rem;
 }
+.item__title span {
+  display: block;
+  font-size: 1.25rem;
+}
+
+iframe {
+  min-height: 100%;
+}

--- a/website/src/components/modern-lerna.tsx
+++ b/website/src/components/modern-lerna.tsx
@@ -1,0 +1,37 @@
+import clsx from "clsx";
+import React from "react";
+import styles from "./about-lerna.module.css";
+
+export default function ModernLerna(): JSX.Element {
+  return (
+    <section className="padding-vert--xl container">
+      <div className={clsx("row margin-bottom--xl", styles.hero)}>
+        <div className="col col--6">
+          <div>
+            <h1 className={clsx("margin-bottom--lg", styles.hero__title)}>
+              What is <br /> Modern Lerna?
+            </h1>
+            <p className={clsx("margin-bottom--md", styles.hero__text)}>
+              Lerna is now faster, more reliable, and more powerful than ever. The "new Lerna" comes with
+              modern features such as local & remote caching support, task pipelines, improved terminal
+              output, Prettier & NPM/Yarn/PNPM workspaces support combined with what the community already
+              loved: a built-in versioning and publishing workflow.
+            </p>
+          </div>
+        </div>
+        <div className="col col--6">
+          <iframe
+            width="100%"
+            height="315"
+            src="https://www.youtube.com/embed/1oxFYphTS4Y"
+            title=" Modern Lerna Walkthrough "
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className={styles.video}
+          ></iframe>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/powered-by-nx.module.css
+++ b/website/src/components/powered-by-nx.module.css
@@ -9,7 +9,7 @@
   display: flex;
 }
 .item__inner div {
-  padding: 5rem;
+  padding: 3rem;
 }
 .item__title span {
   display: block;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -45,13 +45,13 @@ html[data-theme="dark"] {
 }
 
 /**
- Generics iframe
+ Generics iframe in docs
  */
-iframe[src*="youtube"] {
+.docs-doc-page iframe[src*="youtube"] {
   box-shadow: 0 2px 6px var(--ifm-background-surface-color-dark);
   border-radius: 0.375rem;
 }
-iframe {
+.docs-doc-page iframe {
   border: 2px solid var(--ifm-background-surface-color-dark);
   display: block;
   margin: 1.7rem auto;

--- a/website/src/pages/upgrade.tsx
+++ b/website/src/pages/upgrade.tsx
@@ -1,0 +1,19 @@
+import HeroUpgrade from "@site/src/components/hero-upgrade";
+import HowToUpgrade from "@site/src/components/how-to-upgrade";
+import React from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Layout from "@theme/Layout";
+import ModernLerna from "../components/modern-lerna";
+
+export default function Upgrade(): JSX.Element {
+  const { siteConfig } = useDocusaurusContext();
+  return (
+    <Layout title="Upgrade" description="Get the latest developer experience from Lerna for your monorepo.">
+      <main>
+        <HeroUpgrade />
+        <HowToUpgrade />
+        <ModernLerna />
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
It adds a new `/upgrade` page dedicated to showing Lerna users how to upgrade seamlessly their workspaces.