### PR TITLE
chore(e2e): update lockfile expectation to match yarn 4

### DIFF
--- a/e2e/version/src/yarn-lockfiles.spec.ts
+++ b/e2e/version/src/yarn-lockfiles.spec.ts
@@ -96,8 +96,8 @@ describe("lerna-version-yarn-lockfiles", () => {
 
     `);
     const yarnLock = readFileSync(fixture.getWorkspacePath("yarn.lock")).toString();
-    expect(yarnLock).toContain("package-a@^3.3.3, package-a@workspace:packages/package-a");
-    expect(yarnLock).toContain("package-b@workspace:packages/package-b");
-    expect(yarnLock).toContain("package-a: ^3.3.3");
+    expect(yarnLock).toContain(`package-a@npm:^3.3.3, package-a@workspace:packages/package-a`);
+    expect(yarnLock).toContain(`package-b@workspace:packages/package-b`);
+    expect(yarnLock).toContain(`package-a: "npm:^3.3.3"`);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates the assertion in yarn-lockfiles.spec.ts to match what yarn 4 produces.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our e2e tests run on the latest version of Yarn berry, which is now 4.0.0. This version of Yarn changed lockfiles slightly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
