### PR TITLE
feat(repair): add migration to remove unused "lerna" field from lerna.json

### DIFF
--- a/packages/lerna/migrations.json
+++ b/packages/lerna/migrations.json
@@ -12,6 +12,12 @@
       "description": "Remove invalid `init` config from lerna.json as it is no longer applicable, given init cannot be run on an existing workspace",
       "implementation": "./dist/migrations/remove-invalid-init-config/remove-invalid-init-config"
     },
+    "remove-invalid-lerna-config": {
+      "cli": "nx",
+      "version": "7.0.0-alpha.2",
+      "description": "Remove invalid `lerna` config from lerna.json as it is no longer used for anything",
+      "implementation": "./dist/migrations/remove-invalid-lerna-config/remove-invalid-lerna-config"
+    },
     "remove-invalid-use-workspaces": {
       "cli": "nx",
       "version": "7.0.0-alpha.2",

--- a/packages/lerna/project.json
+++ b/packages/lerna/project.json
@@ -81,6 +81,7 @@
           "packages/lerna/src/commands/version/lib/update-lockfile-version.ts",
           "packages/lerna/src/migrations/add-schema-config/add-schema-config.ts",
           "packages/lerna/src/migrations/remove-invalid-init-config/remove-invalid-init-config.ts",
+          "packages/lerna/src/migrations/remove-invalid-lerna-config/remove-invalid-lerna-config.ts",
           "packages/lerna/src/migrations/remove-invalid-use-workspaces/remove-invalid-use-workspaces.ts",
           "packages/lerna/src/migrations/remove-unnecessary-use-nx/remove-unnecessary-use-nx.ts",
           "packages/lerna/src/migrations/update-options-from-legacy-deprecate-config/update-options-from-legacy-deprecate-config.ts"

--- a/packages/lerna/src/migrations/remove-invalid-lerna-config/remove-invalid-lerna-config.test.ts
+++ b/packages/lerna/src/migrations/remove-invalid-lerna-config/remove-invalid-lerna-config.test.ts
@@ -1,0 +1,37 @@
+import { readJson, Tree, writeJson } from "@nx/devkit";
+import { createTreeWithEmptyWorkspace } from "@nx/devkit/testing";
+import removeInvalidConfigMigration from "./remove-invalid-lerna-config";
+
+describe("remove-invalid-lerna-config", () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it(`should remove "lerna" config if present`, async () => {
+    writeJson(tree, "lerna.json", {
+      lerna: "2.0.0-rc.5",
+    });
+    await removeInvalidConfigMigration(tree);
+    expect(readJson(tree, "lerna.json")).toMatchInlineSnapshot(`Object {}`);
+  });
+
+  it(`should not not modify the file if no "lerna" config is present`, async () => {
+    writeJson(tree, "lerna.json", {
+      something: false,
+      somethingElse: {
+        nested: "value",
+      },
+    });
+    await removeInvalidConfigMigration(tree);
+    expect(readJson(tree, "lerna.json")).toMatchInlineSnapshot(`
+      Object {
+        "something": false,
+        "somethingElse": Object {
+          "nested": "value",
+        },
+      }
+    `);
+  });
+});

--- a/packages/lerna/src/migrations/remove-invalid-lerna-config/remove-invalid-lerna-config.ts
+++ b/packages/lerna/src/migrations/remove-invalid-lerna-config/remove-invalid-lerna-config.ts
@@ -1,0 +1,12 @@
+import { formatFiles, readJson, Tree, writeJson } from "@nx/devkit";
+
+export default async function generator(tree: Tree) {
+  const lernaJson = readJson(tree, "lerna.json");
+
+  if (lernaJson.lerna !== undefined) {
+    delete lernaJson.lerna;
+    writeJson(tree, "lerna.json", lernaJson);
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
In a very old lerna.json config I discovered this:

```sh
{
  "lerna": "2.0.0-rc.5",
  "packages": [
    "packages/*"
  ],
  "version": "0.0.0"
}
```

We do not do anything with a `"lerna"` field in `lerna.json` so this migration removes it if it is present