### PR TITLE
feat(publish): support custom directory per-package

### DIFF
--- a/e2e/publish/src/custom-publish-directories.spec.ts
+++ b/e2e/publish/src/custom-publish-directories.spec.ts
@@ -13,7 +13,8 @@ expect.addSnapshotSerializer({
       .replaceAll(/size:\s*\d*\s?B/g, "size: XXXB")
       .replaceAll(/\d*\.\d*\s?kB/g, "XXX.XXX kb")
       .replaceAll(/session\s\w{16}/g, "session XXXXXXXX")
-      .replaceAll(/"vXX\.XX\.XX-0-g[a-f0-9]{7}"/g, '"vXX.XX.XX-0-gXXXXXXXX"');
+      .replaceAll(/"vXX\.XX\.XX-0-g[a-f0-9]{7}"/g, '"vXX.XX.XX-0-gXXXXXXXX"')
+      .replaceAll(/node@v\d+\.\d+\.\d+\+\w+ \(\w+\)/g, "<user agent>");
   },
   test(val: string) {
     return val != null && typeof val === "string";
@@ -108,7 +109,7 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna verb packageConfigs Resolving packages based on package.json "workspaces" configuration.
         lerna verb rootPath /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace
         lerna verb session XXXXXXXX
-        lerna verb user-agent lerna/999.9.9-e2e.0/node@v18.15.0+arm64 (darwin)
+        lerna verb user-agent lerna/999.9.9-e2e.0/<user agent>
         lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
 
         Found 3 packages to publish:

--- a/e2e/publish/src/custom-publish-directories.spec.ts
+++ b/e2e/publish/src/custom-publish-directories.spec.ts
@@ -69,6 +69,8 @@ describe("lerna-publish-custom-publish-directories", () => {
         },
       }));
 
+      await fixture.lerna("create package-3 -y");
+
       await ensureDir(fixture.getWorkspacePath("packages/package-2/docs"));
       await writeFile(fixture.getWorkspacePath("packages/package-2/docs/doc-1.md"), "doc 1");
       await writeFile(fixture.getWorkspacePath("packages/package-2/docs/doc-2.md"), "doc 2");
@@ -97,6 +99,7 @@ describe("lerna-publish-custom-publish-directories", () => {
       );
       await fixture.exec(`npm unpublish --force package-1@${version} --registry=http://localhost:4872`);
       await fixture.exec(`npm unpublish --force package-2@${version} --registry=http://localhost:4872`);
+      await fixture.exec(`npm unpublish --force package-3@${version} --registry=http://localhost:4872`);
 
       const replaceVersion = (str: string) => str.replaceAll(version, "XX.XX.XX");
 
@@ -108,15 +111,16 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna verb user-agent lerna/999.9.9-e2e.0/node@v18.15.0+arm64 (darwin)
         lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
 
-        Found 2 packages to publish:
+        Found 3 packages to publish:
          - package-1 => XX.XX.XX
          - package-2 => XX.XX.XX
+         - package-3 => XX.XX.XX
 
         lerna info auto-confirmed 
         lerna info publish Publishing packages to npm...
         lerna notice Skipping all user and access validation due to third-party registry
         lerna notice Make sure you're authenticated properly ¯\\_(ツ)_/¯
-        lerna WARN ENOLICENSE Packages package-1 and package-2 are missing a license.
+        lerna WARN ENOLICENSE Packages package-1, package-2, and package-3 are missing a license.
         lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
         lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
         lerna verb getCurrentSHA {FULL_COMMIT_SHA}
@@ -138,14 +142,16 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/CONTRIBUTING.md to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-2/CONTRIBUTING.md
         lerna verb pack-directory dist/packages/package-2
         lerna verb packed dist/packages/package-2
+        lerna verb pack-directory packages/package-3
+        lerna verb packed packages/package-3
         lerna verb publish package-1
         lerna success published package-1 XX.XX.XX
         lerna notice 
         lerna notice 📦  package-1@XX.XX.XX
         lerna notice === Tarball Contents === 
-        lerna notice 99B   lib/main.js 
-        lerna notice 1.0kXXXB package.json
-        lerna notice 119B  README.md   
+        lerna notice 99B  lib/main.js 
+        lerna notice XXXB package.json
+        lerna notice 119B README.md   
         lerna notice === Tarball Details === 
         lerna notice name:          package-1                               
         lerna notice version:       XX.XX.XX                                
@@ -162,7 +168,7 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna notice 📦  package-2@XX.XX.XX
         lerna notice === Tarball Contents === 
         lerna notice 99B   lib/main.js 
-        lerna notice 1.3kXXXB package.json
+        lerna notice 1.2kXXXB package.json
         lerna notice === Tarball Details === 
         lerna notice name:          package-2                               
         lerna notice version:       XX.XX.XX                                
@@ -173,10 +179,29 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         lerna notice total files:   2                                       
         lerna notice 
+        lerna verb publish package-3
+        lerna success published package-3 XX.XX.XX
+        lerna notice 
+        lerna notice 📦  package-3@XX.XX.XX
+        lerna notice === Tarball Contents === 
+        lerna notice 99B  lib/package-3.js
+        lerna notice XXXB package.json    
+        lerna notice 119B README.md       
+        lerna notice === Tarball Details === 
+        lerna notice name:          package-3                               
+        lerna notice version:       XX.XX.XX                                
+        lerna notice filename:      package-3-XX.XX.XX.tgz                  
+        lerna notice package size: XXXB                                   
+        lerna notice unpacked size: XXX.XXX kb                                  
+        lerna notice shasum:        {FULL_COMMIT_SHA}
+        lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        lerna notice total files:   3                                       
+        lerna notice 
         Successfully published:
          - package-1@XX.XX.XX
          - package-2@XX.XX.XX
-        lerna success published 2 packages
+         - package-3@XX.XX.XX
+        lerna success published 3 packages
 
       `);
 

--- a/e2e/publish/src/custom-publish-directories.spec.ts
+++ b/e2e/publish/src/custom-publish-directories.spec.ts
@@ -1,0 +1,209 @@
+import { Fixture, normalizeCommitSHAs, normalizeEnvironment } from "@lerna/e2e-utils";
+import { ensureDir, writeFile } from "fs-extra";
+import globby from "globby";
+
+const randomInt = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+const randomVersion = () => `${randomInt(10, 89)}.${randomInt(10, 89)}.${randomInt(10, 89)}`;
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommitSHAs(normalizeEnvironment(str))
+      .replaceAll(/integrity:\s*.*/g, "integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+      .replaceAll(/\d*B package\.json/g, "XXXB package.json")
+      .replaceAll(/size:\s*\d*\s?B/g, "size: XXXB")
+      .replaceAll(/\d*\.\d*\s?kB/g, "XXX.XXX kb")
+      .replaceAll(/session\s\w{16}/g, "session XXXXXXXX")
+      .replaceAll(/"vXX\.XX\.XX-0-g[a-f0-9]{7}"/g, '"vXX.XX.XX-0-gXXXXXXXX"');
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-publish-custom-publish-directories", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-publish-custom-publish-directories",
+      packageManager: "npm",
+      initializeGit: true,
+      lernaInit: true,
+      installDependencies: true,
+    });
+  });
+  afterEach(() => fixture.destroy());
+
+  describe("from-git", () => {
+    it("should publish to the remote registry, including appropriate assets", async () => {
+      await fixture.lerna("create package-1 -y");
+      await fixture.updateJson("packages/package-1/package.json", (pkg) => ({
+        ...pkg,
+        main: "main.js",
+        scripts: { build: "cp ./lib/package-1.js ../../dist/packages/package-1/lib/main.js" },
+        lerna: { publish: { directory: "../../dist/packages/package-1" } },
+      }));
+
+      await fixture.lerna("create package-2 -y");
+      await fixture.updateJson("packages/package-2/package.json", (pkg) => ({
+        ...pkg,
+        main: "main.js",
+        scripts: { build: "cp ./lib/package-2.js ../../dist/packages/package-2/lib/main.js" },
+        lerna: {
+          publish: {
+            directory: "../../dist/packages/package-2",
+            assets: [
+              "package.json",
+              "docs/*.md",
+              {
+                from: "static/images/*",
+                to: "assets",
+              },
+              {
+                from: "../../CONTRIBUTING.md",
+                to: "./",
+              },
+            ],
+          },
+        },
+      }));
+
+      await ensureDir(fixture.getWorkspacePath("packages/package-2/docs"));
+      await writeFile(fixture.getWorkspacePath("packages/package-2/docs/doc-1.md"), "doc 1");
+      await writeFile(fixture.getWorkspacePath("packages/package-2/docs/doc-2.md"), "doc 2");
+      await writeFile(fixture.getWorkspacePath("packages/package-2/docs/not-a-doc.txt"), "not a doc");
+      await ensureDir(fixture.getWorkspacePath("packages/package-2/static/images"));
+      await writeFile(fixture.getWorkspacePath("packages/package-2/static/images/image-1.png"), "image 1");
+      await writeFile(fixture.getWorkspacePath("packages/package-2/static/images/image-2.png"), "image 2");
+      await writeFile(fixture.getWorkspacePath("CONTRIBUTING.md"), "Contributing guide");
+
+      await fixture.exec("git checkout -b test-main");
+      await writeFile(fixture.getWorkspacePath(".gitignore"), "node_modules\n.DS_Store\ndist");
+      await fixture.exec("git add .gitignore");
+      await fixture.exec("git add .");
+      await fixture.exec('git commit -m "initial-commit"');
+      await fixture.exec("git push origin test-main");
+
+      await ensureDir(fixture.getWorkspacePath("dist/packages/package-1/lib"));
+      await ensureDir(fixture.getWorkspacePath("dist/packages/package-2/lib"));
+      await fixture.lerna("run build");
+
+      const version = randomVersion();
+      await fixture.lerna(`version ${version} -y`);
+
+      const output = await fixture.lerna(
+        "publish from-git --registry=http://localhost:4872 --loglevel verbose --concurrency 1 -y"
+      );
+      await fixture.exec(`npm unpublish --force package-1@${version} --registry=http://localhost:4872`);
+      await fixture.exec(`npm unpublish --force package-2@${version} --registry=http://localhost:4872`);
+
+      const replaceVersion = (str: string) => str.replaceAll(version, "XX.XX.XX");
+
+      expect(replaceVersion(output.combinedOutput)).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna verb packageConfigs Resolving packages based on package.json "workspaces" configuration.
+        lerna verb rootPath /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace
+        lerna verb session XXXXXXXX
+        lerna verb user-agent lerna/999.9.9-e2e.0/node@v18.15.0+arm64 (darwin)
+        lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
+
+        Found 2 packages to publish:
+         - package-1 => XX.XX.XX
+         - package-2 => XX.XX.XX
+
+        lerna info auto-confirmed 
+        lerna info publish Publishing packages to npm...
+        lerna notice Skipping all user and access validation due to third-party registry
+        lerna notice Make sure you're authenticated properly ¯\\_(ツ)_/¯
+        lerna WARN ENOLICENSE Packages package-1 and package-2 are missing a license.
+        lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
+        lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
+        lerna verb getCurrentSHA {FULL_COMMIT_SHA}
+        lerna verb publish Expanded asset glob package.json into files ["package.json"]
+        lerna verb publish Expanded asset glob README.md into files ["README.md"]
+        lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/packages/package-1/package.json to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-1/package.json
+        lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/packages/package-1/README.md to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-1/README.md
+        lerna verb pack-directory dist/packages/package-1
+        lerna verb packed dist/packages/package-1
+        lerna verb publish Expanded asset glob package.json into files ["package.json"]
+        lerna verb publish Expanded asset glob docs/*.md into files ["docs/doc-1.md","docs/doc-2.md"]
+        lerna verb publish Expanded asset glob static/images/* into files ["static/images/image-1.png","static/images/image-2.png"]
+        lerna verb publish Expanded asset glob ../../CONTRIBUTING.md into files ["../../CONTRIBUTING.md"]
+        lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/packages/package-2/package.json to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-2/package.json
+        lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/packages/package-2/docs/doc-1.md to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-2/docs/doc-1.md
+        lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/packages/package-2/docs/doc-2.md to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-2/docs/doc-2.md
+        lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/packages/package-2/static/images/image-1.png to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-2/assets/image-1.png
+        lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/packages/package-2/static/images/image-2.png to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-2/assets/image-2.png
+        lerna verb publish Copying asset /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/CONTRIBUTING.md to /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-2/CONTRIBUTING.md
+        lerna verb pack-directory dist/packages/package-2
+        lerna verb packed dist/packages/package-2
+        lerna verb publish package-1
+        lerna success published package-1 XX.XX.XX
+        lerna notice 
+        lerna notice 📦  package-1@XX.XX.XX
+        lerna notice === Tarball Contents === 
+        lerna notice 99B   lib/main.js 
+        lerna notice 1.0kXXXB package.json
+        lerna notice 119B  README.md   
+        lerna notice === Tarball Details === 
+        lerna notice name:          package-1                               
+        lerna notice version:       XX.XX.XX                                
+        lerna notice filename:      package-1-XX.XX.XX.tgz                  
+        lerna notice package size: XXXB                                   
+        lerna notice unpacked size: XXX.XXX kb                                  
+        lerna notice shasum:        {FULL_COMMIT_SHA}
+        lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        lerna notice total files:   3                                       
+        lerna notice 
+        lerna verb publish package-2
+        lerna success published package-2 XX.XX.XX
+        lerna notice 
+        lerna notice 📦  package-2@XX.XX.XX
+        lerna notice === Tarball Contents === 
+        lerna notice 99B   lib/main.js 
+        lerna notice 1.3kXXXB package.json
+        lerna notice === Tarball Details === 
+        lerna notice name:          package-2                               
+        lerna notice version:       XX.XX.XX                                
+        lerna notice filename:      package-2-XX.XX.XX.tgz                  
+        lerna notice package size: XXXB                                   
+        lerna notice unpacked size: XXX.XXX kb                                  
+        lerna notice shasum:        {FULL_COMMIT_SHA}
+        lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        lerna notice total files:   2                                       
+        lerna notice 
+        Successfully published:
+         - package-1@XX.XX.XX
+         - package-2@XX.XX.XX
+        lerna success published 2 packages
+
+      `);
+
+      const files = await globby("**/*", {
+        cwd: fixture.getWorkspacePath("dist"),
+        onlyFiles: false,
+        onlyDirectories: false,
+      });
+      expect(files.sort().join("\n")).toMatchInlineSnapshot(`
+        packages
+        packages/package-1
+        packages/package-1/README.md
+        packages/package-1/lib
+        packages/package-1/lib/main.js
+        packages/package-1/package.json
+        packages/package-2
+        packages/package-2/CONTRIBUTING.md
+        packages/package-2/assets
+        packages/package-2/assets/image-1.png
+        packages/package-2/assets/image-2.png
+        packages/package-2/docs
+        packages/package-2/docs/doc-1.md
+        packages/package-2/docs/doc-2.md
+        packages/package-2/lib
+        packages/package-2/lib/main.js
+        packages/package-2/package.json
+      `);
+    });
+  });
+});

--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -101,7 +101,7 @@ Subdirectory to publish. Must apply to ALL packages, and MUST contain a package.
 Package lifecycles will still be run in the original leaf directory.
 You should probably use one of those lifecycles (`prepare`, `prepublishOnly`, or `prepack`) to _create_ the subdirectory and whatnot.
 
-If you're into unnecessarily complicated publishing, this will give you joy.
+See [Configuring Published Files](https://lerna.js.org/docs/concepts#configuring-published-files) for more information on configuring files to publish to npm.
 
 ```sh
 lerna publish --contents dist

--- a/libs/core/src/lib/package.ts
+++ b/libs/core/src/lib/package.ts
@@ -41,6 +41,13 @@ function shallowCopy(json: any) {
   }, {});
 }
 
+export interface RawManifestLernaConfig {
+  publish?: {
+    directory?: string;
+    assets?: (string | { from: string; to: string })[];
+  };
+}
+
 export interface RawManifest {
   name: string;
   version: string;
@@ -56,6 +63,7 @@ export interface RawManifest {
   workspaces?: string[];
   nx?: Record<string, unknown>;
   gitHead?: string;
+  lerna?: RawManifestLernaConfig;
 }
 
 export type ExtendedNpaResult = npa.Result & {
@@ -139,6 +147,10 @@ export class Package {
 
   get scripts() {
     return this[_scripts];
+  }
+
+  get lernaConfig(): RawManifestLernaConfig | undefined {
+    return this[PKG].lerna;
   }
 
   get bin() {

--- a/website/docs/concepts/configuring-published-files.md
+++ b/website/docs/concepts/configuring-published-files.md
@@ -1,0 +1,87 @@
+---
+id: configuring-published-files
+title: Configuring Published Files
+type: explainer
+---
+
+# Configuring Published Files
+
+When publishing a package to npm, the default is to publish everything in the package's source directory. This is not always optimal, since there are often files only relevant for development, such as tests and configuration files. There are a few ways to ensure that only the appropriate files are packed and published to npm.
+
+## `"files"` and .gitignore
+
+Lerna always publishes using npm, and npm has a few built in ways to include or exclude files. The easiest way to configure which files are included in the published package are via the "files" property in `package.json` and `.gitignore`. See the [npm documentation](https://docs.npmjs.com/cli/v7/commands/npm-publish#files-included-in-package) for more information on how npm recognizes files for publishing.
+
+## `--contents`
+
+`lerna publish` has a `--contents` options, which sets the directory to publish for ALL packages. This is useful if the packages in your monorepo have a uniform output structure. The argument passed to `--contents` must be a subdirectory that exists within every package being published. See the [lerna publish documentation](https://github.com/lerna/lerna/tree/main/libs/commands/publish#--contents-dir) for details.
+
+## `"lerna.publish.directory"` property in `package.json`
+
+The `"lerna.publish.directory"` property in `package.json` can be used to configure the directory to publish for a specific package. This is useful if the packages in your monorepo have different output structures, or if your packages' build output is in a folder outside of its source directory. This is the most flexible way to configure which files are published for each package.
+
+An example configuration for a package that builds to a `dist/packages/foo` folder in the root of the repo:
+
+```json
+// packages/foo/package.json
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "lerna": {
+    "publish": {
+      "directory": "../../dist/packages/foo"
+    }
+  }
+}
+```
+
+[This example repo](https://github.com/fahslaj/lerna-custom-publish-directory) shows how to use this approach to configure the files to publish for packages that transpile TypeScript files to JavaScript output in a `dist` folder in the root of the repo.
+
+# Including Additional Assets in Published Packages
+
+Lerna can copy files from your source directory to the directory specified for publishing. By default, Lerna will copy the `README.md` and `package.json` files. This can be configured via the `"lerna.publish.assets"` property in `package.json` to include additional files or exclude the default files.
+
+The `"assets"` property should be an array of globs or objects with a `"from"` and `"to"` property. The `"from"` property should be a specific file or glob pattern that matches files in the source directory, and the `"to"` property is the path to copy the file to in the publish directory.
+
+This example configuration is taken from [an example repo](https://github.com/fahslaj/lerna-custom-publish-directory). The package builds its output to a root `dist/packages/bar` directory. Lerna is configured to copy additional files to this directory, then publish the contents of `dist/packages/bar` to npm.
+
+```json
+// packages/bar/package.json
+{
+  "name": "bar",
+  "version": "1.0.0",
+  "lerna": {
+    "publish": {
+      "directory": "../../dist/packages/bar",
+      "assets": [
+        "README.md",
+        "package.json",
+        "docs/*.md",
+        {
+          "from": "static/images/*",
+          "to": "assets"
+        },
+        {
+          "from": "../../CONTRIBUTING.md",
+          "to": "./"
+        }
+      ]
+    }
+  }
+}
+```
+
+Lerna will consume the above configuration and copy the appropriate files to the dist directory, producing a structure like this:
+
+```
+dist/packages/bar
+├── assets
+│   ├── my-image-1.png
+│   └── my-image-2.png
+├── CONTRIBUTING.md
+├── docs
+│   ├── my-doc-1.md
+│   └── my-doc-2.md
+├── package.json
+└── README.md
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -49,6 +49,7 @@ const sidebars = {
         "concepts/task-pipeline-configuration",
         "concepts/how-caching-works",
         "concepts/dte-guide",
+        "concepts/configuring-published-files",
         "concepts/alternate-bootstrapping-methods",
         "concepts/hoisting",
       ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for a "lerna.publish" config option in package.json files. This tells Lerna which directory to publish for the package and if any assets should be copied to the directory before publishing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows for publishing directories outside of the source directory of the package. This is especially helpful for patterns where the output of a package is written to a `dist/packages/...` directory in the root of the workspace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and covered by e2e tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
