### PR TITLE
fix(publish): catch publish conflict 403 error from npm

### DIFF
--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -1010,7 +1010,11 @@ class PublishCommand extends Command {
               return pkg;
             })
             .catch((err) => {
-              if (err.code === "EPUBLISHCONFLICT") {
+              if (
+                err.code === "EPUBLISHCONFLICT" ||
+                (err.code === "E403" &&
+                  err.body?.error?.includes("You cannot publish over the previously published versions"))
+              ) {
                 tracker.warn("publish", `Package is already published: ${pkg.name}@${pkg.version}`);
                 tracker.completeWork(1);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Catches another possible form of publish conflict error from npm.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some permission setups on npm were causing a 403 error instead of the EPUBLISHCONFLICT code, and this ensures they are caught appropriately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually by publishing packages to npm with conflicts, observing the error in Lerna, then testing it again with this change and observing Lerna properly swallow the error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
