### PR TITLE
fix(version): option to not ignore scripts on lock update

### DIFF
--- a/libs/commands/version/README.md
+++ b/libs/commands/version/README.md
@@ -75,6 +75,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--no-push`](#--no-push)
     - [`--npm-client-args`](#--npm-client-args)
     - [`--preid`](#--preid)
+    - [`--run-scripts-on-lockfile-update`](#--run-scripts-on-lockfile-update)
     - [`--signoff-git-commit`](#--signoff-git-commit)
     - [`--sign-git-commit`](#--sign-git-commit)
     - [`--sign-git-tag`](#--sign-git-tag)
@@ -501,6 +502,11 @@ lerna version prepatch --preid next
 
 When run with this flag, `lerna version` will increment `premajor`, `preminor`, `prepatch`, or `prerelease` semver
 bumps using the specified [prerelease identifier](http://semver.org/#spec-item-9).
+
+### `--run-scripts-on-lockfile-update`
+
+By default, `lerna version` skips any lifecycle script when syncing the package-lock file after the version bump.
+With this option it will run `prepare`, `postinstall`, etc.
 
 ### `--signoff-git-commit`
 

--- a/libs/commands/version/src/command.ts
+++ b/libs/commands/version/src/command.ts
@@ -208,6 +208,10 @@ const command: CommandModule = {
           "Allows users to specify a custom command to be used when applying git tags. For example, this may be useful for providing a wrapper command in CI/CD pipelines that have no direct write access.",
         type: "string",
       },
+      "run-scripts-on-lockfile-update": {
+        describe: "Do not disable all lifecycle scripts while updating the lock file after the version bump.",
+        type: "boolean",
+      },
       "npm-client-args": {
         describe: "Additional arguments to pass to the npm client when performing 'npm install'.",
         type: "array",

--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -83,6 +83,7 @@ interface VersionCommandConfigOptions extends CommandConfigOptions {
   gitTagCommand?: string;
   message?: string;
   npmClientArgs?: string[];
+  runScriptsOnLockfileUpdate?: boolean;
   changelogPreset?: string;
   changelogEntryAdditionalMarkdown?: string;
   conventionalBumpPrerelease?: boolean;
@@ -622,6 +623,7 @@ class VersionCommand extends Command {
       changelogPreset,
       changelogEntryAdditionalMarkdown,
       changelog = true,
+      runScriptsOnLockfileUpdate = false,
       syncDistVersion = false,
     } = this.options;
     const independentVersions = this.project.isIndependent();
@@ -740,7 +742,12 @@ class VersionCommand extends Command {
       this.logger.verbose("version", "Updating root pnpm-lock.yaml");
       await childProcess.exec(
         "pnpm",
-        ["install", "--lockfile-only", "--ignore-scripts", ...npmClientArgs],
+        [
+          "install",
+          "--lockfile-only",
+          !runScriptsOnLockfileUpdate ? "--ignore-scripts" : "",
+          ...npmClientArgs,
+        ].filter(Boolean),
         this.execOpts
       );
 
@@ -773,7 +780,12 @@ class VersionCommand extends Command {
         this.logger.verbose("version", "Updating root package-lock.json");
         await childProcess.exec(
           "npm",
-          ["install", "--package-lock-only", "--ignore-scripts", ...npmClientArgs],
+          [
+            "install",
+            "--package-lock-only",
+            !runScriptsOnLockfileUpdate ? "--ignore-scripts" : "",
+            ...npmClientArgs,
+          ].filter(Boolean),
           this.execOpts
         );
         changedFiles.add(lockfilePath);

--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -1003,6 +1003,9 @@
             "gitTagVersion": {
               "$ref": "#/$defs/commandOptions/version/gitTagVersion"
             },
+            "runScriptsOnLockfileUpdate": {
+              "$ref": "#/$defs/commandOptions/version/runScriptsOnLockfileUpdate"
+            },
             "syncDistVersion": {
               "$ref": "#/$defs/commandOptions/version/syncDistVersion"
             },
@@ -1702,6 +1705,10 @@
         "gitTagVersion": {
           "type": "boolean",
           "description": "During `lerna version`, when true, commit and tag version changes."
+        },
+        "runScriptsOnLockfileUpdate": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, runs lifecycle scripts when syncing the lock file after the version bump."
         },
         "syncDistVersion": {
           "type": "boolean",


### PR DESCRIPTION
## Description

Option to not pass `--ignore-scripts` while updating the lock file after the version bump.

## Motivation and Context

Currently I'm using the old `lerna bootstrap` and I noticed that when versioning/publishing the npm lock file gets incomplete as `lerna version` is ignoring the scripts by default while updating it.

## How Has This Been Tested?

I've used `patch-package` to remove this code locally and it works as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
