### PR TITLE
chore(info): use import instead of require for info cmd

### DIFF
--- a/libs/commands/info/src/command.ts
+++ b/libs/commands/info/src/command.ts
@@ -8,7 +8,7 @@ const command: CommandModule = {
   describe: "Prints debugging information about the local environment",
   handler(argv) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(".")(argv);
+    return require(".").factory(argv);
   },
 };
 

--- a/libs/commands/info/src/index.ts
+++ b/libs/commands/info/src/index.ts
@@ -1,11 +1,11 @@
 import { Command, output } from "@lerna/core";
 import envinfo from "envinfo";
 
-module.exports = function factory(argv: NodeJS.Process["argv"]) {
+export function factory(argv: NodeJS.Process["argv"]) {
   return new InfoCommand(argv);
-};
+}
 
-class InfoCommand extends Command {
+export class InfoCommand extends Command {
   override initialize() {}
 
   override execute() {
@@ -20,5 +20,3 @@ class InfoCommand extends Command {
       .then(output);
   }
 }
-
-module.exports.InfoCommand = InfoCommand;

--- a/packages/lerna/src/commands/info/command.ts
+++ b/packages/lerna/src/commands/info/command.ts
@@ -1,1 +1,2 @@
-module.exports = require("@lerna/commands/info/command");
+import cmd from "@lerna/commands/info/command";
+module.exports = cmd;

--- a/packages/lerna/src/commands/info/index.ts
+++ b/packages/lerna/src/commands/info/index.ts
@@ -1,5 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const infoIndex = require("@lerna/commands/info");
-
-module.exports = infoIndex;
-module.exports.InfoCommand = infoIndex.InfoCommand;
+export * from "@lerna/commands/info";


### PR DESCRIPTION
 - ensures that typechecks are executed for info command during build

## Description
using require does not execute type checks during `npx nx run-many -t build --parallel=3`

## Motivation and Context
Ensure typechecking during build for libs as well. Remove warnings/errors from eslint regarding `require` statements

## How Has This Been Tested?
All unit tests and integration tests still pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.