### PR TITLE
feat(version): add --from-remote option

### DIFF
--- a/e2e/version/src/from-remote.spec.ts
+++ b/e2e/version/src/from-remote.spec.ts
@@ -1,0 +1,273 @@
+import { Fixture, normalizeEnvironment } from "@lerna/e2e-utils";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeEnvironment(str);
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-version-from-remote", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-version-from-remote",
+      packageManager: "npm",
+      initializeGit: true,
+      runLernaInit: true,
+      installDependencies: true,
+    });
+
+    await fixture.lerna("create from-remote-1 -y");
+    await fixture.lerna("create from-remote-2 -y");
+    await fixture.lerna("create from-remote-3 -y");
+
+    await fixture.createInitialGitCommit();
+    await fixture.exec("git push origin test-main");
+  });
+
+  afterEach(() => fixture.destroy());
+
+  it("should use registry version as base for version bump", async () => {
+    await fixture.updatePackageVersion({ packagePath: "packages/from-remote-1", newVersion: "1.2.4" });
+    await fixture.updatePackageVersion({ packagePath: "packages/from-remote-2", newVersion: "1.2.4" });
+    await fixture.updatePackageVersion({ packagePath: "packages/from-remote-3", newVersion: "1.2.4" });
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: set version to 1.2.4'");
+
+    // publish packages at version 1.2.4, then reset the local changes.
+    // notice that lerna.json's version was never set to 1.2.4, so it remains at the default from lerna init.
+    await fixture.lerna("publish from-package -y --registry http://localhost:4872");
+    await fixture.exec("git reset --hard HEAD~1");
+
+    // lerna should ignore lerna.json and pick version 1.3.0 since it is the next minor version after 1.2.4
+    const result = await fixture.lerna(
+      "version minor --from-remote from-remote-1 --registry http://localhost:4872 -y",
+      { allowNetworkRequests: true }
+    );
+
+    // clean up published packages
+    await fixture.exec(`npm unpublish --force from-remote-1 --registry=http://localhost:4872`);
+    await fixture.exec(`npm unpublish --force from-remote-2 --registry=http://localhost:4872`);
+    await fixture.exec(`npm unpublish --force from-remote-3 --registry=http://localhost:4872`);
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Assuming all packages changed
+      lerna info current version 1.2.4
+
+      Changes:
+       - from-remote-1: 0.0.0 => 1.3.0
+       - from-remote-2: 0.0.0 => 1.3.0
+       - from-remote-3: 0.0.0 => 1.3.0
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
+
+  it("should respect .npmrc", async () => {
+    // create .npmrc with registry instead of explicitly passing it to the version command
+    await fixture.exec('echo "registry=http://localhost:4872" > .npmrc');
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: add .npmrc with registry'");
+
+    await fixture.updatePackageVersion({ packagePath: "packages/from-remote-1", newVersion: "1.2.4" });
+    await fixture.updatePackageVersion({ packagePath: "packages/from-remote-2", newVersion: "1.2.4" });
+    await fixture.updatePackageVersion({ packagePath: "packages/from-remote-3", newVersion: "1.2.4" });
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: set version to 1.2.4'");
+
+    // publish packages at version 1.2.4, then reset the local changes.
+    // notice that lerna.json's version was never set to 1.2.4, so it remains at the default from lerna init.
+    await fixture.lerna("publish from-package -y");
+    await fixture.exec("git reset --hard HEAD~1");
+
+    // lerna should ignore lerna.json and pick version 1.3.0 since it is the next minor version after 1.2.4
+    const result = await fixture.lerna("version minor --from-remote from-remote-1 -y", {
+      allowNetworkRequests: true,
+    });
+
+    // clean up published packages
+    await fixture.exec(`npm unpublish --force from-remote-1`);
+    await fixture.exec(`npm unpublish --force from-remote-2`);
+    await fixture.exec(`npm unpublish --force from-remote-3`);
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Assuming all packages changed
+      lerna info current version 1.2.4
+
+      Changes:
+       - from-remote-1: 0.0.0 => 1.3.0
+       - from-remote-2: 0.0.0 => 1.3.0
+       - from-remote-3: 0.0.0 => 1.3.0
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
+
+  it("throws an error when --from-remote is used with independent versioning mode", async () => {
+    await fixture.updateJson("lerna.json", (json) => ({ ...json, version: "independent" }));
+
+    const result = await fixture.lerna("version minor --from-remote from-remote-1 -y", {
+      allowNetworkRequests: true,
+      silenceError: true,
+    });
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info versioning independent
+      lerna ERR! EINDEPENDENT The --from-remote option is not supported in independent mode.
+
+    `);
+  });
+
+  it("throws an error when --from-remote is passed without an argument", async () => {
+    const result = await fixture.lerna("version minor --from-remote -y", {
+      allowNetworkRequests: true,
+      silenceError: true,
+    });
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info current version 0.0.0
+      lerna ERR! EFROMREMOTE A package name to look up must be provided to the --from-remote option.
+
+    `);
+  });
+
+  it("throws an error when version is not found for specified package", async () => {
+    const result = await fixture.lerna(
+      "version minor --from-remote from-remote-1 --registry http://localhost:4872 -y",
+      { allowNetworkRequests: true, silenceError: true }
+    );
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Assuming all packages changed
+      lerna ERR! ENPMVIEW Could not get current version of from-remote-1 via \`npm view\`.
+      lerna ERR! ENPMVIEW  Please verify that \`npm view from-remote-1\` completes successfully from the root of the workspace.
+
+    `);
+  });
+
+  it("should use specified dist-tag for lookup", async () => {
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-1",
+      newVersion: "1.2.4",
+    });
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-2",
+      newVersion: "1.2.4",
+    });
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-3",
+      newVersion: "1.2.4",
+    });
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: set version to 1.2.4'");
+
+    // publish packages at version 1.2.4 to the "latest" tag
+    await fixture.lerna("publish from-package -y --registry http://localhost:4872");
+
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-1",
+      newVersion: "1.2.5-alpha.0",
+    });
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-2",
+      newVersion: "1.2.5-alpha.0",
+    });
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-3",
+      newVersion: "1.2.5-alpha.0",
+    });
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: set version to 1.2.5-alpha.0'");
+
+    // publish packages at version 1.2.5-alpha.0 to the "next" tag
+    await fixture.lerna("publish from-package --dist-tag next -y --registry http://localhost:4872");
+    await fixture.exec("git reset --hard HEAD~2");
+
+    // at this point, `npm view from-remote-1 dist-tags --json` will return { "latest": "1.2.4", "next": "1.2.5-alpha.0" }
+
+    const result = await fixture.lerna(
+      "version prerelease --from-remote from-remote-1 --dist-tag next --registry http://localhost:4872 -y",
+      { allowNetworkRequests: true }
+    );
+
+    // clean up published packages
+    await fixture.exec(`npm unpublish --force from-remote-1 --registry=http://localhost:4872`);
+    await fixture.exec(`npm unpublish --force from-remote-2 --registry=http://localhost:4872`);
+    await fixture.exec(`npm unpublish --force from-remote-3 --registry=http://localhost:4872`);
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Assuming all packages changed
+      lerna info current version 1.2.5-alpha.0
+
+      Changes:
+       - from-remote-1: 0.0.0 => 1.2.5-alpha.1
+       - from-remote-2: 0.0.0 => 1.2.5-alpha.1
+       - from-remote-3: 0.0.0 => 1.2.5-alpha.1
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
+
+  it("should error if specified dist-tag is not found on the npm view response", async () => {
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-1",
+      newVersion: "1.2.4",
+    });
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-2",
+      newVersion: "1.2.4",
+    });
+    await fixture.updatePackageVersion({
+      packagePath: "packages/from-remote-3",
+      newVersion: "1.2.4",
+    });
+    await fixture.exec("git add .");
+    await fixture.exec("git commit -m 'chore: set version to 1.2.4'");
+
+    // publish packages at version 1.2.4 to the "latest" tag
+    await fixture.lerna("publish from-package -y --registry http://localhost:4872");
+    await fixture.exec("git reset --hard HEAD~1");
+
+    // at this point, `npm view from-remote-1 dist-tags --json` will return { "latest": "1.2.4" }
+
+    const result = await fixture.lerna(
+      "version prerelease --from-remote from-remote-1 --dist-tag next --registry http://localhost:4872 -y",
+      { allowNetworkRequests: true, silenceError: true }
+    );
+
+    // clean up published packages
+    await fixture.exec(`npm unpublish --force from-remote-1 --registry=http://localhost:4872`);
+    await fixture.exec(`npm unpublish --force from-remote-2 --registry=http://localhost:4872`);
+    await fixture.exec(`npm unpublish --force from-remote-3 --registry=http://localhost:4872`);
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Assuming all packages changed
+      lerna ERR! ENODISTTAG No version found for from-remote-1@next.
+      lerna ERR! ENODISTTAG  If you are trying to version based on a different tag than 'latest', ensure that it is provided with the --distTag option.
+
+    `);
+  });
+});

--- a/libs/commands/publish/src/command.ts
+++ b/libs/commands/publish/src/command.ts
@@ -127,6 +127,11 @@ const command: CommandModule = {
           "Include specified private packages when publishing by temporarily removing the private property from the package manifest. This should only be used for testing private packages that will become public. Private packages should not usually be published. See the npm docs for details (https://docs.npmjs.com/cli/v9/configuring-npm/package-json#private).",
         type: "array",
       },
+      "from-remote": {
+        describe:
+          "Set the base version from that of the given package in the remote registry instead of the version in lerna.json",
+        type: "string",
+      },
     };
 
     composeVersionOptions(yargs);

--- a/libs/commands/version/README.md
+++ b/libs/commands/version/README.md
@@ -518,7 +518,7 @@ lerna publish from-git --tag-version-prefix=''
 
 This option allows Lerna to use `npm view <package>` to pick a version to use as the base instead of the version listed in `lerna.json`. This option cannot be used with independent versioning mode.
 
-A package name must be provided for Lerna to use to in the lookup. 
+A package name must be provided for Lerna to use to in the lookup.
 
 Examples:
 

--- a/libs/commands/version/README.md
+++ b/libs/commands/version/README.md
@@ -79,6 +79,9 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--sign-git-tag`](#--sign-git-tag)
     - [`--force-git-tag`](#--force-git-tag)
     - [`--tag-version-prefix`](#--tag-version-prefix)
+    - [`--from-remote`](#--from-remote)
+    - [`--dist-tag`](#--dist-tag)
+    - [`--registry`](#--registry)
     - [`--yes`](#--yes)
   - [Deprecated Options](#deprecated-options)
     - [`--cd-version`](#--cd-version)
@@ -510,6 +513,37 @@ lerna version --tag-version-prefix=''
 # on ci
 lerna publish from-git --tag-version-prefix=''
 ```
+
+### `--from-remote`
+
+This option allows Lerna to use `npm view <package>` to pick a version to use as the base instead of the version listed in `lerna.json`. This option cannot be used with independent versioning mode.
+
+A package name must be provided for Lerna to use to in the lookup. 
+
+Examples:
+
+```bash
+# use the version of test-package to pick the next version
+lerna version --from-remote test-package
+
+# use the version of test-package@next to pick the next version
+lerna version --from-remote test-package --dist-tag next
+
+# use the version of test-package on a specific registry to pick the next version
+lerna version --from-remote test-package --registry https://my-npm-registry.com
+```
+
+### `--dist-tag`
+
+When used with `--from-remote`, specifies the dist tag to use when picking a version from the the remote registry.
+
+See [`--from-remote`](#--from-remote).
+
+### `--registry`
+
+When used with `--from-remote`, specifies the registry to use when picking a version from the the remote registry.
+
+See [`--from-remote`](#--from-remote).
 
 ### `--yes`
 

--- a/libs/commands/version/src/command.ts
+++ b/libs/commands/version/src/command.ts
@@ -204,6 +204,11 @@ const command: CommandModule = {
         describe: "Additional arguments to pass to the npm client when performing 'npm install'.",
         type: "array",
       },
+      "from-remote": {
+        describe:
+          "Set the base version from that of the given package in the remote registry instead of the version in lerna.json",
+        type: "string",
+      },
       y: {
         describe: "Skip all confirmation prompts.",
         alias: "yes",

--- a/libs/commands/version/src/command.ts
+++ b/libs/commands/version/src/command.ts
@@ -209,6 +209,16 @@ const command: CommandModule = {
           "Set the base version from that of the given package in the remote registry instead of the version in lerna.json",
         type: "string",
       },
+      "dist-tag": {
+        describe:
+          "For use with --from-remote. Use the specified dist-tag when looking up the package specified by --from-remote.",
+        type: "string",
+      },
+      registry: {
+        describe:
+          "For use with --from-remote. Use the specified registry for looking up the package specified by --from-remote.",
+        type: "string",
+      },
       y: {
         describe: "Skip all confirmation prompts.",
         alias: "yes",

--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -84,6 +84,7 @@ interface VersionCommandConfigOptions extends CommandConfigOptions {
   rejectCycles?: boolean;
   fromRemote?: string;
   distTag?: string;
+  registry?: string;
 }
 
 class VersionCommand extends Command {
@@ -354,7 +355,7 @@ class VersionCommand extends Command {
       const packageName = this.options.fromRemote;
       const distTag = this.options.distTag ? this.options.distTag : "latest";
 
-      this.baseVersion = await getCurrentVersion(packageName, distTag);
+      this.baseVersion = await getCurrentVersion(packageName, distTag, this.options.registry);
       this.logger.info("current version", this.baseVersion);
       this.logger.silly("version", "Current version of %s@%s is %s", packageName, distTag, this.baseVersion);
     } else {

--- a/libs/commands/version/src/lib/get-current-version.spec.ts
+++ b/libs/commands/version/src/lib/get-current-version.spec.ts
@@ -1,0 +1,60 @@
+import _execa from "execa";
+import { isEqual } from "lodash";
+import { getCurrentVersion } from "./get-current-version";
+
+let mockNpmViewResult: string | undefined = undefined;
+let mockNpmViewError: Error | undefined = undefined;
+
+jest.mock("execa");
+
+const packageName = "my-package";
+
+const execaMockFn = (file: string, args: string[]) => {
+  if (file !== "npm" || !isEqual(args, ["view", packageName, "dist-tags", "--json"])) {
+    throw new Error();
+  }
+
+  return mockNpmViewError ? Promise.reject(mockNpmViewError) : Promise.resolve({ stdout: mockNpmViewResult });
+};
+
+const execa = _execa as jest.MockedFunction<typeof _execa>;
+execa.mockImplementation(execaMockFn as typeof _execa);
+
+describe("getCurrentVersion", () => {
+  afterEach(() => {
+    mockNpmViewError = undefined;
+    mockNpmViewResult = undefined;
+  });
+
+  it("should return current version of package@latest", async () => {
+    mockNpmViewResult = '{ "latest": "1.0.0" }';
+    const result = await getCurrentVersion(packageName, "latest");
+
+    expect(result).toEqual("1.0.0");
+  });
+
+  it("should return current version of package@beta", async () => {
+    mockNpmViewResult = '{ "latest": "1.0.0", "beta": "1.0.1-beta.0" }';
+    const result = await getCurrentVersion(packageName, "beta");
+
+    expect(result).toEqual("1.0.1-beta.0");
+  });
+
+  it("should error if no version is found for a given distTag", async () => {
+    mockNpmViewResult = '{ "latest": "1.0.0" }';
+
+    await expect(getCurrentVersion(packageName, "foo")).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "No version found for my-package@foo.
+       If you are trying to version based on a different tag than 'latest', ensure that it is provided with the --distTag option."
+    `);
+  });
+
+  it("should error if `npm view` command fails", async () => {
+    mockNpmViewError = new Error("ERROR");
+
+    await expect(getCurrentVersion(packageName, "latest")).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "Could not get current version of my-package via \`npm view\`.
+       Please verify that \`npm view my-package\` completes successfully from the root of the workspace."
+    `);
+  });
+});

--- a/libs/commands/version/src/lib/get-current-version.ts
+++ b/libs/commands/version/src/lib/get-current-version.ts
@@ -1,0 +1,30 @@
+import { ValidationError } from "@lerna/core";
+import execa, { ExecaReturnValue } from "execa";
+
+interface DistTagsResponse {
+  [key: string]: string;
+}
+
+export async function getCurrentVersion(packageName: string, distTag: string): Promise<string> {
+  let result: ExecaReturnValue<string>;
+  try {
+    result = await execa("npm", ["view", packageName, "dist-tags", "--json"]);
+  } catch (e) {
+    throw new ValidationError(
+      "ENPMVIEW",
+      `Could not get current version of ${packageName} via \`npm view\`.\n Please verify that \`npm view ${packageName}\` completes successfully from the root of the workspace.`
+    );
+  }
+
+  const distTagsResponse: DistTagsResponse = JSON.parse(result.stdout);
+  const version: string | undefined = distTagsResponse[distTag];
+
+  if (!version) {
+    throw new ValidationError(
+      "ENODISTTAG",
+      `No version found for ${packageName}@${distTag}.\n If you are trying to version based on a different tag than 'latest', ensure that it is provided with the --distTag option.`
+    );
+  }
+
+  return version;
+}

--- a/libs/commands/version/src/lib/get-current-version.ts
+++ b/libs/commands/version/src/lib/get-current-version.ts
@@ -5,10 +5,19 @@ interface DistTagsResponse {
   [key: string]: string;
 }
 
-export async function getCurrentVersion(packageName: string, distTag: string): Promise<string> {
+export async function getCurrentVersion(
+  packageName: string,
+  distTag: string,
+  registry?: string
+): Promise<string> {
+  const args = ["view", packageName, "dist-tags", "--json"];
+  if (registry) {
+    args.push("--registry", registry);
+  }
+
   let result: ExecaReturnValue<string>;
   try {
-    result = await execa("npm", ["view", packageName, "dist-tags", "--json"]);
+    result = await execa("npm", args);
   } catch (e) {
     throw new ValidationError(
       "ENPMVIEW",

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -3,21 +3,22 @@ export { addDependents } from "./lib/add-dependents";
 export { checkWorkingTree, throwIfUncommitted } from "./lib/check-working-tree";
 export * from "./lib/cli";
 export {
-  collectProjects,
-  collectProjectUpdates,
   ProjectCollectorOptions,
   ProjectUpdateCollectorOptions,
+  collectProjectUpdates,
+  collectProjects,
 } from "./lib/collect-updates";
 export { Command } from "./lib/command";
 export { applyBuildMetadata, recommendVersion, updateChangelog } from "./lib/conventional-commits";
 export { describeRef, describeRefSync } from "./lib/describe-ref";
-export { filterOptions, FilterOptions } from "./lib/filter-options";
+export { FilterOptions, filterOptions } from "./lib/filter-options";
 export { filterProjects } from "./lib/filter-projects";
+export { getNpmExecOpts } from "./lib/get-npm-exec-opts";
 export { getPackageManifestPath } from "./lib/get-package-manifest-path";
 export * from "./lib/get-packages-for-option";
 export { hasNpmVersion } from "./lib/has-npm-version";
 export { listableFormatProjects } from "./lib/listable-format-projects";
-export { listableOptions, ListableOptions } from "./lib/listable-options";
+export { ListableOptions, listableOptions } from "./lib/listable-options";
 export { logPacked } from "./lib/log-packed";
 export { Conf } from "./lib/npm-conf/conf";
 export { npmInstall, npmInstallDependencies } from "./lib/npm-install";
@@ -25,17 +26,17 @@ export { npmPublish } from "./lib/npm-publish";
 export { npmRunScript, npmRunScriptStreaming } from "./lib/npm-run-script";
 export { getOneTimePassword } from "./lib/otplease";
 export { output } from "./lib/output";
-export { packDirectory, Packed } from "./lib/pack-directory";
+export { Packed, packDirectory } from "./lib/pack-directory";
 export { ExtendedNpaResult, Package, RawManifest } from "./lib/package";
 export { prereleaseIdFromVersion } from "./lib/prerelease-id-from-version";
-export { generateProfileOutputPath, Profiler } from "./lib/profiler";
-export { CommandConfigOptions, getPackages, Project } from "./lib/project";
+export { Profiler, generateProfileOutputPath } from "./lib/profiler";
+export { CommandConfigOptions, Project, getPackages } from "./lib/project";
 export {
-  getPackage,
-  isExternalNpmDependency,
   ProjectGraphProjectNodeWithPackage,
   ProjectGraphWithPackages,
   ProjectGraphWorkspacePackageDependency,
+  getPackage,
+  isExternalNpmDependency,
 } from "./lib/project-graph-with-packages";
 export { promptConfirmation, promptSelectOne, promptTextInput } from "./lib/prompt";
 export { pulseTillDone } from "./lib/pulse-till-done";

--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -226,34 +226,6 @@
             },
             "yes": {
               "$ref": "#/$defs/globals/yes"
-            },
-
-            "scope": {
-              "$ref": "#/$defs/filters/scope"
-            },
-            "ignore": {
-              "$ref": "#/$defs/filters/ignore"
-            },
-            "private": {
-              "$ref": "#/$defs/filters/private"
-            },
-            "since": {
-              "$ref": "#/$defs/filters/since"
-            },
-            "excludeDependents": {
-              "$ref": "#/$defs/filters/excludeDependents"
-            },
-            "includeDependents": {
-              "$ref": "#/$defs/filters/includeDependents"
-            },
-            "includeDependencies": {
-              "$ref": "#/$defs/filters/includeDependencies"
-            },
-            "includeMergedTags": {
-              "$ref": "#/$defs/filters/includeMergedTags"
-            },
-            "continueIfNoMatch": {
-              "$ref": "#/$defs/filters/continueIfNoMatch"
             }
           }
         },
@@ -373,34 +345,6 @@
             },
             "yes": {
               "$ref": "#/$defs/globals/yes"
-            },
-
-            "scope": {
-              "$ref": "#/$defs/filters/scope"
-            },
-            "ignore": {
-              "$ref": "#/$defs/filters/ignore"
-            },
-            "private": {
-              "$ref": "#/$defs/filters/private"
-            },
-            "since": {
-              "$ref": "#/$defs/filters/since"
-            },
-            "excludeDependents": {
-              "$ref": "#/$defs/filters/excludeDependents"
-            },
-            "includeDependents": {
-              "$ref": "#/$defs/filters/includeDependents"
-            },
-            "includeDependencies": {
-              "$ref": "#/$defs/filters/includeDependencies"
-            },
-            "includeMergedTags": {
-              "$ref": "#/$defs/filters/includeMergedTags"
-            },
-            "continueIfNoMatch": {
-              "$ref": "#/$defs/filters/continueIfNoMatch"
             }
           }
         },
@@ -435,34 +379,6 @@
             },
             "yes": {
               "$ref": "#/$defs/globals/yes"
-            },
-
-            "scope": {
-              "$ref": "#/$defs/filters/scope"
-            },
-            "ignore": {
-              "$ref": "#/$defs/filters/ignore"
-            },
-            "private": {
-              "$ref": "#/$defs/filters/private"
-            },
-            "since": {
-              "$ref": "#/$defs/filters/since"
-            },
-            "excludeDependents": {
-              "$ref": "#/$defs/filters/excludeDependents"
-            },
-            "includeDependents": {
-              "$ref": "#/$defs/filters/includeDependents"
-            },
-            "includeDependencies": {
-              "$ref": "#/$defs/filters/includeDependencies"
-            },
-            "includeMergedTags": {
-              "$ref": "#/$defs/filters/includeMergedTags"
-            },
-            "continueIfNoMatch": {
-              "$ref": "#/$defs/filters/continueIfNoMatch"
             }
           }
         },
@@ -580,34 +496,6 @@
             },
             "yes": {
               "$ref": "#/$defs/globals/yes"
-            },
-
-            "scope": {
-              "$ref": "#/$defs/filters/scope"
-            },
-            "ignore": {
-              "$ref": "#/$defs/filters/ignore"
-            },
-            "private": {
-              "$ref": "#/$defs/filters/private"
-            },
-            "since": {
-              "$ref": "#/$defs/filters/since"
-            },
-            "excludeDependents": {
-              "$ref": "#/$defs/filters/excludeDependents"
-            },
-            "includeDependents": {
-              "$ref": "#/$defs/filters/includeDependents"
-            },
-            "includeDependencies": {
-              "$ref": "#/$defs/filters/includeDependencies"
-            },
-            "includeMergedTags": {
-              "$ref": "#/$defs/filters/includeMergedTags"
-            },
-            "continueIfNoMatch": {
-              "$ref": "#/$defs/filters/continueIfNoMatch"
             }
           }
         },
@@ -801,6 +689,9 @@
             "includePrivate": {
               "$ref": "#/$defs/commandOptions/publish/includePrivate"
             },
+            "fromRemote": {
+              "$ref": "#/$defs/commandOptions/publish/fromRemote"
+            },
 
             "npmClient": {
               "$ref": "#/$defs/globals/npmClient"
@@ -825,37 +716,6 @@
             },
             "yes": {
               "$ref": "#/$defs/globals/yes"
-            },
-
-            "scope": {
-              "$ref": "#/$defs/filters/scope"
-            },
-            "ignore": {
-              "$ref": "#/$defs/filters/ignore"
-            },
-            "private": {
-              "$ref": "#/$defs/filters/private"
-            },
-            "since": {
-              "$ref": "#/$defs/filters/since"
-            },
-            "excludeDependents": {
-              "$ref": "#/$defs/filters/excludeDependents"
-            },
-            "includeDependents": {
-              "$ref": "#/$defs/filters/includeDependents"
-            },
-            "includeDependencies": {
-              "$ref": "#/$defs/filters/includeDependencies"
-            },
-            "includeMergedTags": {
-              "$ref": "#/$defs/filters/includeMergedTags"
-            },
-            "continueIfNoMatch": {
-              "$ref": "#/$defs/filters/continueIfNoMatch"
-            },
-            "summaryFile": {
-              "$ref": "#/$defs/filters/summaryFile"
             }
           }
         },
@@ -1024,6 +884,15 @@
             "tagVersionPrefix": {
               "$ref": "#/$defs/commandOptions/version/tagVersionPrefix"
             },
+            "fromRemote": {
+              "$ref": "#/$defs/commandOptions/version/fromRemote"
+            },
+            "distTag": {
+              "$ref": "#/$defs/commandOptions/version/distTag"
+            },
+            "registry": {
+              "$ref": "#/$defs/commandOptions/version/registry"
+            },
 
             "npmClient": {
               "$ref": "#/$defs/globals/npmClient"
@@ -1051,34 +920,6 @@
             },
             "yes": {
               "$ref": "#/$defs/globals/yes"
-            },
-
-            "scope": {
-              "$ref": "#/$defs/filters/scope"
-            },
-            "ignore": {
-              "$ref": "#/$defs/filters/ignore"
-            },
-            "private": {
-              "$ref": "#/$defs/filters/private"
-            },
-            "since": {
-              "$ref": "#/$defs/filters/since"
-            },
-            "excludeDependents": {
-              "$ref": "#/$defs/filters/excludeDependents"
-            },
-            "includeDependents": {
-              "$ref": "#/$defs/filters/includeDependents"
-            },
-            "includeDependencies": {
-              "$ref": "#/$defs/filters/includeDependencies"
-            },
-            "includeMergedTags": {
-              "$ref": "#/$defs/filters/includeMergedTags"
-            },
-            "continueIfNoMatch": {
-              "$ref": "#/$defs/filters/continueIfNoMatch"
             }
           }
         },
@@ -1603,6 +1444,10 @@
             "type": "string"
           },
           "description": "During `lerna publish`, include specified private packages when publishing by temporarily removing the private property from the package manifest. This should only be used for testing private packages that will become public. The value \"*\" will include all private packages."
+        },
+        "fromRemote": {
+          "type": "string",
+          "description": "When versioning packages with `lerna publish`, set the base version from that of the given package in the remote registry instead of the version in lerna.json. Has no effect when used with the positional arguments 'from-git' or 'from-package'."
         }
       },
       "run": {
@@ -1704,6 +1549,18 @@
         "tagVersionPrefix": {
           "type": "string",
           "description": "During `lerna version`, customize the tag prefix. To remove entirely, pass an empty string."
+        },
+        "fromRemote": {
+          "type": "string",
+          "description": "During `lerna version`, set the base version from that of the given package in the remote registry instead of the version in lerna.json."
+        },
+        "distTag": {
+          "type": "string",
+          "description": "For use with 'fromRemote' for `lerna version`. Use the specified dist-tag when looking up the package specified by 'fromRemote'."
+        },
+        "registry": {
+          "type": "string",
+          "description": "For use with 'fromRemote' for `lerna version`. Use the specified registry for looking up the package specified by 'fromRemote'."
         }
       },
       "shared": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a `--from-remote` option to allow Lerna to pick a new version based on the result of `npm view` instead of what is in `lerna.json`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is an initial step towards supporting workflows that do not track their versions in package.json files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and covered with e2e tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
