### PR TITLE
fix: export package.json to allow for package resolution via resolve-pkg

### DIFF
--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -124,7 +124,8 @@
     "./commands/publish/lib/*": "./dist/commands/publish/lib/*.js",
     "./commands/version/lib/*": "./dist/commands/version/lib/*.js",
     "./migrations/**/*": "./dist/migrations/**/*",
-    "./commands/diff/lib/*": "./dist/commands/diff/lib/*.js"
+    "./commands/diff/lib/*": "./dist/commands/diff/lib/*.js",
+    "./package.json": "./package.json"
   },
   "gitHead": "02c534e3796150ac564c57aa5a248c7bdf7835ab"
 }


### PR DESCRIPTION
This change adds lerna's `package.json` file to its exports.

## Description
We currently have an error with `@commitlint/config-lerna-scopes` as reported in https://github.com/lerna/lerna/issues/3579. The error can be tracked down to `@commitlint/config-lerna-scopes` receiving `undefined` when executing `resolvePkg('lerna', {cwd})` in https://github.com/conventional-changelog/commitlint/blob/v17.6.1/%40commitlint/config-lerna-scopes/index.js#L57. This is apparently by design, see link in https://github.com/sindresorhus/resolve-pkg/issues/9#issuecomment-1433250154.

## Motivation and Context
This should fix https://github.com/lerna/lerna/issues/3579.

## How Has This Been Tested?
I used @gvdp's example repo linked in https://github.com/lerna/lerna/issues/3579 and edited lerna's package.json in there.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
