### PR TITLE
fix: lerna publish failed because of incompatibility with prettier 3

### DIFF
--- a/libs/commands/version/src/lib/git-add.ts
+++ b/libs/commands/version/src/lib/git-add.ts
@@ -33,17 +33,19 @@ async function maybeFormatFile(filePath) {
   if (!prettier) {
     return;
   }
-  const config = await resolvedPrettier.resolveConfig(filePath);
-  const ignorePath = path.join(workspaceRoot, ".prettierignore");
-  const fullFilePath = path.join(workspaceRoot, filePath);
 
-  const fileInfo = await resolvedPrettier.getFileInfo(fullFilePath, { ignorePath });
-
-  if (fileInfo.ignored) {
-    log.silly("version", `Skipped applying prettier to ignored file: ${filePath}`);
-    return;
-  }
   try {
+    const config = await resolvedPrettier.resolveConfig(filePath);
+    const ignorePath = path.join(workspaceRoot, ".prettierignore");
+    const fullFilePath = path.join(workspaceRoot, filePath);
+
+    const fileInfo = await resolvedPrettier.getFileInfo(fullFilePath, { ignorePath });
+
+    if (fileInfo.ignored) {
+      log.silly("version", `Skipped applying prettier to ignored file: ${filePath}`);
+      return;
+    }
+
     const input = fs.readFileSync(fullFilePath, "utf8");
     fs.writeFileSync(
       fullFilePath,


### PR DESCRIPTION
prettier 3 no longer exports the function resolveConfig().

fixes #3775

## Description

This change gracefully catches the throwing call to `resolveConfig()` to fix `lerna publish` failing.

This change does not add support for formatting with prettier 3, that should be done in a follow-up.

## Motivation and Context

see #3775

## How Has This Been Tested?

Tested by looking at the code because the change is very simple. I would be happy if the maintainers who know how to could test it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
