### PR TITLE
docs(website): remove Babel from introduction.md

### DIFF
--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -6,7 +6,7 @@ type: explainer
 
 # Introduction
 
-Lerna is the original [monorepo tool](https://monorepo.tools) for TypeScript/JavaScript. It has been around for many years and is used by tens of thousands of projects, including React, Jest and Babel.
+Lerna is the original [monorepo tool](https://monorepo.tools) for TypeScript/JavaScript. It has been around for many years and is used by tens of thousands of projects, including React and Jest.
 
 It solves three of the biggest problems of JavaScript monorepos:
 


### PR DESCRIPTION
## Description
This PR removes `Babel` from the list of projects that depend on `Lerna`.

## Motivation and Context
It's no longer true that `Babel` uses `Lerna` since [Babel replaced Lerna with a custom Yarn plugin](https://github.com/babel/babel/pull/12138).

## How Has This Been Tested?
Not applicable

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (change that has absolutely no effect on users)

## Checklist:
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
