### PR TITLE
chore(list): enable strict type checking

### DIFF
--- a/libs/commands/list/src/command.ts
+++ b/libs/commands/list/src/command.ts
@@ -12,9 +12,8 @@ const command: CommandModule = {
     listableOptions(yargs);
     return filterOptions(yargs);
   },
-  handler(argv) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(".")(argv);
+  async handler(argv) {
+    return (await import(".")).factory(argv);
   },
 };
 

--- a/libs/commands/list/src/index.ts
+++ b/libs/commands/list/src/index.ts
@@ -7,17 +7,14 @@ import {
   output,
 } from "@lerna/core";
 
-module.exports = function factory(argv: Arguments<CommandConfigOptions>) {
+export function factory(argv: Arguments<CommandConfigOptions>) {
   return new ListCommand(argv);
-};
+}
 
-class ListCommand extends Command {
-  // TODO: refactor based on TS feedback
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  private result: { text: string; count: number };
+export class ListCommand extends Command {
+  private result?: { text: string; count: number };
 
-  get requiresGit() {
+  override get requiresGit() {
     return false;
   }
 
@@ -29,17 +26,15 @@ class ListCommand extends Command {
 
   override execute() {
     // piping to `wc -l` should not yield 1 when no packages matched
-    if (this.result.text.length) {
+    if (this.result?.text.length) {
       output(this.result.text);
     }
 
-    this.logger.success(
+    this.logger["success"](
       "found",
       "%d %s",
-      this.result.count,
-      this.result.count === 1 ? "package" : "packages"
+      this.result?.count,
+      this.result?.count === 1 ? "package" : "packages"
     );
   }
 }
-
-module.exports.ListCommand = ListCommand;

--- a/libs/commands/list/tsconfig.json
+++ b/libs/commands/list/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "files": [],
   "include": [],
+  "compilerOptions": {
+    "strict": true
+  },
   "references": [
     {
       "path": "./tsconfig.lib.json"

--- a/packages/lerna/src/commands/list/command.ts
+++ b/packages/lerna/src/commands/list/command.ts
@@ -1,1 +1,2 @@
-module.exports = require("@lerna/commands/list/command");
+import cmd from "@lerna/commands/list/command";
+module.exports = cmd;

--- a/packages/lerna/src/commands/list/index.ts
+++ b/packages/lerna/src/commands/list/index.ts
@@ -1,5 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const listIndex = require("@lerna/commands/list");
-
-module.exports = listIndex;
-module.exports.ListCommand = listIndex.ListCommand;
+export * from "@lerna/commands/list";


### PR DESCRIPTION
remove some ts-ignore. 
Use import instead of require to enable type checks during build

## Motivation and Context
Make list command more typesafe.

## How Has This Been Tested?
All tests still pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
