### PR TITLE
chore(run): enable strict type checking

### DIFF
--- a/libs/commands/run/src/command.ts
+++ b/libs/commands/run/src/command.ts
@@ -1,10 +1,11 @@
 import { filterOptions } from "@lerna/core";
 import type { CommandModule } from "yargs";
+import { RunCommandConfigOptions } from ".";
 
 /**
  * @see https://github.com/yargs/yargs/blob/master/docs/advanced.md#providing-a-command-module
  */
-const command: CommandModule = {
+const command: CommandModule<object, RunCommandConfigOptions> = {
   command: "run <script>",
   describe: "Run an npm script in each package that contains that script",
   builder(yargs) {
@@ -93,11 +94,10 @@ const command: CommandModule = {
         },
       });
 
-    return filterOptions(yargs);
+    return filterOptions<RunCommandConfigOptions>(yargs);
   },
-  handler(argv) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(".")(argv);
+  async handler(argv) {
+    return (await import(".")).factory(argv);
   },
 };
 

--- a/libs/commands/run/src/lib/run-command.spec.ts
+++ b/libs/commands/run/src/lib/run-command.spec.ts
@@ -1,4 +1,5 @@
 import {
+  Package,
   npmRunScript as _npmRunScript,
   npmRunScriptStreaming as _npmRunScriptStreaming,
   output as _output,
@@ -26,16 +27,27 @@ const npmRunScript = _npmRunScript as any;
 const npmRunScriptStreaming = _npmRunScriptStreaming as any;
 
 // assertion helpers
-const ranInPackagesStreaming = (testDir) =>
-  npmRunScriptStreaming.mock.calls.reduce((arr, [script, { args, npmClient, pkg, prefix }]) => {
-    const dir = normalizeRelativeDir(testDir, pkg.location);
-    const record = [dir, npmClient, "run", script, `(prefixed: ${prefix})`].concat(args);
-    arr.push(record.join(" "));
-    return arr;
-  }, []);
+const ranInPackagesStreaming = (testDir: string) =>
+  npmRunScriptStreaming.mock.calls.reduce(
+    (
+      arr: string[],
+      [script, { args, npmClient, pkg, prefix }]: [
+        string,
+        { args: string[]; npmClient: string; pkg: Package; prefix: string }
+      ]
+    ) => {
+      const dir = normalizeRelativeDir(testDir, pkg.location);
+      const record = [dir, npmClient, "run", script, `(prefixed: ${prefix})`].concat(args);
+      arr.push(record.join(" "));
+      return arr;
+    },
+    []
+  );
 
 describe("RunCommand", () => {
-  npmRunScript.mockImplementation((script, { pkg }) => Promise.resolve({ exitCode: 0, stdout: pkg.name }));
+  npmRunScript.mockImplementation((script: string, { pkg }: { pkg: Package }) =>
+    Promise.resolve({ exitCode: 0, stdout: pkg.name })
+  );
   npmRunScriptStreaming.mockImplementation(() => Promise.resolve({ exitCode: 0 }));
 
   afterEach(() => {
@@ -44,7 +56,7 @@ describe("RunCommand", () => {
 
   describe("in a basic repo", () => {
     // working dir is never mutated
-    let testDir;
+    let testDir: string;
 
     beforeAll(async () => {
       testDir = await initFixture("basic");
@@ -129,7 +141,7 @@ describe("RunCommand", () => {
     });
 
     it("reports script errors with early exit", async () => {
-      npmRunScript.mockImplementationOnce((script, { pkg }) => {
+      npmRunScript.mockImplementationOnce((_script: string, { pkg }: { pkg: Package }) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const err = new Error(pkg.name) as any;
 
@@ -146,7 +158,7 @@ describe("RunCommand", () => {
     });
 
     it("propagates non-zero exit codes with --no-bail", async () => {
-      npmRunScript.mockImplementationOnce((script, { pkg }) => {
+      npmRunScript.mockImplementationOnce((_script: string, { pkg }: { pkg: Package }) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const err = new Error(pkg.name) as any;
 

--- a/libs/commands/run/tsconfig.json
+++ b/libs/commands/run/tsconfig.json
@@ -9,5 +9,11 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
 }

--- a/libs/core/src/lib/filter-options.ts
+++ b/libs/core/src/lib/filter-options.ts
@@ -1,10 +1,11 @@
 import dedent from "dedent";
 import log from "npmlog";
-import { Argv } from "yargs";
+import { Argv, Options } from "yargs";
 
-export function filterOptions(yargs: Argv) {
+export function filterOptions<T extends FilterOptions>(yargs: Argv<object>): Argv<T> {
   // Only for 'run', 'exec', 'clean', 'ls', and 'bootstrap' commands
-  const opts = {
+
+  const opts: { [name: string]: Options } = {
     scope: {
       describe: "Include only packages with names matching the given glob.",
       type: "string",
@@ -65,49 +66,44 @@ export function filterOptions(yargs: Argv) {
     },
   };
 
-  return (
-    yargs
-      // TODO: refactor to address type issues
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      .options(opts)
-      .group(Object.keys(opts), "Filter Options:")
-      .option("include-filtered-dependents", {
-        // TODO: remove in next major release
-        hidden: true,
-        conflicts: ["exclude-dependents", "include-dependents"],
-        type: "boolean",
-      })
-      .option("include-filtered-dependencies", {
-        // TODO: remove in next major release
-        hidden: true,
-        conflicts: "include-dependencies",
-        type: "boolean",
-      })
-      .check((argv) => {
-        /* eslint-disable no-param-reassign */
-        if (argv["includeFilteredDependents"]) {
-          argv["includeDependents"] = true;
-          argv["include-dependents"] = true;
-          delete argv["includeFilteredDependents"];
-          delete argv["include-filtered-dependents"];
-          log.warn("deprecated", "--include-filtered-dependents has been renamed --include-dependents");
-        }
+  return yargs
 
-        if (argv["includeFilteredDependencies"]) {
-          argv["includeDependencies"] = true;
-          argv["include-dependencies"] = true;
-          delete argv["includeFilteredDependencies"];
-          delete argv["include-filtered-dependencies"];
-          log.warn("deprecated", "--include-filtered-dependencies has been renamed --include-dependencies");
-        }
-        /* eslint-enable no-param-reassign */
+    .options(opts)
+    .group(Object.keys(opts), "Filter Options:")
+    .option("include-filtered-dependents", {
+      // TODO: remove in next major release
+      hidden: true,
+      conflicts: ["exclude-dependents", "include-dependents"],
+      type: "boolean",
+    })
+    .option("include-filtered-dependencies", {
+      // TODO: remove in next major release
+      hidden: true,
+      conflicts: "include-dependencies",
+      type: "boolean",
+    })
+    .check((argv) => {
+      /* eslint-disable no-param-reassign */
+      if (argv["includeFilteredDependents"]) {
+        argv["includeDependents"] = true;
+        argv["include-dependents"] = true;
+        delete argv["includeFilteredDependents"];
+        delete argv["include-filtered-dependents"];
+        log.warn("deprecated", "--include-filtered-dependents has been renamed --include-dependents");
+      }
 
-        return argv;
-      })
-  );
+      if (argv["includeFilteredDependencies"]) {
+        argv["includeDependencies"] = true;
+        argv["include-dependencies"] = true;
+        delete argv["includeFilteredDependencies"];
+        delete argv["include-filtered-dependencies"];
+        log.warn("deprecated", "--include-filtered-dependencies has been renamed --include-dependencies");
+      }
+      /* eslint-enable no-param-reassign */
+
+      return argv;
+    }) as Argv<T>;
 }
-
 export interface FilterOptions {
   scope?: string;
   ignore?: string;

--- a/packages/lerna/src/commands/run/command.ts
+++ b/packages/lerna/src/commands/run/command.ts
@@ -1,1 +1,2 @@
-module.exports = require("@lerna/commands/run/command");
+import cmd from "@lerna/commands/run/command";
+module.exports = cmd;

--- a/packages/lerna/src/commands/run/index.ts
+++ b/packages/lerna/src/commands/run/index.ts
@@ -1,5 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const runIndex = require("@lerna/commands/run");
-
-module.exports = runIndex;
-module.exports.RunCommand = runIndex.RunCommand;
+export * from "@lerna/commands/run";


### PR DESCRIPTION
Update ts-config to enable strict type checking
Use import instead of require to enable type checks during build
Remove some ts-ignore comments

## Motivation and Context
Make run command more typesafe.

## How Has This Been Tested?
All tests still pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.