### PR TITLE
docs: use code block for conventional commit flag

### DIFF
--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -97,7 +97,7 @@ Running `lerna publish` now would detect v1.1.0 instead of v1.2.1 as the last re
 The implications of this depends on your usage of `lerna publish`:
 
 - The publish prompt would use v1.1.0 as the base for major/minor/patch suggestions.
-- When using the --conventional-commit flag:
+- When using the `--conventional-commit` flag:
   - would suggest a semver increment based on all the commits since v1.1.0 (including commits from v1.2.0, v1.2.1 etc)
   - The generated CHANGELOG.md files will repeat all the commits that have already been released in v1.2.0, v1.2.1 etc
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I noticed that all flags, except for the `--conventional-commit` flag, were presented as code blocks which is why I aligned the formatting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To ensure consistency and draw attention to the flag, I aligned the formatting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I looked the the Markdown preview here on GitHub.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
