### PR TITLE
feat(publish): add --include-private option for testing private packages

### DIFF
--- a/e2e/publish/src/from-git-recover-from-error.spec.ts
+++ b/e2e/publish/src/from-git-recover-from-error.spec.ts
@@ -77,7 +77,6 @@ describe("lerna-publish-from-git-recover-from-error", () => {
         lerna WARN ENOLICENSE Packages test-1 and test-2 are missing a license.
         lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
         lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
-        lerna WARN publish Package is already published: test-1@XX.XX.XX
         lerna success published test-2 XX.XX.XX
         lerna notice 
         lerna notice 📦  test-2@XX.XX.XX
@@ -95,6 +94,7 @@ describe("lerna-publish-from-git-recover-from-error", () => {
         lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         lerna notice total files:   3                                       
         lerna notice 
+        lerna WARN publish Package is already published: test-1@XX.XX.XX
         Successfully published:
          - test-2@XX.XX.XX
         lerna success published 1 package

--- a/e2e/publish/src/publish-private-packages.spec.ts
+++ b/e2e/publish/src/publish-private-packages.spec.ts
@@ -1,0 +1,544 @@
+import { Fixture, normalizeCommitSHAs, normalizeEnvironment } from "@lerna/e2e-utils";
+
+const randomInt = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+const randomVersion = () => `${randomInt(10, 89)}.${randomInt(10, 89)}.${randomInt(10, 89)}`;
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommitSHAs(normalizeEnvironment(str))
+      .replaceAll(/integrity:\s*.*/g, "integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+      .replaceAll(/\d*B package\.json/g, "XXXB package.json")
+      .replaceAll(/size:\s*\d*\s?B/g, "size: XXXB")
+      .replaceAll(/\d*\.\d*\s?kB/g, "XXX.XXX kb")
+      .replaceAll(/test-\d/g, "test-X");
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-publish-private", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-publish",
+      packageManager: "npm",
+      initializeGit: true,
+      runLernaInit: true,
+      installDependencies: true,
+    });
+  });
+  afterEach(() => fixture.destroy());
+
+  describe("from-git", () => {
+    it("should not publish private packages by default", async () => {
+      await fixture.lerna("create test-1 --private -y");
+
+      await fixture.createInitialGitCommit();
+      await fixture.exec("git push origin test-main");
+
+      const version = randomVersion();
+      await fixture.lerna(`version ${version} -y`);
+
+      const output = await fixture.lerna("publish from-git --registry=http://localhost:4872 -y");
+
+      const replaceVersion = (str: string) => str.replaceAll(version, "XX.XX.XX");
+
+      expect(replaceVersion(output.combinedOutput)).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna success No changed packages to publish 
+
+      `);
+    });
+
+    describe("--include-private", () => {
+      it("without args should throw", async () => {
+        await fixture.lerna("create test-1 --private -y");
+
+        await fixture.createInitialGitCommit();
+        await fixture.exec("git push origin test-main");
+
+        const version = randomVersion();
+        await fixture.lerna(`version ${version} -y`);
+
+        const output = await fixture.lerna(
+          "publish from-git --include-private --registry=http://localhost:4872 -y",
+          { silenceError: true }
+        );
+
+        expect(output.combinedOutput).toMatchInlineSnapshot(`
+          lerna notice cli v999.9.9-e2e.0
+          lerna ERR! EINCLPRIV Must specify at least one private package to include with --include-private.
+
+        `);
+      });
+
+      it("should publish only specified private package and public packages", async () => {
+        await fixture.lerna("create test-1 --private -y");
+        await fixture.lerna("create test-2 --private -y");
+        await fixture.lerna("create test-3 -y");
+        await fixture.lerna("create test-4 --private -y");
+
+        await fixture.createInitialGitCommit();
+        await fixture.exec("git push origin test-main");
+
+        const version = randomVersion();
+        await fixture.lerna(`version ${version} -y`);
+
+        const output = await fixture.lerna(
+          "publish from-git --include-private test-1 test-2 --registry=http://localhost:4872 -y"
+        );
+        const unpublish = async (packageName: string) => {
+          const unpublishOutput = await fixture.exec(
+            `npm unpublish ${packageName}@${version} --force --registry=http://localhost:4872`
+          );
+          expect(replaceVersion(unpublishOutput.combinedOutput)).toContain(`${packageName}@XX.XX.XX`);
+        };
+
+        const replaceVersion = (str: string) => str.replaceAll(version, "XX.XX.XX");
+
+        expect(replaceVersion(output.combinedOutput)).toMatchInlineSnapshot(`
+          lerna notice cli v999.9.9-e2e.0
+          lerna info publish Including private packages ["test-X","test-X"]
+
+          Found 3 packages to publish:
+           - test-X => XX.XX.XX (private!)
+           - test-X => XX.XX.XX (private!)
+           - test-X => XX.XX.XX
+
+          lerna info auto-confirmed 
+          lerna info publish Publishing packages to npm...
+          lerna notice Skipping all user and access validation due to third-party registry
+          lerna notice Make sure you're authenticated properly ¯\\_(ツ)_/¯
+          lerna WARN ENOLICENSE Packages test-X, test-X, and test-X are missing a license.
+          lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
+          lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          Successfully published:
+           - test-X@XX.XX.XX
+           - test-X@XX.XX.XX
+           - test-X@XX.XX.XX
+          lerna success published 3 packages
+
+        `);
+
+        unpublish("test-1");
+        unpublish("test-2");
+        unpublish("test-3");
+      });
+
+      it("should publish all private packages if provided '*'", async () => {
+        await fixture.lerna("create test-1 --private -y");
+        await fixture.lerna("create test-2 --private -y");
+        await fixture.lerna("create test-3 -y");
+
+        await fixture.createInitialGitCommit();
+        await fixture.exec("git push origin test-main");
+
+        const version = randomVersion();
+        await fixture.lerna(`version ${version} -y`);
+
+        const output = await fixture.lerna(
+          'publish from-git --include-private "*" --registry=http://localhost:4872 -y'
+        );
+        const unpublish = async (packageName: string) => {
+          const unpublishOutput = await fixture.exec(
+            `npm unpublish ${packageName}@${version} --force --registry=http://localhost:4872`
+          );
+          expect(replaceVersion(unpublishOutput.combinedOutput)).toContain(`${packageName}@XX.XX.XX`);
+        };
+
+        const replaceVersion = (str: string) => str.replaceAll(version, "XX.XX.XX");
+
+        expect(replaceVersion(output.combinedOutput)).toMatchInlineSnapshot(`
+          lerna notice cli v999.9.9-e2e.0
+          lerna info publish Including private packages ["*"]
+
+          Found 3 packages to publish:
+           - test-X => XX.XX.XX (private!)
+           - test-X => XX.XX.XX (private!)
+           - test-X => XX.XX.XX
+
+          lerna info auto-confirmed 
+          lerna info publish Publishing packages to npm...
+          lerna notice Skipping all user and access validation due to third-party registry
+          lerna notice Make sure you're authenticated properly ¯\\_(ツ)_/¯
+          lerna WARN ENOLICENSE Packages test-X, test-X, and test-X are missing a license.
+          lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
+          lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          Successfully published:
+           - test-X@XX.XX.XX
+           - test-X@XX.XX.XX
+           - test-X@XX.XX.XX
+          lerna success published 3 packages
+
+        `);
+
+        unpublish("test-1");
+        unpublish("test-2");
+        unpublish("test-3");
+      });
+    });
+  });
+
+  describe("from-package", () => {
+    it("should not publish private packages by default", async () => {
+      await fixture.lerna("create test-1 --private -y");
+
+      await fixture.createInitialGitCommit();
+      await fixture.exec("git push origin test-main");
+
+      const version = randomVersion();
+      await fixture.lerna(`version ${version} -y`);
+
+      const output = await fixture.lerna("publish from-package --registry=http://localhost:4872 -y");
+
+      const replaceVersion = (str: string) => str.replaceAll(version, "XX.XX.XX");
+
+      expect(replaceVersion(output.combinedOutput)).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna WARN Unable to determine published version, assuming "test-X" unpublished.
+        lerna notice from-package No unpublished release found
+        lerna success No changed packages to publish 
+
+      `);
+    });
+
+    describe("--include-private", () => {
+      it("should publish only specified private package and public packages", async () => {
+        await fixture.lerna("create test-1 --private -y");
+        await fixture.lerna("create test-2 --private -y");
+        await fixture.lerna("create test-3 -y");
+        await fixture.lerna("create test-4 --private -y");
+
+        await fixture.createInitialGitCommit();
+        await fixture.exec("git push origin test-main");
+
+        const version = randomVersion();
+        await fixture.lerna(`version ${version} -y`);
+
+        const output = await fixture.lerna(
+          "publish from-package --include-private test-1 test-2 --registry=http://localhost:4872 -y"
+        );
+        const unpublish = async (packageName: string) => {
+          const unpublishOutput = await fixture.exec(
+            `npm unpublish ${packageName}@${version} --force --registry=http://localhost:4872`
+          );
+          expect(replaceVersion(unpublishOutput.combinedOutput)).toContain(`${packageName}@XX.XX.XX`);
+        };
+
+        const replaceVersion = (str: string) => str.replaceAll(version, "XX.XX.XX");
+
+        expect(replaceVersion(output.combinedOutput)).toMatchInlineSnapshot(`
+          lerna notice cli v999.9.9-e2e.0
+          lerna info publish Including private packages ["test-X","test-X"]
+          lerna WARN Unable to determine published version, assuming "test-X" unpublished.
+          lerna WARN Unable to determine published version, assuming "test-X" unpublished.
+          lerna WARN Unable to determine published version, assuming "test-X" unpublished.
+          lerna WARN Unable to determine published version, assuming "test-X" unpublished.
+
+          Found 3 packages to publish:
+           - test-X => XX.XX.XX (private!)
+           - test-X => XX.XX.XX (private!)
+           - test-X => XX.XX.XX
+
+          lerna info auto-confirmed 
+          lerna info publish Publishing packages to npm...
+          lerna notice Skipping all user and access validation due to third-party registry
+          lerna notice Make sure you're authenticated properly ¯\\_(ツ)_/¯
+          lerna WARN ENOLICENSE Packages test-X, test-X, and test-X are missing a license.
+          lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
+          lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          lerna success published test-X XX.XX.XX
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX                                
+          lerna notice filename:      test-X-XX.XX.XX.tgz                     
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          Successfully published:
+           - test-X@XX.XX.XX
+           - test-X@XX.XX.XX
+           - test-X@XX.XX.XX
+          lerna success published 3 packages
+
+        `);
+
+        unpublish("test-1");
+        unpublish("test-2");
+        unpublish("test-3");
+      });
+    });
+  });
+
+  describe("canary", () => {
+    it("should not publish private packages by default", async () => {
+      await fixture.lerna("create test-canary --private -y");
+
+      await fixture.createInitialGitCommit();
+      await fixture.exec("git push origin test-main");
+
+      const output = await fixture.lerna("publish --canary major --registry=http://localhost:4872 -y");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna info canary enabled
+        lerna info Assuming all packages changed
+        lerna success No changed packages to publish 
+
+      `);
+    });
+
+    describe("--include-private", () => {
+      it("should publish only specified private package and public packages", async () => {
+        await fixture.lerna("create test-1 --private -y");
+        await fixture.lerna("create test-2 --private -y");
+        await fixture.lerna("create test-3 -y");
+        await fixture.lerna("create test-4 --private -y");
+
+        await fixture.createInitialGitCommit();
+        await fixture.exec("git push origin test-main");
+
+        const output = await fixture.lerna(
+          "publish --canary major --include-private test-1 test-2 --registry=http://localhost:4872 -y"
+        );
+        const unpublish = async (packageName: string) => {
+          const unpublishOutput = await fixture.exec(
+            `npm unpublish ${packageName}@1.0.0-alpha.0 --force --registry=http://localhost:4872`
+          );
+          expect(replaceVersion(unpublishOutput.combinedOutput)).toContain(`${packageName}@XX.XX.XX`);
+        };
+
+        const replaceVersion = (str: string) => str.replaceAll("1.0.0", "XX.XX.XX");
+
+        expect(replaceVersion(output.combinedOutput)).toMatchInlineSnapshot(`
+          lerna notice cli v999.9.9-e2e.0
+          lerna info publish Including private packages ["test-X","test-X"]
+          lerna info canary enabled
+          lerna info Assuming all packages changed
+
+          Found 3 packages to publish:
+           - test-X => XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA} (private!)
+           - test-X => XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA} (private!)
+           - test-X => XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+
+          lerna info auto-confirmed 
+          lerna info publish Publishing packages to npm...
+          lerna notice Skipping all user and access validation due to third-party registry
+          lerna notice Make sure you're authenticated properly ¯\\_(ツ)_/¯
+          lerna WARN ENOLICENSE Packages test-X, test-X, and test-X are missing a license.
+          lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
+          lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
+          lerna success published test-X XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}                   
+          lerna notice filename:      test-X-XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}.tgz        
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          lerna success published test-X XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}                   
+          lerna notice filename:      test-X-XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}.tgz        
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          lerna success published test-X XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice 
+          lerna notice 📦  test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice === Tarball Contents === 
+          lerna notice 90B  lib/test-X.js
+          lerna notice XXXB package.json 
+          lerna notice 110B README.md    
+          lerna notice === Tarball Details === 
+          lerna notice name:          test-X                                  
+          lerna notice version:       XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}                   
+          lerna notice filename:      test-X-XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}.tgz        
+          lerna notice package size: XXXB                                   
+          lerna notice unpacked size: XXX.XXX kb                                  
+          lerna notice shasum:        {FULL_COMMIT_SHA}
+          lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          lerna notice total files:   3                                       
+          lerna notice 
+          Successfully published:
+           - test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+           - test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+           - test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna success published 3 packages
+
+        `);
+
+        unpublish("test-1");
+        unpublish("test-2");
+        unpublish("test-3");
+      });
+    });
+  });
+});

--- a/libs/commands/create/README.md
+++ b/libs/commands/create/README.md
@@ -34,7 +34,8 @@ Command Options:
                   pkg.homepage                                          [string]
   --keywords      A list of package keywords                             [array]
   --license       The desired package license (SPDX identifier)   [default: ISC]
-  --private       Make the new package private, never published
+  --private       Make the new package private, indicating that it
+                  should not be published.
   --registry      Configure the package's publishConfig.registry        [string]
   --tag           Configure the package's publishConfig.tag             [string]
   --yes           Skip all prompts, accepting default values

--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -197,7 +197,6 @@ lerna publish --include-private "*"
 
 Quotes must be placed around "\*" to prevent the shell from prematurely expanding it.
 
-
 ### `--legacy-auth`
 
 When publishing packages that require authentication but you are working with an internally hosted NPM Registry that only uses the legacy Base64 version of username:password. This is the same as the NPM publish `_auth` flag.
@@ -383,7 +382,6 @@ To publish packages with a scope (e.g., `@mycompany/rocks`), you must set [`acce
 - If you _want_ your scoped package to remain private (i.e., `"restricted"`), there is no need to set this value.
 
   Note that this is **not** the same as setting `"private": true` in a leaf package; if the `private` field is set, that package will not be published. For more information, see the [`--include-private` option](#--include-private).
-
 
 ### `publishConfig.registry`
 

--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -20,7 +20,7 @@ When run, this command does one of the following things:
 - Publish packages in the latest commit where the version is not present in the registry (`from-package`).
 - Publish an unversioned "canary" release of packages (and their dependents) updated in the previous commit.
 
-> Lerna will never publish packages which are marked as private (`"private": true` in the `package.json`).
+> Lerna will not publish packages which are marked as private (`"private": true` in the `package.json`). This is consistent with the behavior of `npm publish`. See the [package.json docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#private) for more information. To override this behavior, see the [`--include-private` option](#--include-private).
 
 During all publish operations, appropriate [lifecycle scripts](#lifecycle-scripts) are called in the root and per-package (unless disabled by [`--ignore-scripts](#--ignore-scripts)).
 
@@ -56,6 +56,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 - [`--graph-type <all|dependencies>`](#--graph-type-alldependencies)
 - [`--ignore-scripts`](#--ignore-scripts)
 - [`--ignore-prepublish`](#--ignore-prepublish)
+- [`--include-private`](#--include-private)
 - [`--legacy-auth`](#--legacy-auth)
 - [`--no-git-reset`](#--no-git-reset)
 - [`--no-granular-pathspec`](#--no-granular-pathspec)
@@ -172,6 +173,30 @@ When passed, this flag will disable running [lifecycle scripts](#lifecycle-scrip
 ### `--ignore-prepublish`
 
 When passed, this flag will disable running [deprecated](https://docs.npmjs.com/misc/scripts#prepublish-and-prepare) [`prepublish` scripts](#lifecycle-scripts) during `lerna publish`.
+
+### `--include-private`
+
+Indicates a list of packages marked with `"private": true` that should be published. Since `npm publish` refuses to publish any packages with `"private": true`, Lerna removes the property before publishing.
+
+Note that this is different than [private scoped packages](https://docs.npmjs.com/about-private-packages), which do not have `"private": true` in their `package.json`, are intended to be published, and are included by `lerna publish` by default. See the [npm docs](https://docs.npmjs.com/about-private-packages) for more information about these kind of packages.
+
+> ⚠️ CAUTION ⚠️: Packages marked with `"private": true` are not intended to be published, as detailed in the [npm package.json docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#private). The intended use of this option is to allow publishing packages that _will be public in the future_ to a local registry for testing purposes.
+
+Examples:
+
+```sh
+lerna publish --include-private my-private-package
+lerna publish --include-private my-private-package my-other-private-package
+```
+
+The wildcard "\*" may also be provided in place of a list of packages. In this case, all private packages will be published.
+
+```sh
+lerna publish --include-private "*"
+```
+
+Quotes must be placed around "\*" to prevent the shell from prematurely expanding it.
+
 
 ### `--legacy-auth`
 
@@ -357,7 +382,8 @@ To publish packages with a scope (e.g., `@mycompany/rocks`), you must set [`acce
 - If this field is set for a package _without_ a scope, it **will** fail.
 - If you _want_ your scoped package to remain private (i.e., `"restricted"`), there is no need to set this value.
 
-  Note that this is **not** the same as setting `"private": true` in a leaf package; if the `private` field is set, that package will _never_ be published under any circumstances.
+  Note that this is **not** the same as setting `"private": true` in a leaf package; if the `private` field is set, that package will not be published. For more information, see the [`--include-private` option](#--include-private).
+
 
 ### `publishConfig.registry`
 

--- a/libs/commands/publish/src/command.ts
+++ b/libs/commands/publish/src/command.ts
@@ -122,6 +122,11 @@ const command: CommandModule = {
           "Generate a json summary report after all packages have been successfully published, you can pass an optional path for where to save the file.",
         type: "string",
       },
+      "include-private": {
+        describe:
+          "Include specified private packages when publishing by temporarily removing the private property from the package manifest. This should only be used for testing private packages that will become public. Private packages should not usually be published. See the npm docs for details (https://docs.npmjs.com/cli/v9/configuring-npm/package-json#private).",
+        type: "array",
+      },
     };
 
     composeVersionOptions(yargs);
@@ -178,7 +183,14 @@ const command: CommandModule = {
         /* eslint-enable no-param-reassign */
 
         return argv;
-      });
+      })
+      .middleware((args) => {
+        const { includePrivate } = args;
+        if (includePrivate && Array.isArray(includePrivate)) {
+          // eslint-disable-next-line no-param-reassign
+          args["includePrivate"] = includePrivate.reduce((acc, pkg) => [...acc, ...pkg.split(/[\s,]/)], []);
+        }
+      }, true);
   },
   handler(argv) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/libs/commands/publish/src/lib/get-unpublished-packages.ts
+++ b/libs/commands/publish/src/lib/get-unpublished-packages.ts
@@ -18,8 +18,7 @@ function getUnpublishedPackages(packageGraph, opts) {
 
   let chain = Promise.resolve();
 
-  // don't bother attempting to get the packument for private packages
-  const graphNodesToCheck = Array.from(packageGraph.values()).filter(({ pkg }) => !pkg.private);
+  const graphNodesToCheck = Array.from(packageGraph.values());
 
   const mapper = (pkg) =>
     pacote.packument(pkg.name, opts).then(

--- a/libs/core/src/lib/package.ts
+++ b/libs/core/src/lib/package.ts
@@ -118,6 +118,10 @@ export class Package {
     return Boolean(this[PKG].private);
   }
 
+  set private(isPrivate) {
+    this[PKG].private = isPrivate;
+  }
+
   get resolved() {
     return this[_resolved];
   }
@@ -325,5 +329,12 @@ export class Package {
       // @ts-ignore
       depCollection[depName] = hosted.toString({ noGitPlus: false, noCommittish: false });
     }
+  }
+
+  /**
+   * Remove the private property, effectively making the package public.
+   */
+  removePrivate() {
+    delete this[PKG].private;
   }
 }

--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -822,6 +822,9 @@
             "verifyAccess": {
               "$ref": "#/$defs/commandOptions/publish/verifyAccess"
             },
+            "includePrivate": {
+              "$ref": "#/$defs/commandOptions/publish/includePrivate"
+            },
 
             "npmClient": {
               "$ref": "#/$defs/globals/npmClient"
@@ -1694,6 +1697,13 @@
         "verifyAccess": {
           "type": "boolean",
           "description": "During `lerna publish`, when true, verify package read-write access for current npm user."
+        },
+        "includePrivate": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "During `lerna publish`, include specified private packages when publishing by temporarily removing the private property from the package manifest. This should only be used for testing private packages that will become public. The value \"*\" will include all private packages."
         }
       },
       "run": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds an option `--include-private` to `lerna publish`. This allows packages marked as `"private": true` in package.json to be published. Since npm does not allow publishing packages with `"private": true`, lerna will strip out the property before the publish.

The option accepts a list of package names to be included in the publish. The packages provided are only published if those packages are deemed necessary to publish, as is consistent with lerna's existing publish behavior. Alternatively, a "*" can be provided, telling lerna to allow any private package to be published.

```sh
$ lerna publish from-git --include-private my-private-package my-other-private-package
$ lerna publish from-git --include-private "*"
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows for the ability to publish packages that are currently private, but _will be public in the future_. This is useful for end to end testing. These packages can now be published to a locally hosted npm repository and downloaded for real in the end to end tests, all before the package is ready for publishing on the public npm repository.

Lerna's official stance on publishing private packages (and that you shouldn't do it) wouldn't change with this PR. If a package is meant to be published, then it is by definition "public", which means it should not have `"private": true` in package.json (as described in the [npm docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#private)). However, this strict implementation by lerna leaves no room for the specific use case outlined above - for packages that _will be public, but aren't yet_.

Therefore, this option is meant to be used as a workaround in CI pipelines for testing purposes, not for consistently publishing private packages to actual public repos. 

_Note that this PR is talking about packages with `"private": true` in package.json, which is different than npm's idea of [scoped private packages](https://docs.npmjs.com/about-private-packages)._


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and covered by e2e tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
