### PR TITLE
fix: support changelog-presets using async factory funcs

### DIFF
--- a/libs/core/src/lib/conventional-commits/__fixtures__/fixed/scripts/local-preset-async.js
+++ b/libs/core/src/lib/conventional-commits/__fixtures__/fixed/scripts/local-preset-async.js
@@ -1,0 +1,20 @@
+"use strict";
+
+// https://github.com/conventional-changelog/conventional-changelog/blob/b516084ef6a725197f148236c0ddbfae7ffe3e6f/packages/conventional-changelog-angular/conventional-recommended-bump.js
+const parserOpts = require("./parser-opts");
+const writerOpts = require("./writer-opts");
+const whatBump = require("./what-bump");
+
+async function createPreset(config) {
+  return {
+    conventionalChangelog: {
+      parserOpts,
+      writerOpts,
+    },
+    recommendedBumpOpts: {
+      parserOpts,
+      whatBump,
+    },
+  };
+}
+module.exports = createPreset;

--- a/libs/core/src/lib/conventional-commits/get-changelog-config.ts
+++ b/libs/core/src/lib/conventional-commits/get-changelog-config.ts
@@ -7,7 +7,10 @@ import { ChangelogPresetConfig } from "./constants";
 const cfgCache = new Map();
 
 function isFunction(config: any) {
-  return Object.prototype.toString.call(config) === "[object Function]";
+  return (
+    Object.prototype.toString.call(config) === "[object Function]" ||
+    Object.prototype.toString.call(config) === "[object AsyncFunction]"
+  );
 }
 
 function resolveConfigPromise(presetPackageName: string, presetConfig: object) {

--- a/libs/core/src/lib/conventional-commits/index.spec.ts
+++ b/libs/core/src/lib/conventional-commits/index.spec.ts
@@ -267,6 +267,21 @@ describe("conventional-commits", () => {
       expect(bump).toBe("1.1.0");
     });
 
+    it("supports async function presets", async () => {
+      const cwd = await initFixture("fixed");
+      const [pkg1] = await getPackages(cwd);
+
+      // make a change in package-1
+      await pkg1.set("changed", 1).serialize();
+      await gitAdd(cwd, pkg1.manifestLocation);
+      await gitCommit(cwd, "feat: changed 1");
+
+      const bump = await recommendVersion(pkg1, "fixed", {
+        changelogPreset: "./scripts/local-preset-async.js",
+      });
+      expect(bump).toBe("1.1.0");
+    });
+
     it("supports custom tagPrefix in fixed mode", async () => {
       const cwd = await initFixture("fixed");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7909,14 +7909,14 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
-      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-core": {
@@ -19734,7 +19734,7 @@
         "clone-deep": "4.0.1",
         "cmd-shim": "6.0.1",
         "columnify": "1.6.0",
-        "conventional-changelog-angular": "6.0.0",
+        "conventional-changelog-angular": "7.0.0",
         "conventional-changelog-core": "5.0.1",
         "conventional-recommended-bump": "7.0.1",
         "cosmiconfig": "^8.2.0",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -48,7 +48,7 @@
     "clone-deep": "4.0.1",
     "cmd-shim": "6.0.1",
     "columnify": "1.6.0",
-    "conventional-changelog-angular": "6.0.0",
+    "conventional-changelog-angular": "7.0.0",
     "conventional-changelog-core": "5.0.1",
     "conventional-recommended-bump": "7.0.1",
     "cosmiconfig": "^8.2.0",


### PR DESCRIPTION
 new 7.x.x versions of conventional changelog presets use async factory functions createPreset (see https://github.com/conventional-changelog/conventional-changelog/pull/1045)

## Description
Fixes #3871

## Motivation and Context
#3871

## How Has This Been Tested?
unit and e2e tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x I have added tests to cover my changes.
- [x] All new and existing tests passed.
