### PR TITLE
feat: Add name of package that fails to publish

### DIFF
--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -922,7 +922,7 @@ class PublishCommand extends Command {
               }
 
               this.logger.silly("", err);
-              this.logger.warn("publish", `Package failed to publish: ${pkg.name}`);
+              this.logger.warn("notice", `Package failed to publish: ${pkg.name}`);
               this.logger.error(err.code, (err.body && err.body.error) || err.message);
 
               // avoid dumping logs, this isn't a lerna problem

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -922,6 +922,7 @@ class PublishCommand extends Command {
               }
 
               this.logger.silly("", err);
+              this.logger.warn("publish", `Package failed to publish: ${pkg.name}`);
               this.logger.error(err.code, (err.body && err.body.error) || err.message);
 
               // avoid dumping logs, this isn't a lerna problem

--- a/libs/commands/publish/src/lib/publish-from-package.spec.ts
+++ b/libs/commands/publish/src/lib/publish-from-package.spec.ts
@@ -118,7 +118,11 @@ describe("publish from-package", () => {
       }
     });
 
-    await lernaPublish(cwd)("from-package");
+    try {
+      await lernaPublish(cwd)("from-package");
+    } catch {
+      // ignore error
+    }
 
     const logMessages = loggingOutput("notice");
     expect(logMessages).toContain("Package failed to publish: package-2");

--- a/libs/commands/publish/src/lib/publish-from-package.spec.ts
+++ b/libs/commands/publish/src/lib/publish-from-package.spec.ts
@@ -105,6 +105,23 @@ describe("publish from-package", () => {
     ]);
   });
 
+  it("logs the name of the package that fails to be published", async () => {
+    const cwd = await initFixture("independent");
+
+    getUnpublishedPackages.mockImplementationOnce((packageGraph) => Array.from(packageGraph.values()));
+
+    npmPublish.mockImplementation(pkg => {
+      if (pkg.name === "package-2") {
+        throw new Error("some-error");
+      }
+    })
+
+    await lernaPublish(cwd)("from-package");
+
+    const logMessages = loggingOutput("notice");
+    expect(logMessages).toContain("Package failed to publish: package-2");
+  });
+
   it("exits early when all packages are published", async () => {
     const cwd = await initFixture("normal");
 

--- a/libs/commands/publish/src/lib/publish-from-package.spec.ts
+++ b/libs/commands/publish/src/lib/publish-from-package.spec.ts
@@ -47,9 +47,11 @@ const promptConfirmation = jest.mocked(_promptConfirmation);
 const throwIfUncommitted = jest.mocked(_throwIfUncommitted);
 
 // The mock differs from the real thing
-const npmPublish = _npmPublish as any;
-const writePkg = _writePkg as any;
-const output = _output as any;
+const npmPublish = _npmPublish as jest.MockedFunction<typeof _npmPublish> & { order: () => string[] };
+const writePkg = _writePkg as jest.MockedFunction<typeof _writePkg> & {
+  updatedManifest: (name: string) => { gitHead?: string };
+};
+const output = _output as jest.MockedFunction<typeof _output> & { logged: () => string[] };
 
 const initFixture = initFixtureFactory(__dirname);
 
@@ -110,11 +112,11 @@ describe("publish from-package", () => {
 
     getUnpublishedPackages.mockImplementationOnce((packageGraph) => Array.from(packageGraph.values()));
 
-    npmPublish.mockImplementation(pkg => {
+    npmPublish.mockImplementation(async (pkg) => {
       if (pkg.name === "package-2") {
         throw new Error("some-error");
       }
-    })
+    });
 
     await lernaPublish(cwd)("from-package");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a warning log entry when `lerna publish` fails that includes the package name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes there error returned from the registry doesn't include the package name. For instance `ERR! E402 You must sign up for private packages`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
