### PR TITLE
fix: import-local cannot find local module

### DIFF
--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -118,6 +118,7 @@
     ".": "./dist/index.js",
     "./cli": "./dist/cli.js",
     "./cli.js": "./dist/cli.js",
+    "./dist/cli.js": "./dist/cli.js",
     "./commands/*": "./dist/commands/*/index.js",
     "./commands/*/command": "./dist/commands/*/command.js",
     "./commands/add/lib/*": "./dist/commands/add/lib/*.js",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -117,6 +117,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./cli": "./dist/cli.js",
+    "./cli.js": "./dist/cli.js",
     "./commands/*": "./dist/commands/*/index.js",
     "./commands/*/command": "./dist/commands/*/command.js",
     "./commands/add/lib/*": "./dist/commands/add/lib/*.js",


### PR DESCRIPTION
in import-local, new version get moduleId is lerna/dist/cli.js, old version get moduleId is lerna/cli.js
```
const moduleId = 'lerna/dist/cli.js,'
const ans = Module._resolveFilename(moduleId, {
    id: fromFile,
    filename: fromFile,
    paths: Module._nodeModulePaths(fromDirectory)
})
ans 
```

cannot get the lerna/dist/cli.js、lerna/cli.js in local node_modules, because package.json didnot exports './dist/cli.js'、'./cli.js'
just exports './cli'