### PR TITLE
fix(version): update lock files after the version hook

### DIFF
--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -738,6 +738,11 @@ class VersionCommand extends Command {
     const npmClientArgsRaw = this.options.npmClientArgs || [];
     const npmClientArgs = npmClientArgsRaw.reduce((args, arg) => args.concat(arg.split(/\s|,/)), []);
 
+    if (!this.hasRootedLeaf) {
+      // exec version lifecycle in root (after all updates)
+      await this.runRootLifecycle("version");
+    }
+
     if (this.options.npmClient === "pnpm") {
       this.logger.verbose("version", "Updating root pnpm-lock.yaml");
       await childProcess.exec(
@@ -790,11 +795,6 @@ class VersionCommand extends Command {
         );
         changedFiles.add(lockfilePath);
       }
-    }
-
-    if (!this.hasRootedLeaf) {
-      // exec version lifecycle in root (after all updates)
-      await this.runRootLifecycle("version");
     }
 
     if (this.commitAndTag) {


### PR DESCRIPTION
## Description

Right now the lock-file is updated before the root `version` script, but if we edit some custom stuff in that hook (with `lerna exec --since` then it won't be possible to include those changes in the lock file and that seems undesirable.

## How Has This Been Tested?

Tested locally with a custom hook updating the package.json files of the changed packages.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
