### PR TITLE
fix: remove non-functional schema properties starting with "no"

### DIFF
--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -43,9 +43,6 @@
             "registry": {
               "$ref": "#/$defs/commandOptions/shared/registry"
             },
-            "noBootstrap": {
-              "$ref": "#/$defs/commandOptions/add/noBootstrap"
-            },
             "bootstrap": {
               "$ref": "#/$defs/commandOptions/add/bootstrap"
             },
@@ -110,9 +107,6 @@
           "properties": {
             "hoist": {
               "$ref": "#/$defs/commandOptions/bootstrap/hoist"
-            },
-            "nohoist": {
-              "$ref": "#/$defs/commandOptions/bootstrap/nohoist"
             },
             "mutex": {
               "$ref": "#/$defs/commandOptions/bootstrap/mutex"
@@ -482,14 +476,8 @@
             "parallel": {
               "$ref": "#/$defs/commandOptions/shared/parallel"
             },
-            "noBail": {
-              "$ref": "#/$defs/commandOptions/shared/noBail"
-            },
             "bail": {
               "$ref": "#/$defs/commandOptions/shared/bail"
-            },
-            "noPrefix": {
-              "$ref": "#/$defs/commandOptions/shared/noPrefix"
             },
             "prefix": {
               "$ref": "#/$defs/commandOptions/shared/prefix"
@@ -792,9 +780,6 @@
             "ignoreScripts": {
               "$ref": "#/$defs/commandOptions/shared/ignoreScripts"
             },
-            "noGranularPathspec": {
-              "$ref": "#/$defs/commandOptions/shared/noGranularPathspec"
-            },
             "granularPathspec": {
               "$ref": "#/$defs/commandOptions/shared/granularPathspec"
             },
@@ -807,17 +792,11 @@
             "requireScripts": {
               "$ref": "#/$defs/commandOptions/publish/requireScripts"
             },
-            "noGitReset": {
-              "$ref": "#/$defs/commandOptions/publish/noGitReset"
-            },
             "gitReset": {
               "$ref": "#/$defs/commandOptions/publish/gitReset"
             },
             "tempTag": {
               "$ref": "#/$defs/commandOptions/publish/tempTag"
-            },
-            "noVerifyAccess": {
-              "$ref": "#/$defs/commandOptions/publish/noVerifyAccess"
             },
             "verifyAccess": {
               "$ref": "#/$defs/commandOptions/publish/verifyAccess"
@@ -893,14 +872,8 @@
             "parallel": {
               "$ref": "#/$defs/commandOptions/shared/parallel"
             },
-            "noBail": {
-              "$ref": "#/$defs/commandOptions/shared/noBail"
-            },
             "bail": {
               "$ref": "#/$defs/commandOptions/shared/bail"
-            },
-            "noPrefix": {
-              "$ref": "#/$defs/commandOptions/shared/noPrefix"
             },
             "prefix": {
               "$ref": "#/$defs/commandOptions/shared/prefix"
@@ -1024,32 +997,17 @@
             "message": {
               "$ref": "#/$defs/commandOptions/version/message"
             },
-            "noChangelog": {
-              "$ref": "#/$defs/commandOptions/version/noChangelog"
-            },
             "changelog": {
               "$ref": "#/$defs/commandOptions/version/changelog"
-            },
-            "noCommitHooks": {
-              "$ref": "#/$defs/commandOptions/version/noCommitHooks"
             },
             "commitHooks": {
               "$ref": "#/$defs/commandOptions/version/commitHooks"
             },
-            "noGitTagVersion": {
-              "$ref": "#/$defs/commandOptions/version/noGitTagVersion"
-            },
             "gitTagVersion": {
               "$ref": "#/$defs/commandOptions/version/gitTagVersion"
             },
-            "noGranularPathspec": {
-              "$ref": "#/$defs/commandOptions/shared/noGranularPathspec"
-            },
             "granularPathspec": {
               "$ref": "#/$defs/commandOptions/shared/granularPathspec"
-            },
-            "noPush": {
-              "$ref": "#/$defs/commandOptions/version/noPush"
             },
             "push": {
               "$ref": "#/$defs/commandOptions/version/push"
@@ -1218,17 +1176,11 @@
     "peer": {
       "$ref": "#/$defs/commandOptions/add/peer"
     },
-    "noBootstrap": {
-      "$ref": "#/$defs/commandOptions/add/noBootstrap"
-    },
     "bootstrap": {
       "$ref": "#/$defs/commandOptions/add/bootstrap"
     },
     "hoist": {
       "$ref": "#/$defs/commandOptions/bootstrap/hoist"
-    },
-    "nohoist": {
-      "$ref": "#/$defs/commandOptions/bootstrap/nohoist"
     },
     "mutex": {
       "$ref": "#/$defs/commandOptions/bootstrap/mutex"
@@ -1306,17 +1258,11 @@
     "requireScripts": {
       "$ref": "#/$defs/commandOptions/publish/requireScripts"
     },
-    "noGitReset": {
-      "$ref": "#/$defs/commandOptions/publish/noGitReset"
-    },
     "gitReset": {
       "$ref": "#/$defs/commandOptions/publish/gitReset"
     },
     "tempTag": {
       "$ref": "#/$defs/commandOptions/publish/tempTag"
-    },
-    "noVerifyAccess": {
-      "$ref": "#/$defs/commandOptions/publish/noVerifyAccess"
     },
     "verifyAccess": {
       "$ref": "#/$defs/commandOptions/publish/verifyAccess"
@@ -1350,26 +1296,14 @@
     "message": {
       "$ref": "#/$defs/commandOptions/version/message"
     },
-    "noChangelog": {
-      "$ref": "#/$defs/commandOptions/version/noChangelog"
-    },
     "changelog": {
       "$ref": "#/$defs/commandOptions/version/changelog"
-    },
-    "noCommitHooks": {
-      "$ref": "#/$defs/commandOptions/version/noCommitHooks"
     },
     "commitHooks": {
       "$ref": "#/$defs/commandOptions/version/commitHooks"
     },
-    "noGitTagVersion": {
-      "$ref": "#/$defs/commandOptions/version/noGitTagVersion"
-    },
     "gitTagVersion": {
       "$ref": "#/$defs/commandOptions/version/gitTagVersion"
-    },
-    "noPush": {
-      "$ref": "#/$defs/commandOptions/version/noPush"
     },
     "push": {
       "$ref": "#/$defs/commandOptions/version/push"
@@ -1411,14 +1345,8 @@
     "parallel": {
       "$ref": "#/$defs/commandOptions/shared/parallel"
     },
-    "noBail": {
-      "$ref": "#/$defs/commandOptions/shared/noBail"
-    },
     "bail": {
       "$ref": "#/$defs/commandOptions/shared/bail"
-    },
-    "noPrefix": {
-      "$ref": "#/$defs/commandOptions/shared/noPrefix"
     },
     "prefix": {
       "$ref": "#/$defs/commandOptions/shared/prefix"
@@ -1434,9 +1362,6 @@
     },
     "ignoreScripts": {
       "$ref": "#/$defs/commandOptions/shared/ignoreScripts"
-    },
-    "noGranularPathspec": {
-      "$ref": "#/$defs/commandOptions/shared/noGranularPathspec"
     },
     "granularPathspec": {
       "$ref": "#/$defs/commandOptions/shared/granularPathspec"
@@ -1552,10 +1477,6 @@
           "type": "boolean",
           "description": "During `lerna add`, save the newly added package to peerDependencies instead of dependencies."
         },
-        "noBootstrap": {
-          "type": "boolean",
-          "description": "Do not automatically chain `lerna bootstrap` after `lerna add`."
-        },
         "bootstrap": {
           "type": "boolean",
           "description": "Automatically chain `lerna bootstrap` after `lerna add`."
@@ -1565,10 +1486,6 @@
         "hoist": {
           "type": "string",
           "description": "During `lerna bootstrap`, install external dependencies matching [glob] to the repo root."
-        },
-        "nohoist": {
-          "type": "string",
-          "description": "During `lerna bootstrap`, don't hoist external dependencies matching [glob] to the repo root."
         },
         "mutex": {},
         "strict": {
@@ -1681,10 +1598,6 @@
           "type": "boolean",
           "description": "During `lerna publish`, when true, execute ./scripts/prepublish.js and ./scripts/postpublish.js, relative to package root."
         },
-        "noGitReset": {
-          "type": "boolean",
-          "description": "During `lerna publish`, when true, do not reset changes to working tree after publishing is complete."
-        },
         "gitReset": {
           "type": "boolean",
           "description": "During `lerna publish`, when true, reset changes to working tree after publishing is complete."
@@ -1692,10 +1605,6 @@
         "tempTag": {
           "type": "boolean",
           "description": "During `lerna publish`, when true, create a temporary tag while publishing."
-        },
-        "noVerifyAccess": {
-          "type": "boolean",
-          "description": "During `lerna publish`, when true, do not verify package read-write access for current npm user."
         },
         "verifyAccess": {
           "type": "boolean",
@@ -1777,33 +1686,17 @@
           "type": "string",
           "description": "For `lerna version`, the custom commit message to use when creating the version commit."
         },
-        "noChangelog": {
-          "type": "boolean",
-          "description": "During `lerna version`, when true, do not generate CHANGELOG.md files when using --conventional-commits."
-        },
         "changelog": {
           "type": "boolean",
           "description": "During `lerna version`, when true, generate CHANGELOG.md files when using --conventional-commits."
-        },
-        "noCommitHooks": {
-          "type": "boolean",
-          "description": "During `lerna version`, when true, do not run git commit hooks when committing version changes."
         },
         "commitHooks": {
           "type": "boolean",
           "description": "During `lerna version`, when true, run git commit hooks when committing version changes."
         },
-        "noGitTagVersion": {
-          "type": "boolean",
-          "description": "During `lerna version`, when true, do not commit or tag version changes."
-        },
         "gitTagVersion": {
           "type": "boolean",
           "description": "During `lerna version`, when true, commit and tag version changes."
-        },
-        "noPush": {
-          "type": "boolean",
-          "description": "During `lerna version`, when true, do not push tagged commit to git remote."
         },
         "push": {
           "type": "boolean",
@@ -1866,17 +1759,9 @@
           "type": "boolean",
           "description": "During `lerna exec` and `lerna run`, run commands with unlimited concurrency, streaming prefixed output."
         },
-        "noBail": {
-          "type": "boolean",
-          "description": "During `lerna exec` and `lerna run`, when true, do not exit with non-zero status if a command fails."
-        },
         "bail": {
           "type": "boolean",
           "description": "During `lerna exec` and `lerna run`, exit with non-zero status if any command fails."
-        },
-        "noPrefix": {
-          "type": "boolean",
-          "description": "During `lerna exec` and `lerna run`, when true, do not prefix output with originating package name."
         },
         "prefix": {
           "type": "boolean",
@@ -1897,10 +1782,6 @@
         "ignoreScripts": {
           "type": "boolean",
           "description": "During `lerna bootstrap`, `lerna publish`, and `lerna version`, don't run ANY lifecycle scripts in bootstrapped packages."
-        },
-        "noGranularPathspec": {
-          "type": "boolean",
-          "description": "During `lerna publish` and `lerna version`, when true, do not reset changes file-by-file, but globally."
         },
         "granularPathspec": {
           "type": "boolean",


### PR DESCRIPTION
Setting the commands in this way in the `lerna.json` doesn't appear to have ever worked. The correct way is to set the "positive" thing to false (e.g. `"push": false` rather than `"noPush": true`)