### PR TITLE
feat(version): sync the version of the package contents

### DIFF
--- a/e2e/publish/src/custom-publish-directories.spec.ts
+++ b/e2e/publish/src/custom-publish-directories.spec.ts
@@ -555,4 +555,59 @@ describe("lerna-publish-custom-publish-directories", () => {
       `);
     });
   });
+
+  describe("version", () => {
+    it("should sync the version of the contents directory", async () => {
+      await fixture.updateJson("lerna.json", (lernaJson) => {
+        return {
+          ...lernaJson,
+          command: {
+            publish: {
+              directory: "{workspaceRoot}/dist/{projectRoot}",
+              syncDistVersion: true,
+            },
+          },
+        };
+      });
+
+      const version = randomVersion();
+
+      await fixture.lerna("create package-1 -y");
+      await fixture.updateJson("packages/package-1/package.json", (pkg) => ({
+        ...pkg,
+        main: "main.js",
+        version,
+        scripts: {
+          build: "cp ./lib/package-1.js ../../dist/packages/package-1/lib/main.js",
+          copyManifest: "cp ./package.json ../../dist/packages/package-1/package.json",
+        },
+      }));
+
+      // Make sure dist location exists before running mini build target
+      await ensureDir(fixture.getWorkspacePath("dist/packages/package-1/lib"));
+
+      await fixture.exec("git checkout -b test-main");
+      await writeFile(fixture.getWorkspacePath(".gitignore"), "node_modules\n.DS_Store\ndist");
+      await fixture.exec("git add .gitignore");
+      await fixture.exec("git add .");
+      await fixture.exec('git commit -m "initial-commit"');
+      await fixture.exec("git push origin test-main");
+
+      await fixture.lerna("run build,copyManifest");
+
+      await fixture.lerna(
+        `publish ${version} --registry=http://localhost:4872 --loglevel verbose --concurrency 1 -y`
+      );
+
+      const distVersion = JSON.parse(
+        await fixture.readWorkspaceFile("dist/packages/package-1/package.json")
+      ).version;
+
+      await fixture.exec(`npm unpublish --force package-1@${version} --registry=http://localhost:4872`);
+
+      expect(JSON.parse(await fixture.readWorkspaceFile("packages/package-1/package.json")).version).toEqual(
+        distVersion
+      );
+    });
+  });
 });

--- a/e2e/publish/src/custom-publish-directories.spec.ts
+++ b/e2e/publish/src/custom-publish-directories.spec.ts
@@ -121,7 +121,6 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna verb rootPath /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace
         lerna verb session XXXXXXXX
         lerna verb user-agent lerna/999.9.9-e2e.0/<user agent>
-        lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
         lerna verb silly Interpolated string "../../dist/packages/package-1" for node "package-1" to produce "../../dist/packages/package-1"
         lerna verb silly Interpolated string "../../dist/packages/package-2" for node "package-2" to produce "../../dist/packages/package-2"
         lerna verb silly Interpolated string "package.json" for node "package-2" to produce "package.json"
@@ -130,6 +129,7 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna verb silly Interpolated string "assets" for node "package-2" to produce "assets"
         lerna verb silly Interpolated string "../../CONTRIBUTING.md" for node "package-2" to produce "../../CONTRIBUTING.md"
         lerna verb silly Interpolated string "./" for node "package-2" to produce "./"
+        lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
 
         Found 3 packages to publish:
          - package-1 => XX.XX.XX
@@ -311,13 +311,13 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna verb rootPath /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace
         lerna verb session XXXXXXXX
         lerna verb user-agent lerna/999.9.9-e2e.0/<user agent>
-        lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
         lerna verb silly Interpolated string "{workspaceRoot}/dist/{projectRoot}" for node "package-1" to produce "/tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-1"
         lerna verb silly Interpolated string "package.json" for node "package-1" to produce "package.json"
         lerna verb silly Interpolated string "{projectName}.txt" for node "package-1" to produce "package-1.txt"
         lerna verb silly Interpolated string "{workspaceRoot}/dist/{projectRoot}" for node "package-2" to produce "/tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-2"
         lerna verb silly Interpolated string "package.json" for node "package-2" to produce "package.json"
         lerna verb silly Interpolated string "{projectName}.txt" for node "package-2" to produce "package-2.txt"
+        lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
 
         Found 2 packages to publish:
          - package-1 => XX.XX.XX
@@ -472,11 +472,11 @@ describe("lerna-publish-custom-publish-directories", () => {
         lerna verb rootPath /tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace
         lerna verb session XXXXXXXX
         lerna verb user-agent lerna/999.9.9-e2e.0/<user agent>
-        lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
         lerna verb silly Interpolated string "{workspaceRoot}/dist/{projectRoot}" for node "package-1" to produce "/tmp/lerna-e2e/lerna-publish-custom-publish-directories/lerna-workspace/dist/packages/package-1"
         lerna verb silly Interpolated string "package.json" for node "package-1" to produce "package.json"
         lerna verb silly Interpolated string "{projectName}.txt" for node "package-1" to produce "package-1.txt"
         lerna verb silly Interpolated string "." for node "package-2" to produce "."
+        lerna verb git-describe undefined => "vXX.XX.XX-0-gXXXXXXXX"
 
         Found 2 packages to publish:
          - package-1 => XX.XX.XX

--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -105,7 +105,7 @@ Subdirectory to publish. Must apply to ALL packages, and MUST contain a package.
 Package lifecycles will still be run in the original leaf directory.
 You should probably use one of those lifecycles (`prepare`, `prepublishOnly`, or `prepack`) to _create_ the subdirectory and whatnot.
 
-See [Configuring Published Files](https://lerna.js.org/docs/concepts#configuring-published-files) for more information on configuring files to publish to npm.
+See [Configuring Published Files](https://lerna.js.org/docs/concepts/configuring-published-files) for more information on configuring files to publish to npm.
 
 ```sh
 lerna publish --contents dist

--- a/libs/commands/version/README.md
+++ b/libs/commands/version/README.md
@@ -78,6 +78,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--signoff-git-commit`](#--signoff-git-commit)
     - [`--sign-git-commit`](#--sign-git-commit)
     - [`--sign-git-tag`](#--sign-git-tag)
+    - [`--sync-dist-version`](#--sync-dist-version)
     - [`--force-git-tag`](#--force-git-tag)
     - [`--tag-version-prefix`](#--tag-version-prefix)
     - [`--yes`](#--yes)
@@ -514,6 +515,10 @@ This option is analogous to the `npm version` [option](https://docs.npmjs.com/mi
 ### `--sign-git-tag`
 
 This option is analogous to the `npm version` [option](https://docs.npmjs.com/misc/config#sign-git-tag) of the same name.
+
+### `--sync-dist-version`
+
+Updates the version of the `package.json` of the contents directory.
 
 ### `--force-git-tag`
 

--- a/libs/commands/version/src/command.ts
+++ b/libs/commands/version/src/command.ts
@@ -140,6 +140,10 @@ const command: CommandModule = {
         hidden: true,
         type: "boolean",
       },
+      "sync-dist-version": {
+        describe: "Update the version of the package.json of the contents directory.",
+        type: "boolean",
+      },
       // TODO: (major) make --no-granular-pathspec the default
       "no-granular-pathspec": {
         describe: "Do not stage changes file-by-file, but globally.",

--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -62,6 +62,7 @@ interface VersionCommandConfigOptions extends CommandConfigOptions {
   commitHooks?: boolean;
   gitRemote?: string;
   gitTagVersion?: boolean;
+  syncDistVersion?: boolean;
   granularPathspec?: boolean;
   push?: boolean;
   signGitCommit?: boolean;
@@ -621,6 +622,7 @@ class VersionCommand extends Command {
       changelogPreset,
       changelogEntryAdditionalMarkdown,
       changelog = true,
+      syncDistVersion = false,
     } = this.options;
     const independentVersions = this.project.isIndependent();
     const rootPath = this.project.manifest.location;
@@ -651,7 +653,11 @@ class VersionCommand extends Command {
         // update dependencies
         this.updateDependencies(node);
 
-        return Promise.all([updateLockfileVersion(pkg), pkg.serialize()]).then(([lockfilePath]) => {
+        return Promise.all([
+          updateLockfileVersion(pkg),
+          pkg.serialize(),
+          pkg.syncDistVersion(syncDistVersion),
+        ]).then(([lockfilePath]) => {
           // commit the updated manifest
           changedFiles.add(pkg.manifestLocation);
 

--- a/libs/core/src/lib/package.ts
+++ b/libs/core/src/lib/package.ts
@@ -1,4 +1,5 @@
 import { workspaceRoot } from "@nx/devkit";
+import fs from "fs";
 import loadJsonFile from "load-json-file";
 import npa from "npm-package-arg";
 import path from "path";
@@ -284,6 +285,23 @@ export class Package {
    */
   serialize() {
     return writePkg(this.manifestLocation, this[PKG] as any).then(() => this);
+  }
+
+  /**
+   * Sync dist manifest version
+   */
+  async syncDistVersion(doSync: boolean) {
+    if (doSync) {
+      const distPkg = path.join(this.contents, "package.json");
+
+      if (distPkg !== this.manifestLocation && fs.existsSync(distPkg)) {
+        const pkg = await loadJsonFile<RawManifest>(distPkg);
+        pkg.version = this[PKG].version;
+        await writePkg(distPkg, pkg as any);
+      }
+    }
+
+    return this;
   }
 
   getLocalDependency(

--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -1003,6 +1003,9 @@
             "gitTagVersion": {
               "$ref": "#/$defs/commandOptions/version/gitTagVersion"
             },
+            "syncDistVersion": {
+              "$ref": "#/$defs/commandOptions/version/syncDistVersion"
+            },
             "granularPathspec": {
               "$ref": "#/$defs/commandOptions/shared/granularPathspec"
             },
@@ -1699,6 +1702,10 @@
         "gitTagVersion": {
           "type": "boolean",
           "description": "During `lerna version`, when true, commit and tag version changes."
+        },
+        "syncDistVersion": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, updates the version of the contents directory."
         },
         "push": {
           "type": "boolean",


### PR DESCRIPTION
## Description

Usually in our CI we do `lint` -> `test` -> `built` -> `publish`  
but it has been a pain to build package contents (in other directory like `./dist`)
and then sync the generated version by `lerna publish` with a `version` hook in the root of the monorepo.

## Motivation and Context

In case we configure a publish directory different than the source folder  
we will need a custom script to sync the new version, otherwise the old version will be published.

## How Has This Been Tested?

I've tested it in my monorepo with the build output of this branch and it worked:

![image](https://github.com/lerna/lerna/assets/260185/135c4ba8-ef1e-4644-858c-b9b1e2ac86a5)

the config interpolation happens earlier than before and sync the `dist` output.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
