### PR TITLE
docs: fix wrong links to commands

### DIFF
--- a/e2e/create/src/create.spec.ts
+++ b/e2e/create/src/create.spec.ts
@@ -1246,7 +1246,7 @@ describe("lerna-create", () => {
         expect(result.combinedOutput).toMatchInlineSnapshot(`
           lerna notice cli v999.9.9-e2e.0
           lerna ERR! ENOPKGNAME Invalid package name. Use the <loc> positional to specify package directory.
-          lerna ERR! ENOPKGNAME See https://github.com/lerna/lerna/tree/main/commands/create#usage for details.
+          lerna ERR! ENOPKGNAME See https://github.com/lerna/lerna/tree/main/libs/commands/create#usage for details.
 
         `);
       });
@@ -1261,7 +1261,7 @@ describe("lerna-create", () => {
       expect(result.combinedOutput).toMatchInlineSnapshot(`
         lerna notice cli v999.9.9-e2e.0
         lerna ERR! ENOPKGNAME Invalid package name. Use the <loc> positional to specify package directory.
-        lerna ERR! ENOPKGNAME See https://github.com/lerna/lerna/tree/main/commands/create#usage for details.
+        lerna ERR! ENOPKGNAME See https://github.com/lerna/lerna/tree/main/libs/commands/create#usage for details.
 
       `);
     });
@@ -1283,7 +1283,7 @@ describe("lerna-create", () => {
         > node ./__tests__/test-script.test.js
         testScript tests passed
 
-         
+
 
          >  Lerna (powered by Nx)   Successfully ran target test for project test-script
 

--- a/libs/commands/changed/README.md
+++ b/libs/commands/changed/README.md
@@ -19,21 +19,21 @@ package-2
 
 ## Options
 
-`lerna changed` supports all of the flags supported by [`lerna ls`](https://github.com/lerna/lerna/tree/main/commands/list#options):
+`lerna changed` supports all of the flags supported by [`lerna ls`](https://github.com/lerna/lerna/tree/main/libs/commands/list#options):
 
-- [`--json`](https://github.com/lerna/lerna/tree/main/commands/list#--json)
-- [`--ndjson`](https://github.com/lerna/lerna/tree/main/commands/list#--ndjson)
-- [`-a`, `--all`](https://github.com/lerna/lerna/tree/main/commands/list#--all)
-- [`-l`, `--long`](https://github.com/lerna/lerna/tree/main/commands/list#--long)
-- [`-p`, `--parseable`](https://github.com/lerna/lerna/tree/main/commands/list#--parseable)
-- [`--toposort`](https://github.com/lerna/lerna/tree/main/commands/list#--toposort)
-- [`--graph`](https://github.com/lerna/lerna/tree/main/commands/list#--graph)
+- [`--json`](https://github.com/lerna/lerna/tree/main/libs/commands/list#--json)
+- [`--ndjson`](https://github.com/lerna/lerna/tree/main/libs/commands/list#--ndjson)
+- [`-a`, `--all`](https://github.com/lerna/lerna/tree/main/libs/commands/list#--all)
+- [`-l`, `--long`](https://github.com/lerna/lerna/tree/main/libs/commands/list#--long)
+- [`-p`, `--parseable`](https://github.com/lerna/lerna/tree/main/libs/commands/list#--parseable)
+- [`--toposort`](https://github.com/lerna/lerna/tree/main/libs/commands/list#--toposort)
+- [`--graph`](https://github.com/lerna/lerna/tree/main/libs/commands/list#--graph)
 
 Unlike `lerna ls`, however, `lerna changed` **does not** support [filter options](https://www.npmjs.com/package/@lerna/filter-options), as filtering is not supported by `lerna version` or `lerna publish`.
 
-`lerna changed` supports the following options of [`lerna version`](https://github.com/lerna/lerna/tree/main/commands/version#options) (the others are irrelevant):
+`lerna changed` supports the following options of [`lerna version`](https://github.com/lerna/lerna/tree/main/libs/commands/version#options) (the others are irrelevant):
 
-- [`--conventional-graduate`](https://github.com/lerna/lerna/tree/main/commands/version#--conventional-graduate).
-- [`--force-publish`](https://github.com/lerna/lerna/tree/main/commands/version#--force-publish).
-- [`--ignore-changes`](https://github.com/lerna/lerna/tree/main/commands/version#--ignore-changes).
-- [`--include-merged-tags`](https://github.com/lerna/lerna/tree/main/commands/version#--include-merged-tags).
+- [`--conventional-graduate`](https://github.com/lerna/lerna/tree/main/libs/commands/version#--conventional-graduate).
+- [`--force-publish`](https://github.com/lerna/lerna/tree/main/libs/commands/version#--force-publish).
+- [`--ignore-changes`](https://github.com/lerna/lerna/tree/main/libs/commands/version#--ignore-changes).
+- [`--include-merged-tags`](https://github.com/lerna/lerna/tree/main/libs/commands/version#--include-merged-tags).

--- a/libs/commands/create/src/index.ts
+++ b/libs/commands/create/src/index.ts
@@ -60,7 +60,7 @@ class CreateCommand extends Command {
     if (!name && pkgName.includes("/")) {
       throw new ValidationError(
         "ENOPKGNAME",
-        "Invalid package name. Use the <loc> positional to specify package directory.\nSee https://github.com/lerna/lerna/tree/main/commands/create#usage for details."
+        "Invalid package name. Use the <loc> positional to specify package directory.\nSee https://github.com/lerna/lerna/tree/main/libs/commands/create#usage for details."
       );
     }
 

--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -14,7 +14,7 @@ lerna publish from-package # explicitly publish packages where the latest versio
 
 When run, this command does one of the following things:
 
-- Publish packages updated since the last release (calling [`lerna version`](https://github.com/lerna/lerna/tree/main/commands/version#readme) behind the scenes).
+- Publish packages updated since the last release (calling [`lerna version`](https://github.com/lerna/lerna/tree/main/libs/commands/version#readme) behind the scenes).
   - This is the legacy behavior of lerna 2.x
 - Publish packages tagged in the current commit (`from-git`).
 - Publish packages in the latest commit where the version is not present in the registry (`from-package`).
@@ -32,7 +32,7 @@ Check out [Per-Package Configuration](#per-package-configuration) for more detai
 
 ### bump `from-git`
 
-In addition to the semver keywords supported by [`lerna version`](https://github.com/lerna/lerna/tree/main/commands/version#positionals),
+In addition to the semver keywords supported by [`lerna version`](https://github.com/lerna/lerna/tree/main/libs/commands/version#positionals),
 `lerna publish` also supports the `from-git` keyword.
 This will identify packages tagged by `lerna version` and publish them to npm.
 This is useful in CI scenarios where you wish to manually increment versions,
@@ -47,7 +47,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 
 ## Options
 
-`lerna publish` supports all of the options provided by [`lerna version`](https://github.com/lerna/lerna/tree/main/commands/version#options) in addition to the following:
+`lerna publish` supports all of the options provided by [`lerna version`](https://github.com/lerna/lerna/tree/main/libs/commands/version#options) in addition to the following:
 
 - [`--canary`](#--canary)
 - [`--contents <dir>`](#--contents-dir)
@@ -232,7 +232,7 @@ This option makes the most sense configured in lerna.json, as you really don't w
 }
 ```
 
-The root-level configuration is intentional, as this also covers the [identically-named option in `lerna version`](https://github.com/lerna/lerna/tree/main/commands/version#--no-granular-pathspec).
+The root-level configuration is intentional, as this also covers the [identically-named option in `lerna version`](https://github.com/lerna/lerna/tree/main/libs/commands/version#--no-granular-pathspec).
 
 ### `--verify-access`
 
@@ -364,7 +364,7 @@ The legacy preemptive access verification is now off by default, so `--no-verify
 
 ### `--skip-npm`
 
-Call [`lerna version`](https://github.com/lerna/lerna/tree/main/commands/version#readme) directly, instead.
+Call [`lerna version`](https://github.com/lerna/lerna/tree/main/libs/commands/version#readme) directly, instead.
 
 ## Per-Package Configuration
 
@@ -436,7 +436,7 @@ This _non-standard_ field allows you to customize the published subdirectory jus
 
 Lerna will run [npm lifecycle scripts](https://docs.npmjs.com/misc/scripts#description) during `lerna publish` in the following order:
 
-1. If versioning implicitly, run all [version lifecycle scripts](https://github.com/lerna/lerna/tree/main/commands/version#lifecycle-scripts)
+1. If versioning implicitly, run all [version lifecycle scripts](https://github.com/lerna/lerna/tree/main/libs/commands/version#lifecycle-scripts)
 2. Run `prepublish` lifecycle in root, if [enabled](#--ignore-prepublish)
 3. Run `prepare` lifecycle in root
 4. Run `prepublishOnly` lifecycle in root

--- a/libs/commands/version/README.md
+++ b/libs/commands/version/README.md
@@ -415,7 +415,7 @@ This option makes the most sense configured in lerna.json, as you really don't w
 }
 ```
 
-The root-level configuration is intentional, as this also covers the [identically-named option in `lerna publish`](https://github.com/lerna/lerna/tree/main/commands/publish#--no-granular-pathspec).
+The root-level configuration is intentional, as this also covers the [identically-named option in `lerna publish`](https://github.com/lerna/lerna/tree/main/libs/commands/publish#--no-granular-pathspec).
 
 ### `--no-private`
 
@@ -541,7 +541,7 @@ Use [`--no-git-tag-version`](#--no-git-tag-version) and [`--no-push`](#--no-push
 
 ### Generating Initial Changelogs
 
-If you start using the [`--conventional-commits`](#--conventional-commits) option _after_ the monorepo has been active for awhile, you can still generate changelogs for previous releases using [`conventional-changelog-cli`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#readme) and [`lerna exec`](https://github.com/lerna/lerna/tree/main/commands/exec#readme):
+If you start using the [`--conventional-commits`](#--conventional-commits) option _after_ the monorepo has been active for awhile, you can still generate changelogs for previous releases using [`conventional-changelog-cli`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#readme) and [`lerna exec`](https://github.com/lerna/lerna/tree/main/libs/commands/exec#readme):
 
 ```bash
 # Lerna does not actually use conventional-changelog-cli, so you need to install it temporarily


### PR DESCRIPTION
## Description
On some README for commands, we have wrong links.

## Motivation and Context
Got the right links to check the documentation.

## How Has This Been Tested?
Checked the code on github

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
