### PR TITLE
feat(version): add detect-preid option

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -70,6 +70,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--no-private`](#--no-private)
     - [`--no-push`](#--no-push)
     - [`--preid`](#--preid)
+    - [`--detect-preid`](#--detect-preid)
     - [`--sign-git-commit`](#--sign-git-commit)
     - [`--sign-git-tag`](#--sign-git-tag)
     - [`--force-git-tag`](#--force-git-tag)
@@ -395,6 +396,23 @@ lerna version prepatch --preid next
 
 When run with this flag, `lerna version` will increment `premajor`, `preminor`, `prepatch`, or `prerelease` semver
 bumps using the specified [prerelease identifier](http://semver.org/#spec-item-9).
+
+### `--detect-preid`
+
+```sh
+lerna version prerelease --preid alpha --detect-preid
+# 1.0.0 => 1.0.1-alpha.0
+
+lerna version prerelease --preid beta --detect-preid
+# 1.0.1-alpha.0 => 1.0.1-beta.0
+
+lerna version prerelease --preid alpha --detect-preid
+# 1.0.1-beta.0 => 1.0.1-alpha.1
+```
+
+This option is used with the `--preid` and `--conventional-commits` options.
+It ensures that the prerelease version is bumped to a non-existent git tag by searching the latest tag of
+this semantic prerelease version with a specific [prerelease identifier](http://semver.org/#spec-item-9).
 
 ### `--sign-git-commit`
 

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -142,6 +142,10 @@ exports.builder = (yargs, composed) => {
       requiresArg: true,
       defaultDescription: "alpha",
     },
+    "detect-preid": {
+      describe: "Find latest tag of preid when incrementing conventional prerelease version",
+      type: "boolean",
+    },
     "sign-git-commit": {
       describe: "Pass the `--gpg-sign` flag to `git commit`.",
       type: "boolean",

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -367,7 +367,7 @@ class VersionCommand extends Command {
 
   recommendVersions(resolvePrereleaseId) {
     const independentVersions = this.project.isIndependent();
-    const { changelogPreset, conventionalGraduate } = this.options;
+    const { changelogPreset, conventionalGraduate, detectPreid } = this.options;
     const rootPath = this.project.manifest.location;
     const type = independentVersions ? "independent" : "fixed";
     const prereleasePackageNames = this.getPrereleasePackageNames();
@@ -394,6 +394,7 @@ class VersionCommand extends Command {
           rootPath,
           tagPrefix: this.tagPrefix,
           prereleaseId: getPrereleaseId(node),
+          detectPreid,
         })
       )
     );

--- a/core/conventional-commits/__tests__/conventional-commits.test.js
+++ b/core/conventional-commits/__tests__/conventional-commits.test.js
@@ -49,6 +49,28 @@ describe("conventional-commits", () => {
       expect(bump).toBe("1.1.0-alpha.0");
     });
 
+    it("returns next version prerelease bump with existing prereleaseId", async () => {
+      const cwd = await initFixture("independent");
+      const [pkg1] = await getPackages(cwd);
+      pkg1.version = "1.0.1-beta.0";
+
+      await gitTag(cwd, "package-1@1.0.1-alpha.0");
+      await gitTag(cwd, "package-1@1.0.1-alpha.1");
+      await gitTag(cwd, "package-1@1.0.1-alpha.2");
+
+      const bump = await recommendVersion(pkg1, "independent", { prereleaseId: "alpha", detectPreid: true });
+      expect(bump).toBe("1.0.1-alpha.3");
+    });
+
+    it("returns next independent version prerelease bump with non-existing prereleaseId", async () => {
+      const cwd = await initFixture("independent");
+      const [pkg1] = await getPackages(cwd);
+      pkg1.version = "1.0.1-beta.0";
+
+      const bump = await recommendVersion(pkg1, "independent", { prereleaseId: "alpha", detectPreid: true });
+      expect(bump).toBe("1.0.1-alpha.0");
+    });
+
     it("returns package-specific bumps in independent mode", async () => {
       const cwd = await initFixture("independent");
       const [pkg1, pkg2] = await getPackages(cwd);

--- a/core/conventional-commits/__tests__/get-previous-prerelease.test.js
+++ b/core/conventional-commits/__tests__/get-previous-prerelease.test.js
@@ -1,0 +1,47 @@
+"use strict";
+
+jest.mock("@lerna/child-process");
+
+const childProcess = require("@lerna/child-process");
+const { getPreviousPrerelease } = require("../lib/get-previous-prerelease");
+
+describe("get-previous-prerelease", () => {
+  childProcess.execSync.mockReturnValue(
+    "package-1@1.2.3-alpha.2\npackage-1@1.2.3-alpha.1\npackage-1@1.2.3-alpha.0"
+  );
+
+  it("should return current version if semver.coerce fails", () => {
+    const currentVersion = "some-version";
+    const previousPrerelease = getPreviousPrerelease(currentVersion, "package-1", "alpha");
+
+    expect(previousPrerelease).toBe("some-version");
+  });
+
+  it("should return previous prerelease version with package name", () => {
+    const currentVersion = "1.2.3-alpha.0";
+    const previousPrerelease = getPreviousPrerelease(currentVersion, "package-1", "alpha");
+
+    expect(previousPrerelease).toBe("1.2.3-alpha.2");
+    expect(childProcess.execSync).toHaveBeenLastCalledWith("git", [
+      "tag",
+      "--list",
+      "package-1@1.2.3-alpha*",
+      "--sort",
+      "-version:refname",
+    ]);
+  });
+
+  it("should return previous prerelease version without package name", () => {
+    const currentVersion = "1.2.3-alpha.0";
+    const previousPrerelease = getPreviousPrerelease(currentVersion, undefined, "alpha");
+
+    expect(previousPrerelease).toBe("1.2.3-alpha.2");
+    expect(childProcess.execSync).toHaveBeenLastCalledWith("git", [
+      "tag",
+      "--list",
+      "1.2.3-alpha*",
+      "--sort",
+      "-version:refname",
+    ]);
+  });
+});

--- a/core/conventional-commits/lib/get-previous-prerelease.js
+++ b/core/conventional-commits/lib/get-previous-prerelease.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const log = require("npmlog");
+const semver = require("semver");
+const childProcess = require("@lerna/child-process");
+
+module.exports.getPreviousPrerelease = getPreviousPrerelease;
+
+/**
+ * Finds the previous version with the current raw version and
+ * given prereleaseId. Falls back to the given current version.
+ *
+ * @param {string} currentVersion
+ * @param {string} name (Only used in independent mode)
+ * @param {string} prereleaseId
+ */
+function getPreviousPrerelease(currentVersion, name, prereleaseId) {
+  const coerced = semver.coerce(currentVersion);
+  if (!prereleaseId || !coerced) {
+    return currentVersion;
+  }
+
+  const namePrefix = name ? `${name}@` : "";
+  const tagSearch = `${namePrefix}${coerced.version}-${prereleaseId}*`;
+  const gitTagArgs = ["tag", "--list", tagSearch, "--sort", "-version:refname"];
+  const matchingTags = childProcess.execSync("git", gitTagArgs);
+  if (!matchingTags) {
+    return currentVersion;
+  }
+
+  const latestTag = matchingTags.split("\n")[0];
+  const previousPrerelease = latestTag.split("@").pop();
+  log.silly("getPreviousPrerelease", "found previous prerelease", previousPrerelease);
+  return previousPrerelease;
+}

--- a/core/conventional-commits/package.json
+++ b/core/conventional-commits/package.json
@@ -32,6 +32,7 @@
     "test": "echo \"Run tests from root\" && exit 1"
   },
   "dependencies": {
+    "@lerna/child-process": "file:../../core/child-process",
     "@lerna/validation-error": "file:../validation-error",
     "conventional-changelog-angular": "^5.0.12",
     "conventional-changelog-core": "^4.2.4",


### PR DESCRIPTION
Add `--detect-preid` option to avoid git tag errors when versioning conventional prerelease.

## Description
The current behaviour when incrementing prerelease does not take into account existing versions. This can lead to git tag failing when the resulting prerelease version already exists.

For example, given an alpha branch with version 1.0.1-alpha.0 is merged to a beta branch with version 1.0.1-beta.4 (previous versions included). The next version of the beta branch becomes 1.0.1-beta.0, an already existing version and tag.

A version option `--detect-preid` will attempt to find and bump from a previous existing prerelease version, if it exists. This is limited to version bumps using conventional commits.

## Motivation and Context
I created a [discussion thread](https://github.com/lerna/lerna/discussions/3391) a while ago regarding the current prerelease versioning behaviour. It seems more intuitive for the prerelease version bump to use the next non-existing numerical identifier. This new option offers that behaviour to anyone who might find it useful, myself included.

## How Has This Been Tested?
Published the changes to a local registry and tested on a new Lerna monorepo.
Tested by updating the prerelease version of a package on a beta branch (from `1.0.1-beta.0` to `1.0.1-beta.8`).
Merged a branch with version `1.0.1-alpha.0`. After versioning the beta branch, it resumed the version to `1.0.1-beta.9` instead of resetting to `1.0.1-beta.0` as per current behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
