### PR TITLE
fix(schema): add the other format changelogPreset can assume

### DIFF
--- a/core/lerna/schemas/lerna-schema.json
+++ b/core/lerna/schemas/lerna-schema.json
@@ -1691,7 +1691,12 @@
           "description": "During `lerna version`, bumps version of changed prereleased packages when using --conventional-commits."
         },
         "changelogPreset": {
-          "type": "string",
+          "anyOf": [
+            { "type": "string" },
+            {
+              "$ref": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.2.0/schema.json"
+            }
+          ],
           "description": "For `lerna version`, the custom conventional-changelog preset."
         },
         "gitRemote": {


### PR DESCRIPTION
This references the version 2.2.0 from the following repository. https://github.com/conventional-changelog/conventional-changelog-config-spec

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current schema only allow for a string based "changelogPreset", but lerna also supports an object syntax for this property.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Linked the proposed changes to one of my monorepos' `lerna.json` by adding a `$schema` at the beginning of the file, it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
