### PR TITLE
fix(core): update package engines.node to correctly include only >=16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "verdaccio": "^5.19.0"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -19107,7 +19107,7 @@
         "strong-log-transformer": "^2.1.0"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "packages/legacy-package-management": {
@@ -19180,7 +19180,7 @@
         "yargs": "16.2.0"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "packages/legacy-package-management/node_modules/make-dir": {
@@ -19283,7 +19283,7 @@
         "yargs-parser": "20.2.4"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "packages/legacy-structure/commands/create/node_modules/make-dir": {
@@ -19398,7 +19398,7 @@
         "lerna": "dist/cli.js"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "packages/lerna/node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "yarn": "1.22.19"
   },
   "engines": {
-    "node": "^14.17.0 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "build": "tools/scripts/build.sh",

--- a/packages/child-process/package.json
+++ b/packages/child-process/package.json
@@ -17,7 +17,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": "^14.17.0 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/legacy-package-management/package.json
+++ b/packages/legacy-package-management/package.json
@@ -15,7 +15,7 @@
   ],
   "main": "./dist/index.js",
   "engines": {
-    "node": "^14.17.0 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/legacy-structure/commands/create/package.json
+++ b/packages/legacy-structure/commands/create/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "./dist/index.js",
   "engines": {
-    "node": "^14.17.0 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "./src/index.js",
   "engines": {
-    "node": "^14.17.0 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "tag": "next"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates package.json files to properly exclude Node 14.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Node 14 reached end of life on Apr 30th, 2023 (https://endoflife.date/nodejs), which was two months before the release of Lerna v7. Lerna v7 never intended to support Node 14 and the persistence of ^v14.17.0 in the package.json `engines.node` property for Lerna@^7 was an oversight.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
