### PR TITLE
feat: add json option to version command

### DIFF
--- a/e2e/version/src/positional-arguments.spec.ts
+++ b/e2e/version/src/positional-arguments.spec.ts
@@ -263,4 +263,42 @@ describe("lerna-version-positional-arguments-npm", () => {
 
     `);
   });
+
+  it("should support outputting json format", async () => {
+    const output = await fixture.lerna("version prerelease -y --json");
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info current version 0.0.0
+      lerna info Assuming all packages changed
+      [
+        {
+          "name": "package-a",
+          "version": "0.0.0",
+          "private": false,
+          "location": "/tmp/lerna-e2e/lerna-version-positional-arguments-npm/lerna-workspace/packages/package-a",
+          "newVersion": "0.0.1-alpha.0"
+        }
+      ]
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+
+    // should output valid json format
+    expect(JSON.parse(output.stdout)).toMatchInlineSnapshot(
+      `
+      Array [
+        Object {
+          location: /tmp/lerna-e2e/lerna-version-positional-arguments-npm/lerna-workspace/packages/package-a,
+          name: package-a,
+          newVersion: 0.0.1-alpha.0,
+          private: false,
+          version: 0.0.0,
+        },
+      ]
+    `
+    );
+  });
 });

--- a/libs/commands/version/README.md
+++ b/libs/commands/version/README.md
@@ -67,6 +67,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--ignore-changes`](#--ignore-changes)
     - [`--ignore-scripts`](#--ignore-scripts)
     - [`--include-merged-tags`](#--include-merged-tags)
+    - [`--json`](#--json)
     - [`--message <msg>`](#--message-msg)
     - [`--no-changelog`](#--no-changelog)
     - [`--no-commit-hooks`](#--no-commit-hooks)
@@ -372,6 +373,40 @@ lerna version --include-merged-tags
 ```
 
 Include tags from merged branches when detecting changed packages.
+
+### `--json`
+
+```sh
+lerna version --json
+```
+
+Outputs updated packages in json format. Here an example of the output:
+
+```json
+[
+  {
+    "name": "footer",
+    "version": "0.0.4",
+    "private": false,
+    "location": "/home/ammo/git/lerna-getting-started-example/packages/footer",
+    "newVersion": "0.0.5"
+  },
+  {
+    "name": "header",
+    "version": "0.0.4",
+    "private": false,
+    "location": "/home/ammo/git/lerna-getting-started-example/packages/header",
+    "newVersion": "0.0.5"
+  },
+  {
+    "name": "remixapp",
+    "version": "0.0.4",
+    "private": true,
+    "location": "/home/ammo/git/lerna-getting-started-example/packages/remixapp",
+    "newVersion": "0.0.5"
+  }
+]
+```
 
 ### `--message <msg>`
 

--- a/libs/commands/version/src/command.ts
+++ b/libs/commands/version/src/command.ts
@@ -112,6 +112,10 @@ const command: CommandModule = {
         describe: "Include tags from merged branches when detecting changed packages.",
         type: "boolean",
       },
+      json: {
+        describe: "Outputs changed packages in json format",
+        type: "boolean",
+      },
       m: {
         describe: "Use a custom commit message when creating the version commit.",
         alias: "message",

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -19,7 +19,7 @@ export { getPackageManifestPath } from "./lib/get-package-manifest-path";
 export * from "./lib/get-packages-for-option";
 export { gitCheckout } from "./lib/git-checkout";
 export { hasNpmVersion } from "./lib/has-npm-version";
-export { listableFormatProjects } from "./lib/listable-format-projects";
+export { listableFormatProjects, formatJSON } from "./lib/listable-format-projects";
 export { ListableOptions, listableOptions } from "./lib/listable-options";
 export { logPacked } from "./lib/log-packed";
 export { Conf } from "./lib/npm-conf/conf";

--- a/libs/core/src/lib/listable-format-projects.spec.ts
+++ b/libs/core/src/lib/listable-format-projects.spec.ts
@@ -4,7 +4,7 @@
 import { loggingOutput, tempDirSerializer, windowsPathSerializer } from "@lerna/test-helpers";
 import chalk from "chalk";
 import tempy from "tempy";
-import { listableFormatProjects } from "./listable-format-projects";
+import { formatJSON, listableFormatProjects } from "./listable-format-projects";
 import { ListableOptions } from "./listable-options";
 import { Package, RawManifest } from "./package";
 import {
@@ -96,6 +96,35 @@ pkg-3  v3.0.0 pkgs/pkg-3 (PRIVATE)
     "name": "pkg-2",
     "private": false,
     "location": "__TEST_ROOTDIR__/pkgs/pkg-2"
+  }
+]
+`);
+    });
+
+    test("JSON output with additional props", () => {
+      const text = formatJSON(projectNodes, ({ name }) => ({ projectName: name }));
+
+      expect(text).toMatchInlineSnapshot(`
+[
+  {
+    "name": "pkg-1",
+    "version": "1.0.0",
+    "private": false,
+    "location": "__TEST_ROOTDIR__/pkgs/pkg-1",
+    "projectName": "pkg-1"
+  },
+  {
+    "name": "pkg-2",
+    "private": false,
+    "location": "__TEST_ROOTDIR__/pkgs/pkg-2",
+    "projectName": "pkg-2"
+  },
+  {
+    "name": "pkg-3",
+    "version": "3.0.0",
+    "private": true,
+    "location": "__TEST_ROOTDIR__/pkgs/pkg-3",
+    "projectName": "pkg-3"
   }
 ]
 `);

--- a/libs/core/src/lib/listable-format-projects.ts
+++ b/libs/core/src/lib/listable-format-projects.ts
@@ -73,7 +73,12 @@ function filterResultList(
   return result;
 }
 
-function toJSONList(resultList: ReturnType<typeof filterResultList>) {
+function toJSONList(
+  resultList: ReturnType<typeof filterResultList>,
+  addtionalProperties: (project: ProjectGraphProjectNodeWithPackage) => {
+    [propt: string]: unknown;
+  } = () => ({})
+) {
   // explicit re-mapping exposes non-enumerable properties
   return resultList.map((project) => {
     const pkg = getPackage(project);
@@ -82,12 +87,18 @@ function toJSONList(resultList: ReturnType<typeof filterResultList>) {
       version: pkg.version,
       private: pkg.private,
       location: pkg.location,
+      ...addtionalProperties(project),
     };
   });
 }
 
-function formatJSON(resultList: ReturnType<typeof filterResultList>) {
-  return JSON.stringify(toJSONList(resultList), null, 2);
+export function formatJSON(
+  resultList: ReturnType<typeof filterResultList>,
+  additionalProperties: (project: ProjectGraphProjectNodeWithPackage) => {
+    [propt: string]: unknown;
+  } = () => ({})
+) {
+  return JSON.stringify(toJSONList(resultList, additionalProperties), null, 2);
 }
 
 function formatNDJSON(resultList: ReturnType<typeof filterResultList>) {

--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -997,6 +997,9 @@
             "ignoreScripts": {
               "$ref": "#/$defs/commandOptions/shared/ignoreScripts"
             },
+            "json": {
+              "$ref": "#/$defs/commandOptions/version/json"
+            },
             "message": {
               "$ref": "#/$defs/commandOptions/version/message"
             },
@@ -1695,6 +1698,10 @@
           "type": "string",
           "description": "During `lerna version`, an official GitHub or GitLab release for every version.",
           "enum": ["github", "gitlab"]
+        },
+        "json": {
+          "type": "boolean",
+          "description": "During `lerna version` when true output is provided in json format."
         },
         "message": {
           "type": "string",


### PR DESCRIPTION
 Outputs projects which reveive a new version in json format.

## Description
Follwoing json format is supported:
```json
[
  {
    "name": "footer",
    "version": "0.0.4",
    "private": false,
    "location": "/home/ammo/git/lerna-getting-started-example/packages/footer",
    "newVersion": "0.0.5"
  },
  {
    "name": "header",
    "version": "0.0.4",
    "private": false,
    "location": "/home/ammo/git/lerna-getting-started-example/packages/header",
    "newVersion": "0.0.5"
  },
  {
    "name": "remixapp",
    "version": "0.0.4",
    "private": true,
    "location": "/home/ammo/git/lerna-getting-started-example/packages/remixapp",
    "newVersion": "0.0.5"
  }
]
```

## Motivation and Context
#3720

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
