### PR TITLE
fix(version): update yarn lock for versions of yarn >= 2.0.0

### DIFF
--- a/e2e/version/src/yarn-lockfiles.spec.ts
+++ b/e2e/version/src/yarn-lockfiles.spec.ts
@@ -1,0 +1,103 @@
+import { Fixture, normalizeCommitSHAs, normalizeEnvironment } from "@lerna/e2e-utils";
+import { readFileSync, writeFileSync } from "fs-extra";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommitSHAs(normalizeEnvironment(str));
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+const setupYarnBerry = async (fixture: Fixture) => {
+  await fixture.exec("yarn set version berry");
+  await fixture.exec("yarn config set nodeLinker node-modules");
+  await fixture.exec("yarn config set npmRegistryServer http://localhost:4872");
+  await fixture.exec("yarn config set unsafeHttpWhitelist localhost");
+
+  await fixture.createInitialGitCommit();
+
+  await fixture.exec("yarn install", {
+    env: {
+      ...process.env,
+      YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
+    },
+  });
+  writeFileSync(
+    fixture.getWorkspacePath(".gitignore"),
+    `
+  node_modules
+  .pnp.*
+  .yarn/*
+  !.yarn/patches
+  !.yarn/plugins
+  !.yarn/releases
+  !.yarn/sdks
+  !.yarn/versions
+  `
+  );
+
+  await fixture.overrideLernaConfig({
+    npmClient: "yarn",
+  });
+
+  await fixture.exec("git add .");
+  await fixture.exec("git commit -m 'chore: setup yarn berry'");
+  await fixture.exec("git push origin test-main");
+};
+
+describe("lerna-version-yarn-lockfiles", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-version-yarn-lockfiles",
+      packageManager: "yarn",
+      initializeGit: true,
+      runLernaInit: false,
+      installDependencies: false,
+    });
+
+    await fixture.lernaInit("", { keepDefaultOptions: true });
+    await setupYarnBerry(fixture);
+
+    await fixture.lerna("create package-a -y");
+    await fixture.lerna("create package-b --dependencies package-a -y");
+
+    await fixture.exec("yarn install", {
+      env: {
+        ...process.env,
+        YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
+      },
+    });
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: add packages'");
+    await fixture.exec("git push origin test-main");
+  });
+  afterEach(() => fixture.destroy());
+
+  it("should update yarn.lock", async () => {
+    const output = await fixture.lerna("version 3.3.3 -y");
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info current version 0.0.0
+      lerna info Assuming all packages changed
+
+      Changes:
+       - package-a: 0.0.0 => 3.3.3
+       - package-b: 0.0.0 => 3.3.3
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+    const yarnLock = readFileSync(fixture.getWorkspacePath("yarn.lock")).toString();
+    expect(yarnLock).toContain("package-a@^3.3.3, package-a@workspace:packages/package-a");
+    expect(yarnLock).toContain("package-b@workspace:packages/package-b");
+    expect(yarnLock).toContain("package-a: ^3.3.3");
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates yarn.lock after `lerna version` when on a version of yarn >= 2.0.0.

Yarn versions before 2.0.0 (all non-berry releases) don't put workspace dependencies in the lock file, so they do not need to be updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#3551

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and covered by an e2e test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
