### PR TITLE
Fix crash in `lerna version` when using `gitSignTag`

### DIFF
--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -850,9 +850,14 @@ class VersionCommand extends Command {
     if (await this.hasChanges()) {
       await gitCommit(message, this.gitOpts, this.execOpts);
     }
-    await Promise.all(
-      tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand))
-    );
+    if (this.gitOpts.signGitTag) {
+      for (const tag in tags)
+        await gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand)
+    } else {
+      await Promise.all(
+        tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand))
+      );
+    }
 
     return tags;
   }

--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -851,8 +851,7 @@ class VersionCommand extends Command {
       await gitCommit(message, this.gitOpts, this.execOpts);
     }
     if (this.gitOpts.signGitTag) {
-      for (const tag in tags)
-        await gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand)
+      for (const tag in tags) await gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand);
     } else {
       await Promise.all(
         tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand))


### PR DESCRIPTION
When instructing lerna to sign tags, `gpg` often runs out of memory because it isn't designed to be run in parallel ([see similar issue on another repository](https://github.com/sbt/sbt-pgp/issues/168)). Thus, when `signGitTag` is set to true, signing must be carried out serially.

## Description

If `gitTagSign` is set to true, this PR will sign tags one after another, omitting the race condition

## Motivation and Context

Signing git tags

## How Has This Been Tested?

I'm not sure how to test it, as we'd need to somehow mock `gitTag` to check if we call it concurrently or not.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Possibly related

- https://github.com/lerna/lerna/issues/2554