### PR TITLE
fix(publish): support inconsistent workspace prefix usage

### DIFF
--- a/commands/publish/index.js
+++ b/commands/publish/index.js
@@ -560,19 +560,22 @@ class PublishCommand extends Command {
 
     return pMap(updatesWithWorkspaceLinks, (node) => {
       for (const [depName, resolved] of node.localDependencies) {
-        let depVersion;
-        let savePrefix;
-        if (resolved.workspaceAlias) {
-          depVersion = this.updatesVersions.get(depName) || this.packageGraph.get(depName).pkg.version;
-          savePrefix = resolved.workspaceAlias === "*" ? "" : resolved.workspaceAlias;
-        } else {
-          const specMatch = resolved.workspaceSpec.match(/^workspace:([~^]?)(.*)/);
-          savePrefix = specMatch[1];
-          depVersion = specMatch[2];
-        }
+        // only update local dependencies with workspace: links
+        if (resolved.workspaceSpec) {
+          let depVersion;
+          let savePrefix;
+          if (resolved.workspaceAlias) {
+            depVersion = this.updatesVersions.get(depName) || this.packageGraph.get(depName).pkg.version;
+            savePrefix = resolved.workspaceAlias === "*" ? "" : resolved.workspaceAlias;
+          } else {
+            const specMatch = resolved.workspaceSpec.match(/^workspace:([~^]?)(.*)/);
+            savePrefix = specMatch[1];
+            depVersion = specMatch[2];
+          }
 
-        // it no longer matters if we mutate the shared Package instance
-        node.pkg.updateLocalDependency(resolved, depVersion, savePrefix, { retainWorkspacePrefix: false });
+          // it no longer matters if we mutate the shared Package instance
+          node.pkg.updateLocalDependency(resolved, depVersion, savePrefix, { retainWorkspacePrefix: false });
+        }
       }
 
       // writing changes to disk handled in serializeChanges()

--- a/e2e/tests/lerna-publish/lerna-publish-npm-workspace-prefix.spec.ts
+++ b/e2e/tests/lerna-publish/lerna-publish-npm-workspace-prefix.spec.ts
@@ -77,8 +77,9 @@ describe("lerna-publish-workspace-prefix", () => {
       expect(replaceVersion(output.combinedOutput)).toMatchInlineSnapshot(`
         lerna notice cli v999.9.9-e2e.0
 
-        Found 7 packages to publish:
+        Found 8 packages to publish:
          - test-main => XX.XX.XX
+         - test-no-workspace-prefix => XX.XX.XX
          - test-workspace-alias-caret => XX.XX.XX
          - test-workspace-alias-star => XX.XX.XX
          - test-workspace-alias-tilde => XX.XX.XX
@@ -90,9 +91,26 @@ describe("lerna-publish-workspace-prefix", () => {
         lerna info publish Publishing packages to npm...
         lerna notice Skipping all user and access validation due to third-party registry
         lerna notice Make sure you're authenticated properly ¯\\_(ツ)_/¯
-        lerna WARN ENOLICENSE Packages test-main, test-workspace-alias-caret, test-workspace-alias-star, test-workspace-alias-tilde, test-workspace-approx, test-workspace-compat, and test-workspace-exact are missing a license.
+        lerna WARN ENOLICENSE Packages test-main, test-no-workspace-prefix, test-workspace-alias-caret, test-workspace-alias-star, test-workspace-alias-tilde, test-workspace-approx, test-workspace-compat, and test-workspace-exact are missing a license.
         lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
         lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
+        lerna success published test-no-workspace-prefix XX.XX.XX
+        lerna notice 
+        lerna notice 📦  test-no-workspace-prefix@XX.XX.XX
+        lerna notice === Tarball Contents === 
+        lerna notice XXXB lib/test-no-workspace-prefix.js
+        lerna notice XXXB package.json                   
+        lerna notice XXXB README.md                      
+        lerna notice === Tarball Details === 
+        lerna notice name:          test-no-workspace-prefix                
+        lerna notice version:       XX.XX.XX                                
+        lerna notice filename:      test-no-workspace-prefix-XX.XX.XX.tgz   
+        lerna notice package size:  XXXB                                   
+        lerna notice unpacked size: XXXB                                  
+        lerna notice shasum:        {FULL_COMMIT_SHA}
+        lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        lerna notice total files:   3                                       
+        lerna notice 
         lerna success published test-workspace-alias-caret XX.XX.XX
         lerna notice 
         lerna notice 📦  test-workspace-alias-caret@XX.XX.XX
@@ -214,13 +232,14 @@ describe("lerna-publish-workspace-prefix", () => {
         lerna notice 
         Successfully published:
          - test-main@XX.XX.XX
+         - test-no-workspace-prefix@XX.XX.XX
          - test-workspace-alias-caret@XX.XX.XX
          - test-workspace-alias-star@XX.XX.XX
          - test-workspace-alias-tilde@XX.XX.XX
          - test-workspace-approx@XX.XX.XX
          - test-workspace-compat@XX.XX.XX
          - test-workspace-exact@XX.XX.XX
-        lerna success published 7 packages
+        lerna success published 8 packages
 
       `);
 

--- a/e2e/tests/lerna-publish/lerna-publish-npm-workspace-prefix.spec.ts
+++ b/e2e/tests/lerna-publish/lerna-publish-npm-workspace-prefix.spec.ts
@@ -38,6 +38,7 @@ describe("lerna-publish-workspace-prefix", () => {
       await fixture.lerna("create test-workspace-exact -y");
       await fixture.lerna("create test-workspace-compat -y");
       await fixture.lerna("create test-workspace-approx -y");
+      await fixture.lerna("create test-no-workspace-prefix -y");
       await fixture.lerna("create test-main -y");
 
       await fixture.updateJson(`packages/test-main/package.json`, (json) => ({
@@ -50,6 +51,7 @@ describe("lerna-publish-workspace-prefix", () => {
           "test-workspace-exact": `workspace:0.0.0`,
           "test-workspace-compat": `workspace:^0.0.0`,
           "test-workspace-approx": `workspace:~0.0.0`,
+          "test-no-workspace-prefix": `^0.0.0`,
         },
       }));
 
@@ -242,6 +244,8 @@ describe("lerna-publish-workspace-prefix", () => {
       await unpublish("test-workspace-exact");
       await unpublish("test-workspace-compat");
       await unpublish("test-workspace-approx");
+      await unpublish("test-no-workspace-prefix");
+      await unpublish("test-main");
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a guard to prevent interpreting all local dependencies as workspace links when a single workspace link is detected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#3412

Lerna was assuming that if any one package is linked with the workspace: prefix, then all packages in the workspace are linked that way. This change allows workspaces to be more flexible and iterative when adopting the workspace: prefix standard. After this PR, `lerna publish` will no longer break when publishing a package with inconsistent usage of the workspace prefix for linking local dependencies.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and covered by an e2e test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
