### PR TITLE
fix(publish): revert auto-copying of assets to custom contents/directory

### DIFF
--- a/e2e/publish/src/custom-publish-directories.spec.ts
+++ b/e2e/publish/src/custom-publish-directories.spec.ts
@@ -43,7 +43,11 @@ describe("lerna-publish-custom-publish-directories", () => {
       await fixture.updateJson("packages/package-1/package.json", (pkg) => ({
         ...pkg,
         main: "main.js",
-        scripts: { build: "cp ./lib/package-1.js ../../dist/packages/package-1/lib/main.js" },
+        scripts: {
+          // Case where user manually ensures package.json is present inn publish directory
+          build:
+            "cp ./lib/package-1.js ../../dist/packages/package-1/lib/main.js && cp ./package.json ../../dist/packages/package-1/package.json",
+        },
         lerna: {
           command: {
             publish: { directory: "../../dist/packages/package-1" },
@@ -140,10 +144,6 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
         lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
         lerna verb getCurrentSHA {FULL_COMMIT_SHA}
-        lerna verb publish Expanded asset glob package.json into files ["package.json"]
-        lerna verb publish Expanded asset glob README.md into files ["README.md"]
-        lerna verb publish Copying asset packages/package-1/package.json to dist/packages/package-1/package.json
-        lerna verb publish Copying asset packages/package-1/README.md to dist/packages/package-1/README.md
         lerna verb pack-directory dist/packages/package-1
         lerna verb packed dist/packages/package-1
         lerna verb publish Expanded asset glob package.json into files ["package.json"]
@@ -167,7 +167,6 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna notice === Tarball Contents === 
         lerna notice 99B   lib/main.js 
         lerna notice XXXkb package.json
-        lerna notice 119B  README.md   
         lerna notice === Tarball Details === 
         lerna notice name:          package-1                               
         lerna notice version:       XX.XX.XX                                
@@ -176,7 +175,7 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna notice unpacked size: XXX.XXX kb                                  
         lerna notice shasum:        {FULL_COMMIT_SHA}
         lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-        lerna notice total files:   3                                       
+        lerna notice total files:   2                                       
         lerna notice 
         lerna verb publish package-2
         lerna success published package-2 XX.XX.XX
@@ -229,7 +228,6 @@ describe("lerna-publish-custom-publish-directories", () => {
       expect(files.sort().join("\n")).toMatchInlineSnapshot(`
         packages
         packages/package-1
-        packages/package-1/README.md
         packages/package-1/lib
         packages/package-1/lib/main.js
         packages/package-1/package.json

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -1099,6 +1099,11 @@ class PublishCommand extends Command {
   }
 
   private async copyAssets(pkg: Package) {
+    // Do not copy assets if no custom assets are defined (root level config will have been applied to the pkg by this point)
+    if (!pkg.lernaConfig?.command?.publish?.assets) {
+      return;
+    }
+
     if (normalize(pkg.location) === normalize(pkg.contents)) {
       // no need to copy assets if publishing from the source location
       return;
@@ -1106,7 +1111,7 @@ class PublishCommand extends Command {
 
     const _workspaceRoot = process.env["NX_WORKSPACE_ROOT_PATH"] || workspaceRoot;
 
-    const assets = pkg.lernaConfig?.command?.publish?.assets || ["package.json", "README.md"];
+    const assets = pkg.lernaConfig?.command?.publish?.assets;
     const filesToCopy: {
       from: string;
       to: string;

--- a/website/docs/concepts/configuring-published-files.md
+++ b/website/docs/concepts/configuring-published-files.md
@@ -22,7 +22,7 @@ This is only useful for publishing if the packages in your monorepo have a simpl
 
 In v7, we introduced a more powerful, more focused `--directory` option for `lerna publish`. Please prefer that over the `--contents` option, which will likely be deprecated in future.
 
-## `--directory"`
+## `--directory`
 
 In v7, we introduced a more powerful, more focused `--directory` option for `lerna publish`.
 
@@ -73,6 +73,11 @@ An example configuration for a package that publishes from a `dist/packages/foo`
 }
 ```
 
+:::info
+You will need to make sure that your custom directory location contains a valid `package.json` which will be used for the registry publish. You could create this via a lifecycle script such as `prepare`, `prepublishOnly`, or `prepack` if you need more complex custom logic involved, or simply have it copied for you from the package's source automatically by configuring it as an asset. See the upcoming section on **Including Additional Assets in Published Packages** for full details.
+
+:::
+
 If you wanted to make one of your packages behave like a standard lerna package and publish from source, you could override its publish config like so:
 
 ```json
@@ -83,8 +88,7 @@ If you wanted to make one of your packages behave like a standard lerna package 
   "lerna": {
     "command": {
       "publish": {
-        "directory": ".",
-        "assets": []
+        "directory": "."
       }
     }
   }
@@ -94,8 +98,6 @@ If you wanted to make one of your packages behave like a standard lerna package 
 # Including Additional Assets in Published Packages
 
 Lerna can copy files from your source directory to the directory specified for publishing. Just as with the `directory` option, this can be configured in the `lerna.json` (including using dynamic placeholders within asset definitions), or within the `package.json` of a particular package.
-
-By default, Lerna will copy the `README.md` and `package.json` files. If you decided to override the `assets` configuration, you must make sure to include `"package.json"` in your asset definitions.
 
 Regardless of which file it is configured in, the `"assets"` property should be an array of glob patterns or objects with a `"from"` and `"to"` property. The `"from"` property should be a specific file or glob pattern that matches files in the source directory, and the `"to"` property is the path to copy the file to within the publish directory.
 


### PR DESCRIPTION
The auto-copying feature introduced in v7.0.0 adds unexpected behaviour to the traditional contents option and in general is too magical, reverting and updating docs accordingly.

Fixes #3731 