### PR TITLE
chore: use import instead of require for bundling diff command

### DIFF
--- a/libs/commands/diff/src/command.ts
+++ b/libs/commands/diff/src/command.ts
@@ -24,7 +24,7 @@ const command: CommandModule = {
   },
   handler(argv) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(".")(argv);
+    return require(".").factory(argv);
   },
 };
 

--- a/libs/commands/diff/src/index.ts
+++ b/libs/commands/diff/src/index.ts
@@ -6,19 +6,19 @@ import { hasCommit } from "./lib/has-commit";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const childProcess = require("@lerna/child-process");
 
-module.exports = function factory(argv: NodeJS.Process["argv"]) {
+export function factory(argv: NodeJS.Process["argv"]) {
   return new DiffCommand(argv);
-};
+}
 
 interface DiffCommandOptions extends CommandConfigOptions {
   pkgName: string;
   ignoreChanges: string[];
 }
 
-class DiffCommand extends Command<DiffCommandOptions> {
+export class DiffCommand extends Command<DiffCommandOptions> {
   private args: string[] = [];
 
-  initialize() {
+  override initialize() {
     const packageName = this.options.pkgName;
     let targetPackage;
 
@@ -55,7 +55,7 @@ class DiffCommand extends Command<DiffCommandOptions> {
     this.args = args;
   }
 
-  execute() {
+  override execute() {
     return childProcess.spawn("git", this.args, this.execOpts).catch((err: execa.ExecaError) => {
       if (err.exitCode) {
         // quitting the diff viewer is not an error
@@ -64,5 +64,3 @@ class DiffCommand extends Command<DiffCommandOptions> {
     });
   }
 }
-
-module.exports.DiffCommand = DiffCommand;

--- a/packages/lerna/src/commands/diff/command.ts
+++ b/packages/lerna/src/commands/diff/command.ts
@@ -1,1 +1,2 @@
-module.exports = require("@lerna/commands/diff/command");
+import cmd from "@lerna/commands/diff/command";
+module.exports = cmd;

--- a/packages/lerna/src/commands/diff/index.ts
+++ b/packages/lerna/src/commands/diff/index.ts
@@ -1,5 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const diffIndex = require("@lerna/commands/diff");
-
-module.exports = diffIndex;
-module.exports.DiffCommand = diffIndex.DiffCommand;
+export * from "@lerna/commands/diff";

--- a/packages/lerna/src/commands/diff/lib/get-last-commit.ts
+++ b/packages/lerna/src/commands/diff/lib/get-last-commit.ts
@@ -1,1 +1,1 @@
-module.exports = require("@lerna/commands/diff/lib/get-last-commit");
+export * from "@lerna/commands/diff/lib/get-last-commit";

--- a/packages/lerna/src/commands/diff/lib/has-commit.ts
+++ b/packages/lerna/src/commands/diff/lib/has-commit.ts
@@ -1,1 +1,1 @@
-module.exports = require("@lerna/commands/diff/lib/has-commit");
+export * from "@lerna/commands/diff/lib/has-commit";


### PR DESCRIPTION
 - ensures that typechecks are executed for diff command during build

## Description
using require does not execute type checks during `npx nx run-many -t build --parallel=3`

## Motivation and Context
Ensure typechecking during build for libs as well. Remove warnings/errors from eslint regarding `require` statements

## How Has This Been Tested?
All unit tests and integration tests still pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
