### PR TITLE
chore(run): warn in docs about using yarn and passing args to lerna run

### DIFF
--- a/libs/commands/run/README.md
+++ b/libs/commands/run/README.md
@@ -18,6 +18,14 @@ $ lerna run --parallel watch
 Run an [npm script](https://docs.npmjs.com/misc/scripts) in each package that contains that script. A double-dash (`--`)
 is necessary to pass dashed arguments to the script execution.
 
+> **Note for when using Yarn:**
+>
+> ```sh
+> $ yarn lerna <script> -- [..args]
+> ```
+>
+> The double dash (`--`) will be stripped by `yarn`. This results in the inability for Lerna to pass additional args to child scripts through the command line alone. To get around this, either globally install Lerna and run it directly, or create a script in `package.json` with your `lerna run` command and use `yarn` to directly run that instead.
+
 ## Options
 
 `lerna run` accepts all [filter flags](https://www.npmjs.com/package/@lerna/filter-options).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a note to the docs, warning users about using Yarn with `lerna run -- args`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is needed because it is currently unclear why `yarn lerna run test -- --myarg` won't correctly pass `--myarg` to the `test` script.

#3510

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
