### PR TITLE
chore(exec): enable strict type checking

### DIFF
--- a/libs/commands/exec/src/command.ts
+++ b/libs/commands/exec/src/command.ts
@@ -1,5 +1,6 @@
 import { filterOptions } from "@lerna/core";
 import type { CommandModule } from "yargs";
+import { factory } from "./index";
 
 /**
  * @see https://github.com/yargs/yargs/blob/master/docs/advanced.md#providing-a-command-module
@@ -69,9 +70,8 @@ const command: CommandModule = {
 
     return filterOptions(yargs);
   },
-  handler(argv) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(".")(argv);
+  async handler(argv) {
+    return factory(argv);
   },
 };
 

--- a/libs/commands/exec/src/lib/exec-command.spec.ts
+++ b/libs/commands/exec/src/lib/exec-command.spec.ts
@@ -1,3 +1,4 @@
+import { Package } from "@lerna/core";
 import { commandRunner, initFixtureFactory, loggingOutput, normalizeRelativeDir } from "@lerna/test-helpers";
 import fs from "fs-extra";
 import globby from "globby";
@@ -14,14 +15,20 @@ const childProcess = require("@lerna/child-process");
 const lernaExec = commandRunner(require("../command"));
 
 // assertion helpers
-const calledInPackages = () => childProcess.spawn.mock.calls.map(([, , opts]) => path.basename(opts.cwd));
+const calledInPackages = () =>
+  childProcess.spawn.mock.calls.map(([, , opts]: [string, string, { cwd: string }]) =>
+    path.basename(opts.cwd)
+  );
 
-const execInPackagesStreaming = (testDir) =>
-  childProcess.spawnStreaming.mock.calls.reduce((arr, [command, params, opts, prefix]) => {
-    const dir = normalizeRelativeDir(testDir, opts.cwd);
-    arr.push([dir, command, `(prefix: ${prefix})`].concat(params).join(" "));
-    return arr;
-  }, []);
+const execInPackagesStreaming = (testDir: string) =>
+  childProcess.spawnStreaming.mock.calls.reduce(
+    (arr: string[], [command, params, opts, prefix]: [string, string[], { cwd: string }, string]) => {
+      const dir = normalizeRelativeDir(testDir, opts.cwd);
+      arr.push([dir, command, `(prefix: ${prefix})`].concat(params).join(" "));
+      return arr;
+    },
+    []
+  );
 
 describe("ExecCommand", () => {
   // TODO: it's very suspicious that mockResolvedValue() doesn't work here
@@ -34,7 +41,7 @@ describe("ExecCommand", () => {
 
   describe("in a basic repo", () => {
     // working dir is never mutated
-    let testDir;
+    let testDir: string;
 
     beforeAll(async () => {
       testDir = await initFixture("basic");
@@ -47,7 +54,7 @@ describe("ExecCommand", () => {
     });
 
     it("rejects with execution error", async () => {
-      childProcess.spawn.mockImplementationOnce((cmd, args) => {
+      childProcess.spawn.mockImplementationOnce((cmd: string, args: string[]) => {
         const boom = new Error("execution error") as any;
 
         boom.failed = true;
@@ -69,7 +76,7 @@ describe("ExecCommand", () => {
     });
 
     it("should ignore execution errors with --no-bail", async () => {
-      childProcess.spawn.mockImplementationOnce((cmd, args, { pkg }) => {
+      childProcess.spawn.mockImplementationOnce((cmd: string, args: string[], { pkg }: { pkg: Package }) => {
         const boom = new Error(pkg.name) as any;
 
         boom.failed = true;

--- a/libs/commands/exec/tsconfig.json
+++ b/libs/commands/exec/tsconfig.json
@@ -9,5 +9,11 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
 }

--- a/libs/core/src/lib/command/index.ts
+++ b/libs/core/src/lib/command/index.ts
@@ -49,7 +49,7 @@ export class Command<T extends CommandConfigOptions = CommandConfigOptions> {
   composed: boolean;
   options: T = {} as T;
   runner: Promise<unknown>;
-  concurrency?: number;
+  concurrency = 0;
   toposort = false;
   execOpts: ExecOptions = {};
   logger!: LernaLogger;

--- a/packages/lerna/src/commands/exec/command.ts
+++ b/packages/lerna/src/commands/exec/command.ts
@@ -1,1 +1,2 @@
-module.exports = require("@lerna/commands/exec/command");
+import cmd from "@lerna/commands/exec/command";
+module.exports = cmd;

--- a/packages/lerna/src/commands/exec/index.ts
+++ b/packages/lerna/src/commands/exec/index.ts
@@ -1,5 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const execIndex = require("@lerna/commands/exec");
-
-module.exports = execIndex;
-module.exports.ExecCommand = execIndex.ExecCommand;
+export * from "@lerna/commands/exec";


### PR DESCRIPTION
updated ts-config to enable strict type checking
Use import instead of require to enable type checks during build

## Motivation and Context
Make exec command more typesafe.

## How Has This Been Tested?
All tests still pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

