### PR TITLE
feat(version): add --changelog-skip-unstable option

### DIFF
--- a/integration/__tests__/lerna-publish-conventional-independent-prerelease.spec.ts
+++ b/integration/__tests__/lerna-publish-conventional-independent-prerelease.spec.ts
@@ -381,3 +381,188 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 `);
   });
 });
+
+describe(`lerna publish --conventional-prerelease/graduate independent w/ stable changelog`, () => {
+  let cwd: string;
+
+  beforeAll(async () => {
+    ({ cwd } = await cloneFixture("independent", "chore: init repo"));
+    await Promise.all([
+      gitTag(cwd, "package-1@1.0.0"),
+      gitTag(cwd, "package-2@2.0.0"),
+      gitTag(cwd, "package-3@3.0.0"),
+      gitTag(cwd, "package-4@4.0.0"),
+      gitTag(cwd, "package-5@5.0.0"),
+    ]);
+  });
+
+  test(`release specified stable packages as prerelease`, async () => {
+    const args = [
+      "publish",
+      "--conventional-commits",
+      "--conventional-prerelease=package-2,package-3",
+      "--yes",
+    ];
+    await commitChangeToPackage(cwd, "package-1", "feat(package-1): Add foo", { foo: true });
+    await commitChangeToPackage(cwd, "package-2", "fix(package-2): Fix bar", { bar: true });
+    await commitChangeToPackage(
+      cwd,
+      "package-3",
+      `feat(package-3): Add baz feature${os.EOL}${os.EOL}BREAKING CHANGE: yup`,
+      { baz: true }
+    );
+
+    const { stdout } = await cliRunner(cwd, env)(...args);
+    expect(stdout).toMatchInlineSnapshot(`
+
+Changes:
+ - package-1: 1.0.0 => 1.1.0
+ - package-2: 2.0.0 => 2.0.1-alpha.0
+ - package-3: 3.0.0 => 4.0.0-alpha.0
+ - package-5: 5.0.0 => 5.0.1-alpha.0 (private)
+
+Successfully published:
+ - package-1@1.1.0
+ - package-2@2.0.1-alpha.0
+ - package-3@4.0.0-alpha.0
+`);
+  });
+
+  test(`graduate all prerelease packages with released HEAD`, async () => {
+    const args = [
+      "publish",
+      "--conventional-commits",
+      "--conventional-graduate",
+      "--changelog-skip-unstable",
+      "--yes"
+    ];
+    const { stdout } = await cliRunner(cwd, env)(...args);
+    expect(stdout).toMatchInlineSnapshot(`
+
+Changes:
+ - package-2: 2.0.1-alpha.0 => 2.0.1
+ - package-3: 4.0.0-alpha.0 => 4.0.0
+ - package-5: 5.0.1-alpha.0 => 5.0.1 (private)
+
+Successfully published:
+ - package-2@2.0.1
+ - package-3@4.0.0
+`);
+  });
+
+  test(`generate accurate changelog`, async () => {
+    const changelogFilePaths = await globby(["**/CHANGELOG.md"], {
+      cwd,
+      absolute: true,
+      followSymbolicLinks: false,
+    });
+    const [
+      // no root changelog
+      pkg1Changelog,
+      pkg2Changelog,
+      pkg3Changelog,
+      pkg5Changelog,
+    ] = await Promise.all(changelogFilePaths.sort().map((fp) => fs.readFile(fp, "utf8")));
+
+    /**
+     * ./packages/package-1/CHANGELOG.md
+     */
+    expect(pkg1Changelog).toMatchInlineSnapshot(`
+      # Change Log
+
+      All notable changes to this project will be documented in this file.
+      See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+      # [1.1.0](/compare/package-1@1.0.0...package-1@1.1.0) (YYYY-MM-DD)
+
+
+      ### Features
+
+      * **package-1:** Add foo ([SHA](COMMIT_URL))
+
+    `);
+
+    expect(pkg2Changelog).toMatchInlineSnapshot(`
+      # Change Log
+
+      All notable changes to this project will be documented in this file.
+      See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+      ## [2.0.1](/compare/package-2@2.0.0...package-2@2.0.1) (YYYY-MM-DD)
+
+
+      ### Bug Fixes
+
+      * **package-2:** Fix bar ([SHA](COMMIT_URL))
+
+
+
+
+
+      ## [2.0.1-alpha.0](/compare/package-2@2.0.0...package-2@2.0.1-alpha.0) (YYYY-MM-DD)
+
+
+      ### Bug Fixes
+
+      * **package-2:** Fix bar ([SHA](COMMIT_URL))
+
+    `);
+
+    expect(pkg3Changelog).toMatchInlineSnapshot(`
+      # Change Log
+
+      All notable changes to this project will be documented in this file.
+      See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+      # [4.0.0](/compare/package-3@3.0.0...package-3@4.0.0) (YYYY-MM-DD)
+
+
+      ### Features
+
+      * **package-3:** Add baz feature ([SHA](COMMIT_URL))
+
+
+      ### BREAKING CHANGES
+
+      * **package-3:** yup
+
+
+
+
+
+      # [4.0.0-alpha.0](/compare/package-3@3.0.0...package-3@4.0.0-alpha.0) (YYYY-MM-DD)
+
+
+      ### Features
+
+      * **package-3:** Add baz feature ([SHA](COMMIT_URL))
+
+
+      ### BREAKING CHANGES
+
+      * **package-3:** yup
+
+    `);
+
+    expect(pkg5Changelog).toMatchInlineSnapshot(`
+      # Change Log
+
+      All notable changes to this project will be documented in this file.
+      See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+      ## [5.0.1](/compare/package-5@5.0.0...package-5@5.0.1) (YYYY-MM-DD)
+
+      **Note:** Version bump only for package package-5
+
+
+
+
+
+      ## [5.0.1-alpha.0](/compare/package-5@5.0.0...package-5@5.0.1-alpha.0) (YYYY-MM-DD)
+
+      **Note:** Version bump only for package package-5
+
+    `);
+  });
+
+});

--- a/libs/commands/version/README.md
+++ b/libs/commands/version/README.md
@@ -54,6 +54,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--build-metadata <buildMetadata>`](#--build-metadata)
     - [`--changelog-preset`](#--changelog-preset)
     - [`--changelog-entry-additional-markdown`](#--changelog-entry-additional-markdown)
+    - [`--changelog-skip-unstable`](#--changelog-skip-unstable)
     - [`--conventional-commits`](#--conventional-commits)
     - [`--conventional-graduate`](#--conventional-graduate)
     - [`--force-conventional-graduate`](#--force-conventional-graduate)
@@ -202,6 +203,14 @@ If your text is static, and does not change from release to release, you could c
   }
 }
 ```
+
+### `--changelog-skip-unstable`
+
+```sh
+lerna version --conventional-commits --changelog-skip-unstable
+```
+
+This option allows you to optionally skip the changelog entry for prerelease versions (e.g. `1.0.0-alpha.0`). This is useful if you want to keep the changelog clean and only show stable versions.
 
 ### `--conventional-commits`
 

--- a/libs/commands/version/src/command.ts
+++ b/libs/commands/version/src/command.ts
@@ -78,6 +78,10 @@ const command: CommandModule = {
         describe: "Additional markdown to add to CHANGELOG.md entries.",
         type: "string",
       },
+      "changelog-skip-unstable": {
+        describe: "Skip changelog generation for prerelease versions.",
+        type: "boolean",
+      },
       exact: {
         describe: "Specify cross-dependency version numbers exactly rather than with a caret (^).",
         type: "boolean",

--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -89,6 +89,7 @@ interface VersionCommandConfigOptions extends CommandConfigOptions {
   runScriptsOnLockfileUpdate?: boolean;
   changelogPreset?: string;
   changelogEntryAdditionalMarkdown?: string;
+  changelogSkipUnstable?: boolean;
   conventionalBumpPrerelease?: boolean;
   yes?: boolean;
   rejectCycles?: boolean;
@@ -631,6 +632,7 @@ class VersionCommand extends Command {
       conventionalCommits,
       changelogPreset,
       changelogEntryAdditionalMarkdown,
+      changelogSkipUnstable,
       changelog = true,
       runScriptsOnLockfileUpdate = false,
       syncDistVersion = false,
@@ -691,6 +693,7 @@ class VersionCommand extends Command {
         updateChangelog(getPackage(node), type, {
           changelogPreset,
           changelogEntryAdditionalMarkdown,
+          changelogSkipUnstable,
           rootPath,
           tagPrefix: this.tagPrefix,
         }).then(({ logPath, newEntry }) => {
@@ -724,6 +727,7 @@ class VersionCommand extends Command {
         const { logPath, newEntry } = await updateChangelog(this.project.manifest, "root", {
           changelogPreset,
           changelogEntryAdditionalMarkdown,
+          changelogSkipUnstable,
           rootPath,
           tagPrefix: this.tagPrefix,
           version: this.globalVersion,

--- a/libs/commands/version/src/lib/version-conventional-commits.spec.ts
+++ b/libs/commands/version/src/lib/version-conventional-commits.spec.ts
@@ -186,6 +186,22 @@ describe("version --conventional-commits", () => {
       expect(updateChangelog).not.toHaveBeenCalled();
     });
 
+    it("accepts --changelog-skip-unstable option", async () => {
+      const cwd = await initFixture("independent");
+      const changelogOpts = {
+        changelogPreset: "foo-bar",
+        changelogSkipUnstable: true,
+        rootPath: cwd,
+        tagPrefix: "v",
+        prereleaseId: undefined,
+        buildMetadata: undefined
+      };
+
+      await lernaVersion(cwd)("--conventional-commits", "--changelog-preset", "foo-bar", "--changelog-skip-unstable");
+
+      expect(updateChangelog).toHaveBeenCalledWith(expect.any(Object), "independent", changelogOpts);
+    });
+
     it("should respect --no-private", async () => {
       const cwd = await initFixture("independent");
       // TODO: (major) make --no-private the default
@@ -348,6 +364,27 @@ describe("version --conventional-commits", () => {
       await lernaVersion(cwd)("--conventional-commits", "--no-changelog");
 
       expect(updateChangelog).not.toHaveBeenCalled();
+    });
+
+    it("accepts --changelog-skip-unstable option", async () => {
+      const cwd = await initFixture("normal");
+      const changelogOpts = {
+        changelogPreset: "baz-qux",
+        changelogSkipUnstable: true,
+        rootPath: cwd,
+        tagPrefix: "v",
+        prereleaseId: undefined,
+        buildMetadata: undefined
+      };
+
+      await lernaVersion(cwd)(
+        "--conventional-commits",
+        "--changelog-preset",
+        "baz-qux",
+        "--changelog-skip-unstable"
+      );
+
+      expect(updateChangelog).toHaveBeenCalledWith(expect.any(Object), "fixed", changelogOpts);
     });
 
     it("should respect --no-private", async () => {

--- a/libs/core/src/lib/conventional-commits/constants.ts
+++ b/libs/core/src/lib/conventional-commits/constants.ts
@@ -4,6 +4,7 @@ export type ChangelogPresetConfig = string | { name: string; [key: string]: unkn
 export type BaseChangelogOptions = {
   changelogPreset?: ChangelogPresetConfig;
   changelogEntryAdditionalMarkdown?: string;
+  changelogSkipUnstable?: boolean;
   rootPath: string;
   tagPrefix?: string;
   conventionalBumpPrerelease?: boolean;

--- a/libs/core/src/lib/conventional-commits/update-changelog.ts
+++ b/libs/core/src/lib/conventional-commits/update-changelog.ts
@@ -14,6 +14,7 @@ export function updateChangelog(
   {
     changelogPreset,
     changelogEntryAdditionalMarkdown,
+    changelogSkipUnstable,
     rootPath,
     tagPrefix = "v",
     version,
@@ -33,6 +34,8 @@ export function updateChangelog(
       // "old" preset API
       options.config = Object.assign({}, config);
     }
+
+    options.skipUnstable = changelogSkipUnstable;
 
     // NOTE: must pass as positional argument due to weird bug in merge-config
     const gitRawCommitsOpts = Object.assign({}, options.config.gitRawCommitsOpts);

--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -979,6 +979,9 @@
             "changelogEntryAdditionalMarkdown": {
               "$ref": "#/$defs/commandOptions/version/changelogEntryAdditionalMarkdown"
             },
+            "changelogSkipUnstable": {
+              "$ref": "#/$defs/commandOptions/version/changelogSkipUnstable"
+            },
             "exact": {
               "$ref": "#/$defs/commandOptions/shared/exact"
             },
@@ -1689,6 +1692,10 @@
         "changelogEntryAdditionalMarkdown": {
           "type": "string",
           "description": "Additional markdown to add to CHANGELOG.md entries."
+        },
+        "changelogSkipUnstable": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, skip changelog generation for prerelease versions."
         },
         "gitRemote": {
           "type": "string",


### PR DESCRIPTION
## Description

Adds `--changelog-skip-unstable` option that allows to include changelogs from prereleases when publishing a stable release.

## Motivation and Context

fixes: https://github.com/lerna/lerna/issues/3392, https://github.com/lerna/lerna/issues/3119, https://github.com/lerna/lerna/issues/2248

## How Has This Been Tested?

Added unit and integration tests.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
