### PR TITLE
fix(packages): correct ref in lerna-schema.json

### DIFF
--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -986,7 +986,7 @@
               "$ref": "#/$defs/commandOptions/version/amend"
             },
             "buildMetadata": {
-              "$ref": "#/$defs/commandOptions/version/buildMetadata"
+              "$ref": "#/$defs/commandOptions/version/build-metadata"
             },
             "conventionalCommits": {
               "$ref": "#/$defs/commandOptions/shared/conventionalCommits"


### PR DESCRIPTION
Correct ref to `build-metadata` in lerna-schema.json

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Current json has invalid $ref (which is not existing).
I assume that intention was target line https://github.com/lerna/lerna/blob/main/packages/lerna/schemas/lerna-schema.json#L1741

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
