### PR TITLE
chore(init): enable strict type checking for init cmd

### DIFF
--- a/libs/commands/init/tsconfig.json
+++ b/libs/commands/init/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "files": [],
   "include": [],
+  "compilerOptions": {
+    "strict": true
+  },
   "references": [
     {
       "path": "./tsconfig.lib.json"

--- a/libs/core/src/lib/package.ts
+++ b/libs/core/src/lib/package.ts
@@ -51,6 +51,7 @@ export interface RawManifest {
   optionalDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   publishConfig?: Record<"directory" | "registry" | "tag", string>;
+  workspaces?: string[];
 }
 
 type ExtendedNpaResult = npa.Result & {


### PR DESCRIPTION
 Removed some ts-ignore comments and any types

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Make init command lib more typesafe

## How Has This Been Tested?
Existing unit and regression test. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
