### PR TITLE
Fix file formatting on git add

### DIFF
--- a/libs/commands/version/src/lib/git-add.ts
+++ b/libs/commands/version/src/lib/git-add.ts
@@ -47,7 +47,7 @@ async function maybeFormatFile(filePath) {
     const input = fs.readFileSync(fullFilePath, "utf8");
     fs.writeFileSync(
       fullFilePath,
-      resolvedPrettier.format(input, { ...config, filepath: fullFilePath }),
+      await resolvedPrettier.format(input, { ...config, filepath: fullFilePath }),
       "utf8"
     );
     log.silly("version", `Successfully applied prettier to updated file: ${filePath}`);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

PR #3766 brought prettier 3 support by using asynchronous prettier APIs, but missed one `await` when calling `.format(...)`.

Because of this, `fs.writeFileSync(...)` is called with a Promise instead of a string and throws an exception:

> TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type
> string or an instance of Buffer, > TypedArray, or DataView. Received
> an instance of Promise

This exception is caught by the try/catch, and the file is never written.

Worse, when formatting files that are not supported by prettier (ex: yarn.lock), `.format(...)` fails and the promise rejection isn't handled, which lead to the following exception:

> UndefinedParserError: No parser could be inferred for file "..."

and Node terminates the process, which is probably the cause of #3788 and #3773

## Motivation and Context

This fixes file formatting and overall crashes during `lerna version`.

## How Has This Been Tested?

Tested when doing a release in a [project](https://github.com/DataDog/browser-sdk) that uses lerna 7.1.4 and prettier 3.0.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
