### PR TITLE
feat(create): support relative path as lerna create location

### DIFF
--- a/commands/create/index.js
+++ b/commands/create/index.js
@@ -52,12 +52,18 @@ class CreateCommand extends Command {
     // npm-package-arg handles all the edge-cases with scopes
     const { name, scope } = npa(pkgName);
 
+    if (!name && pkgName.includes("/")) {
+      throw new ValidationError(
+        "ENOPKGNAME",
+        "Invalid package name. Use the <loc> positional to specify package directory.\nSee https://github.com/lerna/lerna/tree/main/commands/create#usage for details."
+      );
+    }
+
     // optional scope is _not_ included in the directory name
     this.dirName = scope ? name.split("/").pop() : name;
     this.pkgName = name;
-    this.pkgsDir =
-      this.project.packageParentDirs.find((pd) => pd.indexOf(pkgLocation) > -1) ||
-      this.project.packageParentDirs[0];
+
+    this.pkgsDir = this._getPackagesDir(pkgLocation);
 
     this.camelName = camelCase(this.dirName);
 
@@ -142,6 +148,29 @@ class CreateCommand extends Command {
     this.setRepository();
 
     return Promise.resolve(this.setDependencies());
+  }
+
+  _getPackagesDir(pkgLocation) {
+    if (!pkgLocation) {
+      return this.project.packageParentDirs[0];
+    }
+
+    const normalizedPkgLocation = path
+      .resolve(this.project.rootPath, path.normalize(pkgLocation))
+      .toLowerCase();
+    const packageParentDirs = this.project.packageParentDirs.map((p) => p.toLowerCase());
+
+    // using indexOf over includes due to platform differences (/private/tmp should match /tmp on macOS)
+    const matchingPath = packageParentDirs.find((p) => p.indexOf(normalizedPkgLocation) > -1);
+
+    if (matchingPath) {
+      return matchingPath;
+    }
+
+    throw new ValidationError(
+      "ENOPKGDIR",
+      `Location "${pkgLocation}" is not configured as a workspace directory.`
+    );
   }
 
   execute() {

--- a/libs/e2e-utils/src/lib/fixture.ts
+++ b/libs/e2e-utils/src/lib/fixture.ts
@@ -163,6 +163,13 @@ export class Fixture {
   }
 
   /**
+   * Check if a workspace file exists.
+   */
+  async workspaceFileExists(file: string): Promise<boolean> {
+    return existsSync(this.getWorkspacePath(file));
+  }
+
+  /**
    * Execute a given command in the root of the lerna workspace under test within the fixture.
    * This has been given a terse name to help with readability in the spec files.
    */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Provides a few quality of life updates for the <loc> positional argument for `lerna create`:
- Allows use of a path relative to the root of the project (./packages/apps)
- Fixes issue matching with multi-segment paths (#2520)
- No longer fails to match with configured workspace directories due to case sensitivity.
- Throws an explicit error when the location does not match a configured workspace directory. Previously, this would default to the first configured directory, which was misleading.
- Throws an explicit error when the "name" argument is not valid and it appears to look like a path (has a / in it). The error hints that the <loc> positional should be used instead and links to the create docs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#2520
#3444

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and covered with many e2e tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
