### PR TITLE
fix(run): only use run-one when not passing multiple scripts

### DIFF
--- a/e2e/run/task-runner/src/multiple-targets/assertions.spec.ts
+++ b/e2e/run/task-runner/src/multiple-targets/assertions.spec.ts
@@ -81,4 +81,42 @@ describe("lerna-run-nx-multiple-targets", () => {
 
     `);
   });
+
+  it("should run multiple comma-delimited targets concurrently for a single package", async () => {
+    const output = await fixture.readOutput("multiple-targets-single-package");
+    expect(output).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna notice filter including "package-X"
+      lerna info filter [ 'package-X' ]
+
+      >  Lerna (powered by Nx)   Running targets XXXXXXXXXX, XXXXXXXXXX for project package-X:
+
+      - package-X
+
+
+
+      > package-X:XXXXXXXXXX
+
+
+      > package-X@0.0.0 XXXXXXXXXX
+      > echo test-package-X
+
+      test-package-X
+
+      > package-X:XXXXXXXXXX
+
+
+      > package-X@0.0.0 XXXXXXXXXX
+      > echo test-package-X
+
+      test-package-X
+
+
+
+      >  Lerna (powered by Nx)   Successfully ran targets XXXXXXXXXX, XXXXXXXXXX for project package-X
+
+
+
+    `);
+  });
 });

--- a/e2e/run/task-runner/src/multiple-targets/exec.sh
+++ b/e2e/run/task-runner/src/multiple-targets/exec.sh
@@ -11,6 +11,7 @@ initializeFixture $DIR
 
 # Run the relevant task runner commands and write stdout and stderr to a named file in each case (for later assertions)
 npx lerna run print-name,print-name-again > $OUTPUTS/multiple-targets.txt 2>&1
+npx lerna run print-name,print-name-again --scope="package-3" > $OUTPUTS/multiple-targets-single-package.txt 2>&1
 
 # Run the assertions
 runAssertions $DIR $E2E_ROOT $FIXTURE_ROOT_PATH $UPDATE_SNAPSHOTS

--- a/libs/commands/run/src/index.ts
+++ b/libs/commands/run/src/index.ts
@@ -222,7 +222,7 @@ class RunCommand extends Command {
     this.configureNxOutput();
     const { targetDependencies, options, extraOptions } = await this.prepNxOptions();
 
-    if (this.packagesWithScript.length === 1) {
+    if (this.packagesWithScript.length === 1 && !Array.isArray(this.script)) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const { runOne } = require("nx/src/command-line/run-one");
       const fullQualifiedTarget =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the run command to use `runMany` when a single package matches the filter, but multiple targets are provided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Nx's `runOne` function cannot accept multiple targets. Because of this, Lerna currently errors in the following case:

```
$ lerna run --scope="my-specific-package" script1,script2
```

This fix makes this case use `runMany` instead, which can accept multiple targets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and an e2e test has been added to cover this case. All existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
