### PR TITLE
feat(version): use npmClientArgs in npm install after lerna version

### DIFF
--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -405,7 +405,13 @@ This option allows arguments to be passed to the `npm install` that `lerna versi
 
 For example:
 
-`lerna version 3.3.3 --npm-client-args=--legacy-peer-deps`
+```sh
+lerna version 3.3.3 --npm-client-args=--legacy-peer-deps
+
+lerna version 3.3.3 --npm-client-args="--legacy-peer-deps,--force"
+
+lerna version 3.3.3 --npm-client-args="--legacy-peer-deps --force"
+```
 
 This can also be set in `lerna.json`:
 
@@ -413,6 +419,19 @@ This can also be set in `lerna.json`:
 {
   ...
   "npmClientArgs": ["--legacy-peer-deps", "--production"]
+}
+```
+
+or specifically for the version command:
+
+```json
+{
+  ...
+  "command": {
+    "version": {
+      "npmClientArgs": ["--legacy-peer-deps", "--production"]
+    }
+  }
 }
 ```
 

--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -407,6 +407,15 @@ For example:
 
 `lerna version 3.3.3 --npm-client-args=--legacy-peer-deps`
 
+This can also be set in `lerna.json`:
+
+```json
+{
+  ...
+  "npmClientArgs": ["--legacy-peer-deps", "--production"]
+}
+```
+
 ### `--preid`
 
 ```sh

--- a/commands/version/README.md
+++ b/commands/version/README.md
@@ -70,6 +70,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--no-granular-pathspec`](#--no-granular-pathspec)
     - [`--no-private`](#--no-private)
     - [`--no-push`](#--no-push)
+    - [`--npm-client-args`](#--npm-client-args)
     - [`--preid`](#--preid)
     - [`--signoff-git-commit`](#--signoff-git-commit)
     - [`--sign-git-commit`](#--sign-git-commit)
@@ -397,6 +398,14 @@ Note that this option does _not_ exclude [private scoped packages](https://docs.
 
 By default, `lerna version` will push the committed and tagged changes to the configured [git remote](#--git-remote-name).
 Pass `--no-push` to disable this behavior.
+
+### `--npm-client-args`
+
+This option allows arguments to be passed to the `npm install` that `lerna version` performs to update the lockfile.
+
+For example:
+
+`lerna version 3.3.3 --npm-client-args=--legacy-peer-deps`
 
 ### `--preid`
 

--- a/commands/version/command.js
+++ b/commands/version/command.js
@@ -168,6 +168,10 @@ exports.builder = (yargs, composed) => {
       requiresArg: true,
       defaultDescription: "v",
     },
+    "npm-client-args": {
+      describe: "Additional arguments to pass to the npm client when performing 'npm install'.",
+      type: "array",
+    },
     y: {
       describe: "Skip all confirmation prompts.",
       alias: "yes",

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -616,7 +616,8 @@ class VersionCommand extends Command {
       );
     }
 
-    const npmClientArgs = this.options.npmClientArgs || [];
+    const npmClientArgsRaw = this.options.npmClientArgs || [];
+    const npmClientArgs = npmClientArgsRaw.reduce((args, arg) => args.concat(arg.split(/\s|,/)), []);
 
     if (this.options.npmClient === "pnpm") {
       chain = chain.then(() => {

--- a/commands/version/index.js
+++ b/commands/version/index.js
@@ -616,11 +616,13 @@ class VersionCommand extends Command {
       );
     }
 
+    const npmClientArgs = this.options.npmClientArgs || [];
+
     if (this.options.npmClient === "pnpm") {
       chain = chain.then(() => {
         this.logger.verbose("version", "Updating root pnpm-lock.yaml");
         return childProcess
-          .exec("pnpm", ["install", "--lockfile-only", "--ignore-scripts"], this.execOpts)
+          .exec("pnpm", ["install", "--lockfile-only", "--ignore-scripts", ...npmClientArgs], this.execOpts)
           .then(() => {
             const lockfilePath = path.join(this.project.rootPath, "pnpm-lock.yaml");
             changedFiles.add(lockfilePath);
@@ -634,7 +636,11 @@ class VersionCommand extends Command {
         chain = chain.then(() => {
           this.logger.verbose("version", "Updating root package-lock.json");
           return childProcess
-            .exec("npm", ["install", "--package-lock-only", "--ignore-scripts"], this.execOpts)
+            .exec(
+              "npm",
+              ["install", "--package-lock-only", "--ignore-scripts", ...npmClientArgs],
+              this.execOpts
+            )
             .then(() => {
               changedFiles.add(lockfilePath);
             });

--- a/core/lerna/schemas/lerna-schema.json
+++ b/core/lerna/schemas/lerna-schema.json
@@ -1123,6 +1123,9 @@
     "npmClient": {
       "$ref": "#/$defs/globals/npmClient"
     },
+    "npmClientArgs": {
+      "$ref": "#/$defs/globals/npmClientArgs"
+    },
     "loglevel": {
       "$ref": "#/$defs/globals/loglevel"
     },
@@ -1422,6 +1425,13 @@
         "description": "The npm client to use when running commands (either npm, yarn, or pnpm). Defaults to npm if unspecified.",
         "default": "npm",
         "enum": ["npm", "yarn", "pnpm"]
+      },
+      "npmClientArgs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Arguments to pass to the npm client when running commands."
       },
       "loglevel": {
         "type": "string",

--- a/core/lerna/schemas/lerna-schema.json
+++ b/core/lerna/schemas/lerna-schema.json
@@ -1067,6 +1067,9 @@
             "npmClient": {
               "$ref": "#/$defs/globals/npmClient"
             },
+            "npmClientArgs": {
+              "$ref": "#/$defs/globals/npmClientArgs"
+            },
             "loglevel": {
               "$ref": "#/$defs/globals/loglevel"
             },

--- a/e2e/tests/lerna-version/npm-client-args.spec.ts
+++ b/e2e/tests/lerna-version/npm-client-args.spec.ts
@@ -1,0 +1,59 @@
+import { Fixture } from "../../utils/fixture";
+import { normalizeCommitSHAs, normalizeEnvironment } from "../../utils/snapshot-serializer-utils";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommitSHAs(normalizeEnvironment(str));
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-version-npm-client-args", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      name: "lerna-version-npm-client-args",
+      packageManager: "npm",
+      initializeGit: true,
+      runLernaInit: true,
+      installDependencies: true,
+    });
+    await fixture.lerna("create package-a -y");
+
+    // eslint-plugin-react-app@6.2.2 requires a peer dependency of eslint@"6.x".
+    // Without it, the npm install at the end of `lerna version` will fail if
+    // --legacy-peer-deps is not passed correctly.
+    await fixture.updateJson("package.json", (json) => ({
+      ...json,
+      dependencies: {
+        ...(json.dependencies as Record<string, string>),
+        "eslint-plugin-react-app": "6.2.2",
+        eslint: "8.25.0",
+      },
+    }));
+    await fixture.createInitialGitCommit();
+    await fixture.exec("git push origin test-main");
+  });
+  afterEach(() => fixture.destroy());
+
+  it("should add npmClientArgs to npm install at the end of the version command", async () => {
+    const output = await fixture.lerna("version 3.3.3 -y --npmClientArgs=--legacy-peer-deps");
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info current version 0.0.0
+      lerna info Assuming all packages changed
+
+      Changes:
+       - package-a: 0.0.0 => 3.3.3
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
+});

--- a/e2e/version/src/npm-client-args.spec.ts
+++ b/e2e/version/src/npm-client-args.spec.ts
@@ -58,4 +58,40 @@ describe("lerna-version-npm-client-args", () => {
 
     `);
   });
+
+  it("should support multiple arguments, comma delimited", async () => {
+    const output = await fixture.lerna('version 3.3.3 -y --npm-client-args="--legacy-peer-deps,--fund"');
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info current version 0.0.0
+      lerna info Assuming all packages changed
+
+      Changes:
+       - package-a: 0.0.0 => 3.3.3
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
+
+  it("should support multiple arguments, space delimited", async () => {
+    const output = await fixture.lerna('version 3.3.3 -y --npm-client-args="--legacy-peer-deps --fund"');
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info current version 0.0.0
+      lerna info Assuming all packages changed
+
+      Changes:
+       - package-a: 0.0.0 => 3.3.3
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
 });

--- a/e2e/version/src/npm-client-args.spec.ts
+++ b/e2e/version/src/npm-client-args.spec.ts
@@ -1,5 +1,4 @@
-import { Fixture } from "../../utils/fixture";
-import { normalizeCommitSHAs, normalizeEnvironment } from "../../utils/snapshot-serializer-utils";
+import { Fixture, normalizeCommitSHAs, normalizeEnvironment } from "@lerna/e2e-utils";
 
 expect.addSnapshotSerializer({
   serialize(str: string) {
@@ -34,13 +33,16 @@ describe("lerna-version-npm-client-args", () => {
         eslint: "8.25.0",
       },
     }));
+    await fixture.exec(
+      "npm install eslint-plugin-react-app@6.2.2 eslint@8.25.0 --save=false --legacy-peer-deps"
+    );
     await fixture.createInitialGitCommit();
     await fixture.exec("git push origin test-main");
   });
   afterEach(() => fixture.destroy());
 
   it("should add npmClientArgs to npm install at the end of the version command", async () => {
-    const output = await fixture.lerna("version 3.3.3 -y --npmClientArgs=--legacy-peer-deps");
+    const output = await fixture.lerna("version 3.3.3 -y --npm-client-args=--legacy-peer-deps");
     expect(output.combinedOutput).toMatchInlineSnapshot(`
       lerna notice cli v999.9.9-e2e.0
       lerna info current version 0.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds configured npmClientArgs to the npm install command that happens at the end of lerna version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#3386

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually and covered by e2e tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
