### PR TITLE
feat(init): detect existing package manager and auto-install packages

### DIFF
--- a/e2e/init/src/init-npm.spec.ts
+++ b/e2e/init/src/init-npm.spec.ts
@@ -1,0 +1,66 @@
+import { Fixture, normalizeEnvironment } from "@lerna/e2e-utils";
+import { writeFileSync } from "fs-extra";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeEnvironment(str);
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-init-npm", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-init-npm",
+      packageManager: "npm",
+      initializeGit: false,
+      lernaInit: false,
+      installDependencies: false,
+    });
+
+    writeFileSync(
+      fixture.getWorkspacePath("package.json"),
+      JSON.stringify({
+        name: "root",
+        private: true,
+        workspaces: ["packages/*"],
+      })
+    );
+
+    fixture.install();
+  });
+
+  afterEach(() => fixture.destroy());
+
+  it("should not set npmClient in lerna.json", async () => {
+    const result = await fixture.lernaInit("--loglevel verbose");
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Applying the following file system updates:
+      CREATE lerna.json
+      UPDATE package.json
+      CREATE .gitignore
+      lerna info Initializing Git repository
+      lerna verb Using npm to install packages
+      lerna success Initialized Lerna files
+      lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
+
+    `);
+
+    const lernaJson = await fixture.readWorkspaceFile("lerna.json");
+
+    expect(lernaJson).toMatchInlineSnapshot(`
+      {
+        "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+        "version": "0.0.0"
+      }
+
+    `);
+  });
+});

--- a/e2e/init/src/init-npm.spec.ts
+++ b/e2e/init/src/init-npm.spec.ts
@@ -38,7 +38,7 @@ describe("lerna-init-npm", () => {
   afterEach(() => fixture.destroy());
 
   it("should not set npmClient in lerna.json", async () => {
-    const result = await fixture.lernaInit("--loglevel verbose");
+    const result = await fixture.lernaInit();
 
     expect(result.combinedOutput).toMatchInlineSnapshot(`
       lerna notice cli v999.9.9-e2e.0
@@ -47,7 +47,7 @@ describe("lerna-init-npm", () => {
       UPDATE package.json
       CREATE .gitignore
       lerna info Initializing Git repository
-      lerna verb Using npm to install packages
+      lerna info Using npm to install packages
       lerna success Initialized Lerna files
       lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
 
@@ -66,7 +66,7 @@ describe("lerna-init-npm", () => {
 
   describe("--skip-install", () => {
     it("should not install packages", async () => {
-      const result = await fixture.lernaInit("--loglevel verbose --skip-install");
+      const result = await fixture.lernaInit("--skip-install");
 
       expect(result.combinedOutput).toMatchInlineSnapshot(`
         lerna notice cli v999.9.9-e2e.0

--- a/e2e/init/src/init-npm.spec.ts
+++ b/e2e/init/src/init-npm.spec.ts
@@ -32,7 +32,7 @@ describe("lerna-init-npm", () => {
       })
     );
 
-    fixture.install();
+    await fixture.install();
   });
 
   afterEach(() => fixture.destroy());

--- a/e2e/init/src/init-npm.spec.ts
+++ b/e2e/init/src/init-npm.spec.ts
@@ -63,4 +63,32 @@ describe("lerna-init-npm", () => {
 
     `);
   });
+
+  describe("--skip-install", () => {
+    it("should not install packages", async () => {
+      const result = await fixture.lernaInit("--loglevel verbose --skip-install");
+
+      expect(result.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna info Applying the following file system updates:
+        CREATE lerna.json
+        UPDATE package.json
+        CREATE .gitignore
+        lerna info Initializing Git repository
+        lerna success Initialized Lerna files
+        lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
+
+      `);
+
+      const lernaJson = await fixture.readWorkspaceFile("lerna.json");
+
+      expect(lernaJson).toMatchInlineSnapshot(`
+        {
+          "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+          "version": "0.0.0"
+        }
+
+      `);
+    });
+  });
 });

--- a/e2e/init/src/init-pnpm.spec.ts
+++ b/e2e/init/src/init-pnpm.spec.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from "fs-extra";
 
 expect.addSnapshotSerializer({
   serialize(str: string) {
-    return normalizeEnvironment(str).replace(/\.\.\..*\n/g, "");
+    return normalizeEnvironment(str).replace(/\.*.*\n/g, "");
   },
   test(val: string) {
     return val != null && typeof val === "string";

--- a/e2e/init/src/init-pnpm.spec.ts
+++ b/e2e/init/src/init-pnpm.spec.ts
@@ -1,0 +1,67 @@
+import { Fixture, normalizeEnvironment } from "@lerna/e2e-utils";
+import { writeFileSync } from "fs-extra";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeEnvironment(str).replace(/\.\.\..*\n/g, "");
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-init-pnpm", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-init-pnpm",
+      packageManager: "pnpm",
+      initializeGit: false,
+      lernaInit: false,
+      installDependencies: false,
+    });
+
+    writeFileSync(
+      fixture.getWorkspacePath("package.json"),
+      JSON.stringify({
+        name: "root",
+        private: true,
+        workspaces: ["packages/*"],
+      })
+    );
+
+    fixture.install();
+  });
+
+  afterEach(() => fixture.destroy());
+
+  it("should set npmClient to pnpm in lerna.json", async () => {
+    const result = await fixture.lernaInit("--loglevel verbose");
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Applying the following file system updates:
+      CREATE lerna.json
+      UPDATE package.json
+      CREATE .gitignore
+      lerna info Initializing Git repository
+      lerna verb Using pnpm to install packages
+      lerna success Initialized Lerna files
+      lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
+
+    `);
+
+    const lernaJson = await fixture.readWorkspaceFile("lerna.json");
+
+    expect(lernaJson).toMatchInlineSnapshot(`
+      {
+        "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+        "version": "0.0.0",
+        "npmClient": "pnpm"
+      }
+
+    `);
+  });
+});

--- a/e2e/init/src/init-pnpm.spec.ts
+++ b/e2e/init/src/init-pnpm.spec.ts
@@ -31,7 +31,7 @@ describe("lerna-init-pnpm", () => {
       })
     );
 
-    fixture.install();
+    await fixture.install();
   });
 
   afterEach(() => fixture.destroy());

--- a/e2e/init/src/init-pnpm.spec.ts
+++ b/e2e/init/src/init-pnpm.spec.ts
@@ -1,9 +1,11 @@
-import { Fixture, normalizeEnvironment } from "@lerna/e2e-utils";
+import { Fixture, getPublishedVersion, normalizeEnvironment } from "@lerna/e2e-utils";
 import { writeFileSync } from "fs-extra";
 
 expect.addSnapshotSerializer({
   serialize(str: string) {
-    return normalizeEnvironment(str).replace(/\.*.*\n/g, "");
+    return normalizeEnvironment(str)
+      .replace(/\.+\/\.?pnpm.*\n/g, "")
+      .replace("info cli using local version of lerna\n", "");
   },
   test(val: string) {
     return val != null && typeof val === "string";
@@ -28,6 +30,9 @@ describe("lerna-init-pnpm", () => {
       JSON.stringify({
         name: "root",
         private: true,
+        devDependencies: {
+          lerna: getPublishedVersion(),
+        },
       })
     );
 

--- a/e2e/init/src/init-pnpm.spec.ts
+++ b/e2e/init/src/init-pnpm.spec.ts
@@ -42,7 +42,7 @@ describe("lerna-init-pnpm", () => {
   afterEach(() => fixture.destroy());
 
   it("should set npmClient to pnpm in lerna.json", async () => {
-    const result = await fixture.lernaInit("--loglevel verbose");
+    const result = await fixture.lernaInit();
 
     expect(result.combinedOutput).toMatchInlineSnapshot(`
       lerna notice cli v999.9.9-e2e.0
@@ -51,7 +51,7 @@ describe("lerna-init-pnpm", () => {
       UPDATE package.json
       CREATE .gitignore
       lerna info Initializing Git repository
-      lerna verb Using pnpm to install packages
+      lerna info Using pnpm to install packages
       lerna success Initialized Lerna files
       lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
 

--- a/e2e/init/src/init-pnpm.spec.ts
+++ b/e2e/init/src/init-pnpm.spec.ts
@@ -28,7 +28,6 @@ describe("lerna-init-pnpm", () => {
       JSON.stringify({
         name: "root",
         private: true,
-        workspaces: ["packages/*"],
       })
     );
 

--- a/e2e/init/src/init-yarn.spec.ts
+++ b/e2e/init/src/init-yarn.spec.ts
@@ -1,0 +1,67 @@
+import { Fixture, normalizeEnvironment } from "@lerna/e2e-utils";
+import { writeFileSync } from "fs-extra";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeEnvironment(str);
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-init-yarn", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-init-yarn",
+      packageManager: "yarn",
+      initializeGit: false,
+      lernaInit: false,
+      installDependencies: false,
+    });
+
+    writeFileSync(
+      fixture.getWorkspacePath("package.json"),
+      JSON.stringify({
+        name: "root",
+        private: true,
+        workspaces: ["packages/*"],
+      })
+    );
+
+    fixture.install();
+  });
+
+  afterEach(() => fixture.destroy());
+
+  it("should set npmClient to yarn in lerna.json", async () => {
+    const result = await fixture.lernaInit("--loglevel verbose");
+
+    expect(result.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info Applying the following file system updates:
+      CREATE lerna.json
+      UPDATE package.json
+      CREATE .gitignore
+      lerna info Initializing Git repository
+      lerna verb Using yarn to install packages
+      lerna success Initialized Lerna files
+      lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
+
+    `);
+
+    const lernaJson = await fixture.readWorkspaceFile("lerna.json");
+
+    expect(lernaJson).toMatchInlineSnapshot(`
+      {
+        "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+        "version": "0.0.0",
+        "npmClient": "yarn"
+      }
+
+    `);
+  });
+});

--- a/e2e/init/src/init-yarn.spec.ts
+++ b/e2e/init/src/init-yarn.spec.ts
@@ -32,7 +32,7 @@ describe("lerna-init-yarn", () => {
       })
     );
 
-    fixture.install();
+    await fixture.install();
   });
 
   afterEach(() => fixture.destroy());

--- a/e2e/init/src/init-yarn.spec.ts
+++ b/e2e/init/src/init-yarn.spec.ts
@@ -38,7 +38,7 @@ describe("lerna-init-yarn", () => {
   afterEach(() => fixture.destroy());
 
   it("should set npmClient to yarn in lerna.json", async () => {
-    const result = await fixture.lernaInit("--loglevel verbose");
+    const result = await fixture.lernaInit();
 
     expect(result.combinedOutput).toMatchInlineSnapshot(`
       lerna notice cli v999.9.9-e2e.0
@@ -47,7 +47,7 @@ describe("lerna-init-yarn", () => {
       UPDATE package.json
       CREATE .gitignore
       lerna info Initializing Git repository
-      lerna verb Using yarn to install packages
+      lerna info Using yarn to install packages
       lerna success Initialized Lerna files
       lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
 

--- a/e2e/init/src/init.spec.ts
+++ b/e2e/init/src/init.spec.ts
@@ -25,6 +25,7 @@ describe("lerna-init", () => {
       CREATE package.json
       CREATE .gitignore
       lerna info Initializing Git repository
+      lerna info Using npm to install packages
       lerna success Initialized Lerna files
       lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
       "
@@ -65,6 +66,7 @@ describe("lerna-init", () => {
         CREATE package.json
         CREATE .gitignore
         lerna info Initializing Git repository
+        lerna info Using npm to install packages
         lerna success Initialized Lerna files
         lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
         "
@@ -106,6 +108,7 @@ describe("lerna-init", () => {
         CREATE package.json
         CREATE .gitignore
         lerna info Initializing Git repository
+        lerna info Using npm to install packages
         lerna success Initialized Lerna files
         lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
         "
@@ -147,6 +150,7 @@ describe("lerna-init", () => {
         CREATE package.json
         CREATE .gitignore
         lerna info Initializing Git repository
+        lerna info Using npm to install packages
         lerna success Initialized Lerna files
         lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
         "
@@ -188,6 +192,7 @@ describe("lerna-init", () => {
         CREATE package.json
         CREATE .gitignore
         lerna info Initializing Git repository
+        lerna info Using npm to install packages
         lerna success Initialized Lerna files
         lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
         "

--- a/integration/__tests__/lerna-init.spec.ts
+++ b/integration/__tests__/lerna-init.spec.ts
@@ -21,6 +21,7 @@ describe("lerna init", () => {
       CREATE package.json
       CREATE .gitignore
       lerna info Initializing Git repository
+      lerna info Using npm to install packages
       lerna success Initialized Lerna files
       lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
     `);

--- a/libs/commands/init/README.md
+++ b/libs/commands/init/README.md
@@ -62,3 +62,7 @@ It will configure `lerna.json` to enforce exact match for all subsequent executi
   "version": "0.0.0"
 }
 ```
+
+### `--skip-install`
+
+Skip running `npm/yarn/pnpm install` after initializing Lerna in the repo.

--- a/libs/commands/init/README.md
+++ b/libs/commands/init/README.md
@@ -19,15 +19,22 @@ When run, this command will:
 1. Add `lerna` as a [`devDependency`](https://docs.npmjs.com/files/package.json#devdependencies) in `package.json` if it doesn't already exist.
 2. Create a `lerna.json` config file to store the `version` number.
 3. Generate a `.gitignore` file if one doesn't already exist.
+4. Initialize a git repository if one doesn't already exist.
+5. Install dependencies with the `npmClient` set in `lerna.json`, or `npm` if unspecified.
 
 Example output on a new git repo:
 
 ```sh
 $ lerna init
-lerna info version v2.0.0
-lerna info Updating package.json
-lerna info Creating lerna.json
+lerna info version v7.1.4
+lerna info Applying the following file system updates:
+CREATE lerna.json
+CREATE package.json
+CREATE .gitignore
+lerna info Initializing Git repository
+lerna info Using npm to install packages
 lerna success Initialized Lerna files
+lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-started
 ```
 
 ## Options

--- a/libs/commands/init/README.md
+++ b/libs/commands/init/README.md
@@ -1,6 +1,6 @@
 # `lerna init`
 
-> Create a new Lerna repo or upgrade an existing repo to the current version of Lerna
+> Create a new Lerna repo or add Lerna to an existing repo
 
 Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` CLI.
 
@@ -10,17 +10,15 @@ Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` C
 $ lerna init
 ```
 
-Create a new Lerna repo or upgrade an existing repo to the current version of Lerna.
-
-> Lerna assumes the repo has already been initialized with `git init`.
+Create a new Lerna repo or add Lerna to an existing repo.
 
 When run, this command will:
 
 1. Add `lerna` as a [`devDependency`](https://docs.npmjs.com/files/package.json#devdependencies) in `package.json` if it doesn't already exist.
-2. Create a `lerna.json` config file to store the `version` number.
+2. Create a `lerna.json` config file.
 3. Generate a `.gitignore` file if one doesn't already exist.
 4. Initialize a git repository if one doesn't already exist.
-5. Install dependencies with the `npmClient` set in `lerna.json`, or `npm` if unspecified.
+5. Install dependencies with the detected package manager. If no lockfile is present, Lerna will default to using `npm`.
 
 Example output on a new git repo:
 
@@ -39,13 +37,38 @@ lerna info New to Lerna? Check out the docs: https://lerna.js.org/docs/getting-s
 
 ## Options
 
+### `--dry-run`
+
+```sh
+$ lerna init --dry-run
+```
+
+Preview the changes that will be made to the file system without actually modifying anything.
+
 ### `--independent`
 
 ```sh
 $ lerna init --independent
 ```
 
-This flag tells Lerna to use independent versioning mode.
+This flag tells Lerna to use independent versioning mode. See [Version and Publish](https://lerna.js.org/docs/features/version-and-publish#versioning-strategies) for details.
+
+### `--packages`
+
+```sh
+$ lerna init --packages="packages/*"
+$ lerna init --packages="packages/*" --packages="components/*"
+```
+
+Set the `packages` globs used to find packages in the repo. If not specified, then Lerna will use [package manager workspaces](https://lerna.js.org/docs/faq#how-does-lerna-detect-packages) to detect packages.
+
+> NOTE: if you are initializing Lerna in an existing repo, you will need to either enable [package manager workspaces](https://lerna.js.org/docs/faq#how-does-lerna-detect-packages) OR provide the `--packages` argument.
+
+### `--skip-install`
+
+Skip running `npm/yarn/pnpm install` after initializing Lerna in the repo.
+
+## Deprecated Options
 
 ### `--exact`
 
@@ -70,6 +93,4 @@ It will configure `lerna.json` to enforce exact match for all subsequent executi
 }
 ```
 
-### `--skip-install`
-
-Skip running `npm/yarn/pnpm install` after initializing Lerna in the repo.
+> `--exact` is deprecated because `lerna init` should no longer be run on an existing Lerna repo.

--- a/libs/commands/init/src/command.ts
+++ b/libs/commands/init/src/command.ts
@@ -28,7 +28,7 @@ const command: CommandModule = {
       default: false,
     },
     skipInstall: {
-      describe: "Skip installation of npm dependencies after initialization",
+      describe: "Skip installation of dependencies after initialization",
       type: "boolean",
     },
   },

--- a/libs/commands/init/src/command.ts
+++ b/libs/commands/init/src/command.ts
@@ -27,6 +27,10 @@ const command: CommandModule = {
       type: "boolean",
       default: false,
     },
+    skipInstall: {
+      describe: "Skip installation of npm dependencies after initialization",
+      type: "boolean",
+    },
   },
   handler(argv) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/libs/commands/init/src/index.ts
+++ b/libs/commands/init/src/index.ts
@@ -198,7 +198,7 @@ class InitCommand {
       }
 
       if (this.args.skipInstall === undefined) {
-        this.logger.verbose("", `Using ${this.packageManager} to install packages`);
+        this.logger.info("", `Using ${this.packageManager} to install packages`);
 
         const [command, ...args] = this.packageManagerCommand.install.split(" ");
 

--- a/libs/e2e-utils/src/lib/fixture.ts
+++ b/libs/e2e-utils/src/lib/fixture.ts
@@ -567,7 +567,7 @@ function stripConsoleColors(log: string): string {
   return log.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
 }
 
-function getPublishedVersion(): string {
+export function getPublishedVersion(): string {
   process.env.PUBLISHED_VERSION =
     process.env.PUBLISHED_VERSION ||
     // fallback to known e2e version

--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,6 +18707,7 @@
         "ini": "^1.3.8",
         "init-package-json": "5.0.0",
         "inquirer": "^8.2.4",
+        "is-ci": "3.0.1",
         "is-stream": "2.0.0",
         "js-yaml": "4.1.0",
         "libnpmpublish": "7.3.0",

--- a/packages/legacy-structure/commands/create/package.json
+++ b/packages/legacy-structure/commands/create/package.json
@@ -55,6 +55,7 @@
     "ini": "^1.3.8",
     "init-package-json": "5.0.0",
     "inquirer": "^8.2.4",
+    "is-ci": "3.0.1",
     "is-stream": "2.0.0",
     "js-yaml": "4.1.0",
     "libnpmpublish": "7.3.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Detects the package manager during `lerna init` by looking for existing lockfiles. Also makes the `init` command perform an installation task after the initialization to ensure Lerna is downloaded from the registry.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes it easier to add Lerna to a project that is managed by Yarn or Pnpm.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually and covered by e2e tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
