### PR TITLE
chore(changed): enable strict type checking

### DIFF
--- a/libs/commands/changed/src/command.ts
+++ b/libs/commands/changed/src/command.ts
@@ -49,9 +49,9 @@ const command: CommandModule = {
 
     return listableOptions(yargs, "Output Options:");
   },
-  handler(argv) {
+  async handler(argv) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(".")(argv);
+    return (await import(".")).factory(argv);
   },
 };
 

--- a/libs/commands/changed/src/index.ts
+++ b/libs/commands/changed/src/index.ts
@@ -7,21 +7,21 @@ import {
   output,
 } from "@lerna/core";
 
-module.exports = function factory(argv: Arguments<ChangedCommandOptions>) {
+export function factory(argv: Arguments<ChangedCommandOptions>) {
   return new ChangedCommand(argv);
-};
-
-interface ChangedCommandOptions extends CommandConfigOptions {
-  conventionalCommits: boolean;
-  conventionalGraduate: boolean | string;
-  forceConventionalGraduate: boolean;
-  forcePublish: boolean | string;
 }
 
-class ChangedCommand extends Command<ChangedCommandOptions> {
-  result: ReturnType<typeof listableFormatProjects>;
+interface ChangedCommandOptions extends CommandConfigOptions {
+  conventionalCommits?: boolean;
+  conventionalGraduate?: boolean | string;
+  forceConventionalGraduate?: boolean;
+  forcePublish?: boolean | string;
+}
 
-  get otherCommandConfigs() {
+export class ChangedCommand extends Command<ChangedCommandOptions> {
+  result?: ReturnType<typeof listableFormatProjects>;
+
+  override get otherCommandConfigs() {
     // back-compat
     return ["version", "publish"];
   }
@@ -54,18 +54,17 @@ class ChangedCommand extends Command<ChangedCommandOptions> {
       // prevents execute()
       return false;
     }
+    return true;
   }
 
   override execute() {
-    output(this.result.text);
+    output(this.result?.text);
 
-    this.logger.success(
+    this.logger["success"](
       "found",
       "%d %s ready to publish",
-      this.result.count,
-      this.result.count === 1 ? "package" : "packages"
+      this.result?.count,
+      this.result?.count === 1 ? "package" : "packages"
     );
   }
 }
-
-module.exports.ChangedCommand = ChangedCommand;

--- a/libs/commands/changed/src/lib/changed-command.spec.ts
+++ b/libs/commands/changed/src/lib/changed-command.spec.ts
@@ -35,7 +35,7 @@ expect.addSnapshotSerializer({
 expect.addSnapshotSerializer(tempDirSerializer);
 
 describe("ChangedCommand", () => {
-  let cwd;
+  let cwd = "";
 
   beforeAll(async () => {
     cwd = await initFixture("normal");

--- a/libs/commands/changed/tsconfig.json
+++ b/libs/commands/changed/tsconfig.json
@@ -9,5 +9,11 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
 }

--- a/libs/commands/diff/src/lib/get-last-commit.ts
+++ b/libs/commands/diff/src/lib/get-last-commit.ts
@@ -1,4 +1,4 @@
-import { ExecOpts } from "@lerna/core";
+import { ExecOptions } from "child_process";
 import log from "npmlog";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -7,7 +7,7 @@ const childProcess = require("@lerna/child-process");
 /**
  * @param {import("@lerna/child-process").ExecOpts} execOpts
  */
-export function getLastCommit(execOpts?: ExecOpts) {
+export function getLastCommit(execOpts?: ExecOptions) {
   if (hasTags(execOpts)) {
     log.silly("getLastTagInBranch", "");
     return childProcess.execSync("git", ["describe", "--tags", "--abbrev=0"], execOpts);
@@ -19,7 +19,7 @@ export function getLastCommit(execOpts?: ExecOpts) {
 /**
  * @param {import("@lerna/child-process").ExecOpts} opts
  */
-function hasTags(opts?: ExecOpts) {
+function hasTags(opts?: ExecOptions) {
   let result = false;
 
   try {

--- a/libs/commands/diff/src/lib/has-commit.ts
+++ b/libs/commands/diff/src/lib/has-commit.ts
@@ -1,13 +1,13 @@
 import log from "npmlog";
-import { ExecOpts } from "@lerna/core";
+import { ExecOptions } from "child_process";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const childProcess = require("@lerna/child-process");
 
 /**
- * @param {import("@lerna/child-process").ExecOpts} opts
+ * @param {import("child_process").ExecOptions} opts
  */
-export function hasCommit(opts?: ExecOpts) {
+export function hasCommit(opts?: ExecOptions) {
   log.silly("hasCommit", "");
   let retVal: boolean;
 

--- a/libs/commands/import/src/index.ts
+++ b/libs/commands/import/src/index.ts
@@ -2,11 +2,11 @@ import {
   Arguments,
   Command,
   CommandConfigOptions,
-  ExecOpts,
   promptConfirmation,
   pulseTillDone,
   ValidationError,
 } from "@lerna/core";
+import { ExecOptions } from "child_process";
 import dedent from "dedent";
 import fs from "fs-extra";
 import pMapSeries from "p-map-series";
@@ -28,7 +28,7 @@ interface ImportCommandOptions extends CommandConfigOptions {
 }
 
 export class ImportCommand extends Command<ImportCommandOptions> {
-  private externalExecOpts: ExecOpts = { cwd: "" };
+  private externalExecOpts: ExecOptions = { cwd: "" };
   private targetDirRelativeToGitRoot?: string;
   private commits: string[] = [];
   private origGitEmail?: string;

--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -898,7 +898,11 @@ class VersionCommand extends Command {
 
   private async hasChanges() {
     try {
-      await execa("git", ["diff", "--staged", "--quiet"], { stdio: "pipe", ...this.execOpts });
+      await execa("git", ["diff", "--staged", "--quiet"], {
+        stdio: "pipe",
+        ...this.execOpts,
+        cwd: this.execOpts.cwd as string, // force it to a string
+      });
     } catch (e) {
       // git diff exited with a non-zero exit code, so we assume changes were found
       return true;

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -8,7 +8,7 @@ export {
   collectProjectUpdates,
   collectProjects,
 } from "./lib/collect-updates";
-export { Command, PreInitializedProjectData, ExecOpts, Arguments } from "./lib/command";
+export { Command, PreInitializedProjectData, Arguments } from "./lib/command";
 export { detectProjects } from "./lib/command/detect-projects";
 export { isGitInitialized } from "./lib/command/is-git-initialized";
 export { applyBuildMetadata, recommendVersion, updateChangelog } from "./lib/conventional-commits";

--- a/libs/core/src/lib/check-working-tree.ts
+++ b/libs/core/src/lib/check-working-tree.ts
@@ -5,7 +5,7 @@ import { collectUncommitted } from "./collect-uncommitted";
 import { describeRef } from "./describe-ref";
 import { ValidationError } from "./validation-error";
 
-export function checkWorkingTree({ cwd } = {}) {
+export function checkWorkingTree({ cwd }: { cwd?: string | URL } = {}) {
   let chain = Promise.resolve();
 
   chain = chain.then(() => describeRef({ cwd }));

--- a/libs/core/src/lib/command/index.ts
+++ b/libs/core/src/lib/command/index.ts
@@ -15,6 +15,7 @@ import { isGitInitialized } from "./is-git-initialized";
 import { logPackageError } from "./log-package-error";
 import { warnIfHanging } from "./warn-if-hanging";
 import yargs from "yargs";
+import { ExecOptions } from "child_process";
 
 const DEFAULT_CONCURRENCY = os.cpus().length;
 
@@ -22,11 +23,6 @@ export interface PreInitializedProjectData {
   projectFileMap: ProjectFileMap;
   projectGraph: ProjectGraphWithPackages;
 }
-
-export type ExecOpts = {
-  cwd: string;
-  maxBuffer?: number;
-};
 
 export type Arguments<T extends CommandConfigOptions = CommandConfigOptions> = {
   cwd?: string;
@@ -43,7 +39,7 @@ export class Command<T extends CommandConfigOptions = CommandConfigOptions> {
   runner: Promise<unknown>;
   concurrency?: number;
   toposort = false;
-  execOpts?: ExecOpts;
+  execOpts: ExecOptions = {};
   logger!: log.Logger;
   envDefaults: any;
   argv: Arguments<T> = {} as Arguments<T>;
@@ -211,7 +207,7 @@ export class Command<T extends CommandConfigOptions = CommandConfigOptions> {
 
   // Override this to inherit config from another command.
   // For example `changed` inherits config from `publish`.
-  get otherCommandConfigs() {
+  get otherCommandConfigs(): string[] {
     return [];
   }
 

--- a/libs/core/src/lib/describe-ref.ts
+++ b/libs/core/src/lib/describe-ref.ts
@@ -4,7 +4,7 @@ const childProcess = require("@lerna/child-process");
 
 interface DescribeRefOptions {
   // Defaults to `process.cwd()`
-  cwd?: string;
+  cwd?: string | URL;
   // Glob passed to `--match` flag
   match?: string;
 }

--- a/packages/lerna/src/commands/changed/command.ts
+++ b/packages/lerna/src/commands/changed/command.ts
@@ -1,1 +1,2 @@
-module.exports = require("@lerna/commands/changed/command");
+import cmd from "@lerna/commands/changed/command";
+module.exports = cmd;

--- a/packages/lerna/src/commands/changed/index.ts
+++ b/packages/lerna/src/commands/changed/index.ts
@@ -1,5 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const changedIndex = require("@lerna/commands/changed");
-
-module.exports = changedIndex;
-module.exports.ChangedCommand = changedIndex.ChangedCommand;
+export * from "@lerna/commands/changed";


### PR DESCRIPTION
remove some ts-ignore. 
Use import instead of require to enable type checks during build

## Motivation and Context
Make changed command more typesafe.

## How Has This Been Tested?
All tests still pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
