### PR TITLE
fix: resolving rimraf bin dir

### DIFF
--- a/libs/core/src/lib/rimraf-dir.ts
+++ b/libs/core/src/lib/rimraf-dir.ts
@@ -10,7 +10,7 @@ const childProcess = require("@lerna/child-process");
 
 let rimrafBinPath: string | undefined;
 
-export async function useRimrafBinPath(): Promise<string> {
+async function useRimrafBinPath(): Promise<string> {
   if (typeof rimrafBinPath === "string") {
     return rimrafBinPath;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to the fact that rimraf has changed its binary path, lerna no longer works with the new version 4.4.x. Therefore the cli location is now read from the package.json, as fallback the original module resolving was used.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

fixes [#3614](https://github.com/lerna/lerna/issues/3611)
