### PR TITLE
docs(website): add state of js banner

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -65,14 +65,14 @@ const config = {
         contextualSearch: false,
         searchPagePath: false,
       },
-      // announcementBar: {
-      //   id: "lerna-talks",
-      //   content:
-      //     'Do not miss Lerna talks at <a target="_blank" style="font-weight: bolder" rel="noopener noreferrer" href="https://nx.dev/conf?utm_source=lerna.js.org">NxConf on October 17!</a>',
-      //   backgroundColor: "#9333EA",
-      //   textColor: "#FFFFFF",
-      //   isCloseable: false,
-      // },
+      announcementBar: {
+        id: "lerna-talks",
+        content:
+          'State of JS survey: <a target="_blank" style="font-weight: bolder" rel="noopener noreferrer" href="https://stateofjs.com/en-us/">Give Nx & Lerna a thumbs up</a> <span aria-hidden="true">&rarr;</span>',
+        backgroundColor: "#9333EA",
+        textColor: "#FFFFFF",
+        isCloseable: false,
+      },
       colorMode: {
         defaultMode: "light",
         disableSwitch: false,


### PR DESCRIPTION
It adds the state of JS survey link on the banner for lerna.js.org.