### PR TITLE
docs(website): adds hotloading limitation section to commands

### DIFF
--- a/website/docs/api-reference/commands.md
+++ b/website/docs/api-reference/commands.md
@@ -42,7 +42,7 @@ $ lerna run --scope "toolbar-*" test
 $ lerna run --scope package-1 --scope "*-2" lint
 ```
 
-**Note:** For certain globs, it may be necesssary to quote the option argument to avoid premature shell expansion.
+**Note:** For certain globs, it may be necessary to quote the option argument to avoid premature shell expansion.
 
 ### **Running with `npx`**
 

--- a/website/docs/api-reference/commands.md
+++ b/website/docs/api-reference/commands.md
@@ -37,12 +37,12 @@ Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` C
 Include only packages with names matching the given glob.
 
 ```sh
-lerna exec --scope my-component -- ls -la
-lerna run --scope "toolbar-*" test
-lerna run --scope package-1 --scope "*-2" lint
+$ lerna exec --scope my-component -- ls -la
+$ lerna run --scope "toolbar-*" test
+$ lerna run --scope package-1 --scope "*-2" lint
 ```
 
-**Note:** For certain globs, it may be necessary to quote the option argument to avoid premature shell expansion.
+**Note:** For certain globs, it may be necesssary to quote the option argument to avoid premature shell expansion.
 
 ### **Running with `npx`**
 
@@ -51,8 +51,8 @@ When running `lerna` with `npx`, it is necessary to use an explicit "=" when pas
 For example:
 
 ```sh
-npx lerna run --scope="toolbar-*" test
-npx lerna run --scope="package-{1,2,5}" test
+$ npx lerna run --scope="toolbar-*" test
+$ npx lerna run --scope="package-{1,2,5}" test
 ```
 
 ### `--ignore <glob>`
@@ -60,9 +60,9 @@ npx lerna run --scope="package-{1,2,5}" test
 Exclude packages with names matching the given glob.
 
 ```sh
-lerna exec --ignore "package-{1,2,5}"  -- ls -la
-lerna run --ignore package-1 test
-lerna run --ignore "package-@(1|2)" --ignore package-3 lint
+$ lerna exec --ignore "package-{1,2,5}"  -- ls -la
+$ lerna run --ignore package-1 test
+$ lerna run --ignore "package-@(1|2)" --ignore package-3 lint
 ```
 
 More examples of filtering can be found [here](https://github.com/lerna/lerna/blob/c0a750e0f482c16dda2f922f235861283efbe94d/commands/list/__tests__/list-command.test.js#L305-L356).
@@ -125,7 +125,7 @@ $ lerna bootstrap --scope "package-*" --ignore "package-util-*" --include-depend
 ### `--include-merged-tags`
 
 ```sh
-lerna exec --since --include-merged-tags -- ls -la
+$ lerna exec --since --include-merged-tags -- ls -la
 ```
 
 Include tags from merged branches when running a command with `--since`. This is only useful if you do a lot of publishing from feature branches, which is not generally recommended.

--- a/website/docs/api-reference/commands.md
+++ b/website/docs/api-reference/commands.md
@@ -37,9 +37,9 @@ Install [lerna](https://www.npmjs.com/package/lerna) for access to the `lerna` C
 Include only packages with names matching the given glob.
 
 ```sh
-$ lerna exec --scope my-component -- ls -la
-$ lerna run --scope "toolbar-*" test
-$ lerna run --scope package-1 --scope "*-2" lint
+lerna exec --scope my-component -- ls -la
+lerna run --scope "toolbar-*" test
+lerna run --scope package-1 --scope "*-2" lint
 ```
 
 **Note:** For certain globs, it may be necessary to quote the option argument to avoid premature shell expansion.
@@ -51,8 +51,8 @@ When running `lerna` with `npx`, it is necessary to use an explicit "=" when pas
 For example:
 
 ```sh
-$ npx lerna run --scope="toolbar-*" test
-$ npx lerna run --scope="package-{1,2,5}" test
+npx lerna run --scope="toolbar-*" test
+npx lerna run --scope="package-{1,2,5}" test
 ```
 
 ### `--ignore <glob>`
@@ -60,9 +60,9 @@ $ npx lerna run --scope="package-{1,2,5}" test
 Exclude packages with names matching the given glob.
 
 ```sh
-$ lerna exec --ignore "package-{1,2,5}"  -- ls -la
-$ lerna run --ignore package-1 test
-$ lerna run --ignore "package-@(1|2)" --ignore package-3 lint
+lerna exec --ignore "package-{1,2,5}"  -- ls -la
+lerna run --ignore package-1 test
+lerna run --ignore "package-@(1|2)" --ignore package-3 lint
 ```
 
 More examples of filtering can be found [here](https://github.com/lerna/lerna/blob/c0a750e0f482c16dda2f922f235861283efbe94d/commands/list/__tests__/list-command.test.js#L305-L356).
@@ -125,7 +125,11 @@ $ lerna bootstrap --scope "package-*" --ignore "package-util-*" --include-depend
 ### `--include-merged-tags`
 
 ```sh
-$ lerna exec --since --include-merged-tags -- ls -la
+lerna exec --since --include-merged-tags -- ls -la
 ```
 
 Include tags from merged branches when running a command with `--since`. This is only useful if you do a lot of publishing from feature branches, which is not generally recommended.
+
+## Limitations
+
+Even though you can run Lerna without installing the project dependencies first, for instance with [pnpm dlx](https://pnpm.io/cli/dlx) or [npx](https://www.npmjs.com/package/npx), it is not recommended. The command may work, but its output may not be 100% accurate. See [this issue](https://github.com/lerna/lerna/issues/3807#issuecomment-1686841507) for more details.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description, motivation and context

I reported an issue in [https://github.com/lerna/lerna/issues/3807](https://github.com/lerna/lerna/issues/3807) which was resolved by NX folks that happened when running a Lerna command without installing the project dependencies. @fahslaj wrote on the same issue that although this may work, it is not recommended. Lerna commands should always run in a project with all its dependencies installed. This PR adds the docs to state that limitation

## How Has This Been Tested?
Boot up the website locally and check the limitation section in `/api-reference/commands` page.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
