### PR TITLE
feat: do not include bootstrap, add, link commands by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,7 @@ You will need two different terminal windows for this as one of them will contai
 - Run `npm run local-registry start` in Terminal 1 (keep it running)
 - Run `npm adduser --registry http://localhost:4873` in Terminal 2 (real credentials are not required, you just need to
   be logged in. You can use test/test/test@test.io.)
-- Run `npm run local-registry enable` in Terminal 2
-- Run `npm run lerna-release 999.9.9 --local` in Terminal 2 - you can choose any nonexistent version number here, but it's recommended to use something which is different from the current major
+- Run `npm --registry=http://localhost:4873/ run lerna-release 999.9.9 --local` in Terminal 2 - you can choose any nonexistent version number here, but it's recommended to use something which is different from the current major
 
 You can then install your local version of lerna wherever you want by leveraging the `--registry` flag on the npm/npx client.
 

--- a/libs/commands/changed/src/command.ts
+++ b/libs/commands/changed/src/command.ts
@@ -50,4 +50,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/changed/tsconfig.lib.json
+++ b/libs/commands/changed/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/clean/src/command.ts
+++ b/libs/commands/clean/src/command.ts
@@ -25,4 +25,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/clean/tsconfig.lib.json
+++ b/libs/commands/clean/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/create/src/command.ts
+++ b/libs/commands/create/src/command.ts
@@ -90,4 +90,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/create/tsconfig.lib.json
+++ b/libs/commands/create/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/diff/src/command.ts
+++ b/libs/commands/diff/src/command.ts
@@ -28,4 +28,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/diff/tsconfig.lib.json
+++ b/libs/commands/diff/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/exec/src/command.ts
+++ b/libs/commands/exec/src/command.ts
@@ -75,4 +75,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/exec/tsconfig.lib.json
+++ b/libs/commands/exec/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/import/src/command.ts
+++ b/libs/commands/import/src/command.ts
@@ -39,4 +39,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/import/tsconfig.lib.json
+++ b/libs/commands/import/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/info/src/command.ts
+++ b/libs/commands/info/src/command.ts
@@ -12,4 +12,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/info/tsconfig.lib.json
+++ b/libs/commands/info/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/init/src/command.ts
+++ b/libs/commands/init/src/command.ts
@@ -23,4 +23,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/init/tsconfig.lib.json
+++ b/libs/commands/init/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/list/src/command.ts
+++ b/libs/commands/list/src/command.ts
@@ -18,4 +18,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/list/tsconfig.lib.json
+++ b/libs/commands/list/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/publish/src/command.ts
+++ b/libs/commands/publish/src/command.ts
@@ -198,4 +198,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/publish/tsconfig.lib.json
+++ b/libs/commands/publish/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/run/src/command.ts
+++ b/libs/commands/run/src/command.ts
@@ -101,4 +101,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/run/tsconfig.lib.json
+++ b/libs/commands/run/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/commands/version/src/command.ts
+++ b/libs/commands/version/src/command.ts
@@ -320,4 +320,4 @@ const command: CommandModule = {
   addBumpPositional,
 };
 
-module.exports = command;
+export = command;

--- a/libs/commands/version/tsconfig.lib.json
+++ b/libs/commands/version/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
+    "module": "commonjs",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/libs/core/src/lib/cli.ts
+++ b/libs/core/src/lib/cli.ts
@@ -1,16 +1,13 @@
 import dedent from "dedent";
 import log from "npmlog";
 import os from "os";
-import yargs from "yargs/yargs";
+import yargs from "yargs";
 
 /**
  * A factory that returns a yargs() instance configured with everything except commands.
  * Chain .parse() from this method to invoke.
- *
- * @param {Array = []} argv
- * @param {String = process.cwd()} cwd
  */
-export function lernaCLI(argv?: any, cwd?: any) {
+export function lernaCLI(argv?: string | readonly string[], cwd?: string) {
   const cli = yargs(argv, cwd);
 
   return globalOptions(cli)
@@ -18,7 +15,7 @@ export function lernaCLI(argv?: any, cwd?: any) {
     .demandCommand(1, "A command is required. Pass --help to see all available commands and options.")
     .recommendCommands()
     .strict()
-    .fail((msg: any, err: any) => {
+    .fail((msg, err: any) => {
       // certain yargs validations throw strings :P
       const actual = err || new Error(msg);
 
@@ -47,16 +44,16 @@ export function lernaCLI(argv?: any, cwd?: any) {
     `);
 }
 
-function globalOptions(argv: any) {
+function globalOptions(argv: yargs.Argv) {
   // the global options applicable to _every_ command
-  const opts = {
+  const opts: { [key: string]: yargs.Options } = {
     loglevel: {
       defaultDescription: "info",
       describe: "What level of logs to report.",
       type: "string",
     },
     concurrency: {
-      defaultDescription: os.cpus().length,
+      defaultDescription: String(os.cpus().length),
       describe: "How many processes to use when lerna parallelizes tasks.",
       type: "number",
       requiresArg: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23651,7 +23651,6 @@
       "dependencies": {
         "@lerna/child-process": "6.6.1",
         "@lerna/create": "6.6.1",
-        "@lerna/legacy-package-management": "6.6.1",
         "@npmcli/arborist": "6.2.3",
         "@npmcli/run-script": "4.1.7",
         "@nrwl/devkit": ">=15.5.2 < 16",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@lerna/child-process": "6.6.1",
     "@lerna/create": "6.6.1",
-    "@lerna/legacy-package-management": "6.6.1",
     "@npmcli/arborist": "6.2.3",
     "@npmcli/run-script": "4.1.7",
     "@nrwl/devkit": ">=15.5.2 < 16",

--- a/packages/lerna/src/commands/add-caching/command.ts
+++ b/packages/lerna/src/commands/add-caching/command.ts
@@ -15,4 +15,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/packages/lerna/src/commands/repair/command.ts
+++ b/packages/lerna/src/commands/repair/command.ts
@@ -25,4 +25,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/packages/lerna/src/commands/watch/command.ts
+++ b/packages/lerna/src/commands/watch/command.ts
@@ -34,4 +34,4 @@ const command: CommandModule = {
   },
 };
 
-module.exports = command;
+export = command;

--- a/packages/lerna/src/index.ts
+++ b/packages/lerna/src/index.ts
@@ -1,30 +1,28 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-"use strict";
-
-// Legacy package management commands included by default until v7
-const { addCmd, bootstrapCmd, linkCmd } = require("@lerna/legacy-package-management");
+import log from "npmlog";
 
 // Currently external until the usage of LERNA_MODULE_DATA can be refactored
 const createCmd = require("@lerna/create/command");
 
 // Bundled
 import { lernaCLI } from "@lerna/core";
-import * as changedCmd from "@lerna/commands/changed/command";
-import * as cleanCmd from "@lerna/commands/clean/command";
-import * as diffCmd from "@lerna/commands/diff/command";
-import * as execCmd from "@lerna/commands/exec/command";
-import * as importCmd from "@lerna/commands/import/command";
-import * as infoCmd from "@lerna/commands/info/command";
-import * as initCmd from "@lerna/commands/init/command";
-import * as listCmd from "@lerna/commands/list/command";
-import * as publishCmd from "@lerna/commands/publish/command";
-import * as runCmd from "@lerna/commands/run/command";
-import * as versionCmd from "@lerna/commands/version/command";
+import changedCmd from "@lerna/commands/changed/command";
+import cleanCmd from "@lerna/commands/clean/command";
+import diffCmd from "@lerna/commands/diff/command";
+import execCmd from "@lerna/commands/exec/command";
+import importCmd from "@lerna/commands/import/command";
+import infoCmd from "@lerna/commands/info/command";
+import initCmd from "@lerna/commands/init/command";
+import listCmd from "@lerna/commands/list/command";
+import publishCmd from "@lerna/commands/publish/command";
+import runCmd from "@lerna/commands/run/command";
+import versionCmd from "@lerna/commands/version/command";
 
-import * as addCachingCmd from "./commands/add-caching/command";
-import * as repairCmd from "./commands/repair/command";
-import * as watchCmd from "./commands/watch/command";
+import addCachingCmd from "./commands/add-caching/command";
+import repairCmd from "./commands/repair/command";
+import watchCmd from "./commands/watch/command";
 
+// Evaluated at runtime to grab the current lerna version
 const pkg = require("../package.json");
 
 module.exports = function main(argv: NodeJS.Process["argv"]) {
@@ -32,10 +30,8 @@ module.exports = function main(argv: NodeJS.Process["argv"]) {
     lernaVersion: pkg.version,
   };
 
-  return lernaCLI()
-    .command(addCmd)
+  const cli = lernaCLI()
     .command(addCachingCmd)
-    .command(bootstrapCmd)
     .command(changedCmd)
     .command(cleanCmd)
     .command(createCmd)
@@ -44,12 +40,45 @@ module.exports = function main(argv: NodeJS.Process["argv"]) {
     .command(importCmd)
     .command(infoCmd)
     .command(initCmd)
-    .command(linkCmd)
     .command(listCmd)
     .command(publishCmd)
     .command(repairCmd)
     .command(runCmd)
     .command(watchCmd)
-    .command(versionCmd)
-    .parse(argv, context);
+    .command(versionCmd);
+
+  applyLegacyPackageManagementCommands(cli);
+
+  return cli.parse(argv, context);
 };
+
+/**
+ * Legacy package management commands not included by default in v7 and will no longer be maintained,
+ * but if the user wants to install the final version of them and use them we will respect that by
+ * applying them to the CLI.
+ *
+ * To provide clear feedback to folks trying to run those commands, we add "shell" commands that will
+ * explain the situation and exit without doing anything.
+ */
+function applyLegacyPackageManagementCommands(yargsInstance: ReturnType<typeof lernaCLI>) {
+  try {
+    const { addCmd, bootstrapCmd, linkCmd } = require("@lerna/legacy-package-management");
+    yargsInstance.command(addCmd).command(bootstrapCmd).command(linkCmd);
+  } catch {
+    ["add", "bootstrap", "link"].forEach((commandName) => {
+      yargsInstance.command({
+        command: commandName,
+        describe: `The "${commandName}" command was removed in v7, and is no longer maintained.`,
+        handler() {
+          log.error(
+            commandName,
+            `The "${commandName}" command was removed in v7, and is no longer maintained.`
+          );
+          // TODO: in v7 link to a specific guide
+          log.error(commandName, `Learn more about this change at https://lerna.js.org`);
+          process.exit(1);
+        },
+      });
+    });
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: We no longer include the bootstrap, add, and link commands by default. We strongly recommend using your package manager (npm, yarn, pnpm) for package management related concerns such as installing and linking dependencies.

If you want to temporarily continue to use those commands in v7 you can do so by installing the @lerna/legacy-package-management package at the same version as your lerna version.

There will not be any active work done on these commands and you should look to migrate as soon as possible, please check out https://lerna.js.org for further guidance.