### PR TITLE
chore(init): use import instead of require

### DIFF
--- a/libs/commands/init/src/command.ts
+++ b/libs/commands/init/src/command.ts
@@ -32,9 +32,8 @@ const command: CommandModule = {
       type: "boolean",
     },
   },
-  handler(argv) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(".")(argv);
+  async handler(argv) {
+    return (await import(".")).factory(argv);
   },
 };
 

--- a/packages/lerna/src/commands/init/command.ts
+++ b/packages/lerna/src/commands/init/command.ts
@@ -1,1 +1,2 @@
-module.exports = require("@lerna/commands/init/command");
+import cmd from "@lerna/commands/init/command";
+module.exports = cmd;

--- a/packages/lerna/src/commands/init/index.ts
+++ b/packages/lerna/src/commands/init/index.ts
@@ -1,5 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const initIndex = require("@lerna/commands/init");
-
-module.exports = initIndex;
-module.exports.InitCommand = initIndex.InitCommand;
+export * from "@lerna/commands/init";


### PR DESCRIPTION
ensures that typechecks are executed for init command during build

## Description
using require does not execute type checks during npx nx run-many -t build --parallel=3

## Motivation and Context
Ensure typechecking during build for libs as well. Remove warnings/errors from eslint regarding require statements

## How Has This Been Tested?
All unit tests and integration tests still pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
