### PR TITLE
fix: fix strict-ssl mapping for node-fetch-registry during unpublished projects lookup

### DIFF
--- a/libs/commands/publish/src/lib/fetch-config.ts
+++ b/libs/commands/publish/src/lib/fetch-config.ts
@@ -1,6 +1,7 @@
 import log from "npmlog";
 
 export interface FetchConfig {
+  [key: string]: unknown;
   fetchRetries?: number;
   log: typeof log;
   registry?: string;

--- a/libs/commands/publish/src/lib/get-projects-with-unpublished-packages.spec.ts
+++ b/libs/commands/publish/src/lib/get-projects-with-unpublished-packages.spec.ts
@@ -82,3 +82,26 @@ test("getProjectsWithUnpublishedPackages with private package", async () => {
     }),
   ]);
 });
+
+test("getProjectsWithUnpublishedPackages with strict-ssl = false", async () => {
+  const cwd = await initFixture("public-private");
+  const packages = await getPackages(cwd);
+  const projectNodes = packages.map(
+    (pkg): ProjectGraphProjectNodeWithPackage => ({
+      name: pkg.name,
+      type: "lib",
+      data: { root: pkg.location },
+      package: pkg,
+    })
+  );
+
+  const opts = {'strict-ssl': false};
+  const pkgs = await getProjectsWithUnpublishedPackages(projectNodes, opts);
+
+  expect(pacote.packument).toHaveBeenCalledWith("package-1", {'strict-ssl': false, 'strictSSL': false});
+  expect(pkgs).toEqual([
+    expect.objectContaining({
+      name: "package-1",
+    }),
+  ]);
+});

--- a/libs/commands/publish/src/lib/get-projects-with-unpublished-packages.spec.ts
+++ b/libs/commands/publish/src/lib/get-projects-with-unpublished-packages.spec.ts
@@ -95,10 +95,10 @@ test("getProjectsWithUnpublishedPackages with strict-ssl = false", async () => {
     })
   );
 
-  const opts = {'strict-ssl': false};
+  const opts = { "strict-ssl": false };
   const pkgs = await getProjectsWithUnpublishedPackages(projectNodes, opts);
 
-  expect(pacote.packument).toHaveBeenCalledWith("package-1", {'strict-ssl': false, 'strictSSL': false});
+  expect(pacote.packument).toHaveBeenCalledWith("package-1", { "strict-ssl": false, strictSSL: false });
   expect(pkgs).toEqual([
     expect.objectContaining({
       name: "package-1",

--- a/libs/commands/publish/src/lib/get-projects-with-unpublished-packages.ts
+++ b/libs/commands/publish/src/lib/get-projects-with-unpublished-packages.ts
@@ -16,7 +16,7 @@ export async function getProjectsWithUnpublishedPackages(
   const mapper = (node: ProjectGraphProjectNodeWithPackage) => {
     const pkg = getPackage(node);
     // libnpmpublish / npm-registry-fetch check strictSSL rather than strict-ssl
-    opts['strictSSL'] = opts["strict-ssl"];
+    opts["strictSSL"] = opts["strict-ssl"];
     return pacote.packument(pkg.name, opts).then(
       (packument) => {
         if (packument.versions === undefined || packument.versions[pkg.version] === undefined) {

--- a/libs/commands/publish/src/lib/get-projects-with-unpublished-packages.ts
+++ b/libs/commands/publish/src/lib/get-projects-with-unpublished-packages.ts
@@ -15,6 +15,8 @@ export async function getProjectsWithUnpublishedPackages(
 
   const mapper = (node: ProjectGraphProjectNodeWithPackage) => {
     const pkg = getPackage(node);
+    // libnpmpublish / npm-registry-fetch check strictSSL rather than strict-ssl
+    opts['strictSSL'] = opts["strict-ssl"];
     return pacote.packument(pkg.name, opts).then(
       (packument) => {
         if (packument.versions === undefined || packument.versions[pkg.version] === undefined) {


### PR DESCRIPTION
fixes #3746 

## Description
There is a missing mapping of strict-ssl for unpublished projects lookup.
This results into falsy unpublished projects.

## Motivation and Context
We are using lerna to automatically determine which packages are unpublished. We have encountered the issue it tries to publish packages again and again regardless if they are already published.
With debugging I have found out there is an issue using the given strict-ssl attribute. It is not passed to pacote correctly.

In general it is the same issue like here #2952 

## How Has This Been Tested?
I have debugged everything and also tried to write an unit test which should cover this scenario.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - there are some tests failing (perhaps of my Windows environment)
