### PR TITLE
chore: fix nightly node loading logic

### DIFF
--- a/.github/actions/install-node-and-dependencies/action.yml
+++ b/.github/actions/install-node-and-dependencies/action.yml
@@ -15,7 +15,8 @@ runs:
     - name: Install node and npm based on the given values (or the volta config in package.json)
       uses: actions/setup-node@v3
       with:
-        node-version-file: "package.json"
+        node-version-file: ${{ inputs.node-version == '' && 'package.json' || '' }}
+        node-version: ${{ inputs.node-version }}
       # The volta action seems to failing to install/unpack a lot recently https://github.com/volta-cli/action/issues/77#issuecomment-1481045178
       # uses: volta-cli/action@v4
       # with:


### PR DESCRIPTION
Our node 16 nightly was broken because it was only respecting the package.json, now it will respect the given node 16 value