### PR TITLE
fix(version): create correct independent tags when using --sign-git-tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Generate and configure GPG for signing commits and tags in E2E tests
         run: |
-          # Generate a PGP key for test@example.com and store the output from stderr
+          # Generate a GPG key for test@example.com and store the output from stderr
           GPG_OUTPUT=$(echo "Key-Type: default
           Key-Length: 2048
           Subkey-Type: default
@@ -81,7 +81,7 @@ jobs:
           # Find and extract the revocation file path from sdterr
           REVOCATION_FILE=$(echo "$GPG_OUTPUT" | grep '.rev' | tr '\n' ' ' | awk -F "'" '{print $4}')
 
-          # Get the PGP key ID and the full fingerprint
+          # Get the GPG key ID and the full fingerprint
           export GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)
           export GPG_FULL_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep "$GPG_KEY_ID" | grep -v "sec" | awk '{print $1}' | cut -d'/' -f2)
 
@@ -104,8 +104,10 @@ jobs:
           NX_AGENT_NAME: ${{ matrix.agent }}
 
       - name: Revoke and delete GPG key
+        # It's important that we always run this step, otherwise the key will remain active if any of the steps above fail
+        if: ${{ always() }}
         run: |
-          # As instructed in the revocation file, the colon needs to first be removed
+          # As instructed in the text of revocation file, there is a colon that needs to be removed manually
           sed -i "s/:-----BEGIN PGP PUBLIC KEY BLOCK-----/-----BEGIN PGP PUBLIC KEY BLOCK-----/" $REVOCATION_FILE
 
           # Revoke the key and delete it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,35 @@ jobs:
           git config --global user.email test@example.com
           git config --global user.name "Tester McPerson"
 
+      - name: Generate and configure GPG for signing commits and tags in E2E tests
+        run: |
+          # Generate a PGP key for test@example.com and store the output from stderr
+          GPG_OUTPUT=$(echo "Key-Type: default
+          Key-Length: 2048
+          Subkey-Type: default
+          Subkey-Length: 2048
+          Name-Real: Tester McPerson
+          Name-Email: test@example.com
+          Expire-Date: 0
+          %no-protection" | gpg --pinentry-mode loopback --batch --generate-key 2>&1)
+
+          # Find and extract the revocation file path from sdterr
+          REVOCATION_FILE=$(echo "$GPG_OUTPUT" | grep '.rev' | tr '\n' ' ' | awk -F "'" '{print $4}')
+
+          # Get the PGP key ID and the full fingerprint
+          export GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)
+          export GPG_FULL_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep "$GPG_KEY_ID" | grep -v "sec" | awk '{print $1}' | cut -d'/' -f2)
+
+          # Export fingerprint and the path to the revocation file to GITHUB_ENV
+          # This allows the last step in this job to revoke and delete the key
+          echo "GPG_FULL_KEY_ID=$GPG_FULL_KEY_ID" >> $GITHUB_ENV
+          echo "REVOCATION_FILE=$REVOCATION_FILE" >> $GITHUB_ENV
+
+          # Setup git signing for commits and tags
+          git config commit.gpgsign true
+          git config tag.gpgsign true
+          git config --global user.signingkey $GPG_KEY_ID
+
       - name: Install primary node version (see volta config in package.json) and dependencies
         uses: ./.github/actions/install-node-and-dependencies
 
@@ -73,6 +102,15 @@ jobs:
         run: npx nx-cloud start-agent
         env:
           NX_AGENT_NAME: ${{ matrix.agent }}
+
+      - name: Revoke and delete GPG key
+        run: |
+          # As instructed in the revocation file, the colon needs to first be removed
+          sed -i "s/:-----BEGIN PGP PUBLIC KEY BLOCK-----/-----BEGIN PGP PUBLIC KEY BLOCK-----/" $REVOCATION_FILE
+
+          # Revoke the key and delete it
+          gpg --yes --import $REVOCATION_FILE
+          gpg --batch --yes --delete-secret-and-public-key $GPG_FULL_KEY_ID
 
   windows-main:
     name: Nx Cloud - Windows Main Job

--- a/e2e/version/src/sign-git-tag.spec.ts
+++ b/e2e/version/src/sign-git-tag.spec.ts
@@ -1,0 +1,285 @@
+import { Fixture, normalizeCommitSHAs, normalizeEnvironment } from "@lerna/e2e-utils";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommitSHAs(normalizeEnvironment(str));
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-version-sign-git-tag", () => {
+  describe("single package", () => {
+    let fixture: Fixture;
+
+    beforeEach(async () => {
+      fixture = await Fixture.create({
+        e2eRoot: process.env.E2E_ROOT,
+        name: "lerna-version-sign-git-tag",
+        packageManager: "npm",
+        initializeGit: true,
+        lernaInit: { args: [`--packages="packages/*"`] },
+        installDependencies: true,
+      });
+      await fixture.lerna("create package-a -y");
+      await fixture.createInitialGitCommit();
+      await fixture.exec("git push origin test-main");
+    });
+    afterEach(() => fixture.destroy());
+
+    it("should create tags that match version when not using --sign-git-tag", async () => {
+      const output = await fixture.lerna("version 3.3.3 -y");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna info current version 0.0.0
+        lerna info Assuming all packages changed
+
+        Changes:
+         - package-a: 0.0.0 => 3.3.3
+
+        lerna info auto-confirmed 
+        lerna info execute Skipping releases
+        lerna info git Pushing tags...
+        lerna success version finished
+
+      `);
+
+      const checkTagIsPresentLocally = await fixture.exec("git describe --abbrev=0");
+
+      expect(checkTagIsPresentLocally.combinedOutput).toMatchInlineSnapshot(`
+        v3.3.3
+
+      `);
+
+      const checkTagIsPresentOnRemote = await fixture.exec("git ls-remote origin refs/tags/v3.3.3");
+
+      expect(checkTagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/v3.3.3
+
+      `);
+    });
+
+    it("should create tags that match version when using --sign-git-tag", async () => {
+      const output = await fixture.lerna("version 3.4.5 --sign-git-tag -y");
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna info current version 0.0.0
+        lerna info Assuming all packages changed
+
+        Changes:
+         - package-a: 0.0.0 => 3.4.5
+
+        lerna info auto-confirmed 
+        lerna info execute Skipping releases
+        lerna info git Pushing tags...
+        lerna success version finished
+
+      `);
+
+      const checkTagIsPresentLocally = await fixture.exec("git describe --abbrev=0");
+      expect(checkTagIsPresentLocally.combinedOutput).toMatchInlineSnapshot(`
+        v3.4.5
+
+      `);
+
+      const checkTagIsPresentOnRemote = await fixture.exec("git ls-remote origin refs/tags/v3.4.5");
+      expect(checkTagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/v3.4.5
+
+      `);
+    });
+  });
+
+  describe("multiple packages", () => {
+    let fixture: Fixture;
+
+    beforeEach(async () => {
+      fixture = await Fixture.create({
+        e2eRoot: process.env.E2E_ROOT,
+        name: "lerna-version-sign-git-tag-multiple-packages",
+        packageManager: "npm",
+        initializeGit: true,
+        lernaInit: { args: [`--packages="packages/*"`] },
+        installDependencies: true,
+      });
+      await fixture.lerna("create package-a -y");
+      await fixture.lerna("create package-b -y");
+      await fixture.createInitialGitCommit();
+      await fixture.exec("git push origin test-main");
+    });
+    afterEach(() => fixture.destroy());
+
+    it("should create tags that match version when not using --sign-git-tag", async () => {
+      const output = await fixture.lerna("version 3.3.3 -y");
+
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna info current version 0.0.0
+        lerna info Assuming all packages changed
+
+        Changes:
+         - package-a: 0.0.0 => 3.3.3
+         - package-b: 0.0.0 => 3.3.3
+
+        lerna info auto-confirmed 
+        lerna info execute Skipping releases
+        lerna info git Pushing tags...
+        lerna success version finished
+
+      `);
+
+      const checkTagIsPresentLocally = await fixture.exec("git describe --abbrev=0");
+
+      expect(checkTagIsPresentLocally.combinedOutput).toMatchInlineSnapshot(`
+        v3.3.3
+
+      `);
+
+      const checkTagIsPresentOnRemote = await fixture.exec("git ls-remote origin refs/tags/v3.3.3");
+
+      expect(checkTagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/v3.3.3
+
+      `);
+    });
+
+    it("should create tags that match version when using --sign-git-tag", async () => {
+      const output = await fixture.lerna("version 3.4.5 --sign-git-tag -y");
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna info current version 0.0.0
+        lerna info Assuming all packages changed
+
+        Changes:
+         - package-a: 0.0.0 => 3.4.5
+         - package-b: 0.0.0 => 3.4.5
+
+        lerna info auto-confirmed 
+        lerna info execute Skipping releases
+        lerna info git Pushing tags...
+        lerna success version finished
+
+      `);
+
+      const checkTagIsPresentLocally = await fixture.exec("git describe --abbrev=0");
+      expect(checkTagIsPresentLocally.combinedOutput).toMatchInlineSnapshot(`
+        v3.4.5
+
+      `);
+
+      const checkTagIsPresentOnRemote = await fixture.exec("git ls-remote origin refs/tags/v3.4.5");
+      expect(checkTagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/v3.4.5
+
+      `);
+    });
+  });
+
+  describe("independent packages", () => {
+    let fixture: Fixture;
+
+    beforeEach(async () => {
+      fixture = await Fixture.create({
+        e2eRoot: process.env.E2E_ROOT,
+        name: "lerna-version-sign-git-tag-multiple-packages",
+        packageManager: "npm",
+        initializeGit: true,
+        lernaInit: { args: [`--packages="packages/*" --independent`] },
+        installDependencies: true,
+      });
+      await fixture.lerna("create package-a -y");
+      await fixture.lerna("create package-b -y");
+      await fixture.createInitialGitCommit();
+      await fixture.exec("git push origin test-main");
+    });
+    afterEach(() => fixture.destroy());
+
+    it("should create tags that match version when not using --sign-git-tag", async () => {
+      const output = await fixture.lerna("version 3.3.3 -y");
+
+      // NOTE: In the independent case, lerna started with version 1.0.0 as its assumed baseline (not 0.0.0 as in the fixed mode case)
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna info versioning independent
+        lerna info Assuming all packages changed
+
+        Changes:
+         - package-a: 1.0.0 => 3.3.3
+         - package-b: 1.0.0 => 3.3.3
+
+        lerna info auto-confirmed 
+        lerna info execute Skipping releases
+        lerna info git Pushing tags...
+        lerna success version finished
+
+      `);
+
+      // It should create one tag for each independently versioned package
+      const checkPackageTagsArePresentLocally = await fixture.exec("git describe --abbrev=0");
+      expect(checkPackageTagsArePresentLocally.combinedOutput).toMatchInlineSnapshot(`
+        package-a@3.3.3
+
+      `);
+
+      const checkPackageATagIsPresentOnRemote = await fixture.exec(
+        "git ls-remote origin refs/tags/package-a@3.3.3"
+      );
+      expect(checkPackageATagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/package-a@3.3.3
+
+      `);
+      const checkPackageBTagIsPresentOnRemote = await fixture.exec(
+        "git ls-remote origin refs/tags/package-b@3.3.3"
+      );
+      expect(checkPackageBTagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/package-b@3.3.3
+
+      `);
+    });
+
+    it("should create tags that match version when using --sign-git-tag", async () => {
+      const output = await fixture.lerna("version 3.4.5 --sign-git-tag -y");
+
+      // NOTE: In the independent case, lerna started with version 1.0.0 as its assumed baseline (not 0.0.0 as in the fixed mode case)
+      expect(output.combinedOutput).toMatchInlineSnapshot(`
+        lerna notice cli v999.9.9-e2e.0
+        lerna info versioning independent
+        lerna info Assuming all packages changed
+
+        Changes:
+         - package-a: 1.0.0 => 3.4.5
+         - package-b: 1.0.0 => 3.4.5
+
+        lerna info auto-confirmed 
+        lerna info execute Skipping releases
+        lerna info git Pushing tags...
+        lerna success version finished
+
+      `);
+
+      // It should create one tag for each independently versioned package
+      const checkPackageTagsArePresentLocally = await fixture.exec("git describe --abbrev=0");
+      expect(checkPackageTagsArePresentLocally.combinedOutput).toMatchInlineSnapshot(`
+        package-a@3.4.5
+
+      `);
+
+      const checkPackageATagIsPresentOnRemote = await fixture.exec(
+        "git ls-remote origin refs/tags/package-a@3.4.5"
+      );
+      expect(checkPackageATagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/package-a@3.4.5
+
+      `);
+      const checkPackageBTagIsPresentOnRemote = await fixture.exec(
+        "git ls-remote origin refs/tags/package-b@3.4.5"
+      );
+      expect(checkPackageBTagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/package-b@3.4.5
+
+      `);
+    });
+  });
+});

--- a/e2e/version/src/sign-git-tag.spec.ts
+++ b/e2e/version/src/sign-git-tag.spec.ts
@@ -14,7 +14,7 @@ expect.addSnapshotSerializer({
  * The reason is that using the `--sign-git-tag` flag requires a GPG key to be present on the machine,
  * which is not a guarantee in a local development environment.
  */
-const describeFunc = process.env.CI === 'true' ? describe : describe.skip;
+const describeFunc = process.env.CI === "true" ? describe : describe.skip;
 
 describeFunc("lerna-version-sign-git-tag", () => {
   describe("single package", () => {

--- a/e2e/version/src/sign-git-tag.spec.ts
+++ b/e2e/version/src/sign-git-tag.spec.ts
@@ -9,7 +9,14 @@ expect.addSnapshotSerializer({
   },
 });
 
-describe("lerna-version-sign-git-tag", () => {
+/**
+ * NOTE: This test suite should only execute in CI/CD.
+ * The reason is that using the `--sign-git-tag` flag requires a GPG key to be present on the machine,
+ * which is not a guarantee in a local development environment.
+ */
+const describeFunc = process.env.CI === 'true' ? describe : describe.skip;
+
+describeFunc("lerna-version-sign-git-tag", () => {
   describe("single package", () => {
     let fixture: Fixture;
 

--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -875,7 +875,7 @@ class VersionCommand extends Command {
       await gitCommit(message, this.gitOpts, this.execOpts);
     }
     if (this.gitOpts.signGitTag) {
-      for (const tag in tags) await gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand);
+      for (const tag of tags) await gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand);
     } else {
       await Promise.all(
         tags.map((tag) => gitTag(tag, this.gitOpts, this.execOpts, this.options.gitTagCommand))


### PR DESCRIPTION
Since `lerna@7.3.0`, running `lerna version` with independent versioning and the `--sign-git-tag` flag would always create `0`, `1`, ... `N` as tags instead of the actual version.

## Description

A recent fix done in #3832 introduced a new issue. In TypeScript, `for (const tag in tags)` would iterate through the array of tags. However, `for...in` returns a list of keys on the `tags` object, meaning that it iterates through the indices of the array, rather than the values. This means that regardless of what version number we are creating a tag for, that value will never be used - its index in the `tags` array will be used instead.

The issue is a bit niche, as it only happens when the repo is configured to use `independent` versioning and the `--sign-git-tag` flag is used.

## Motivation and Context

This is an issue because your project might have a specific version (e.g. `1.0.0`), but `lerna version` will create the tag `0` for it. This is especially crucial when using `--conventional-commits`, as that flag uses the latest tag in order to evaluate the next version bump.

The issue is described in more detail in #3916.

## How Has This Been Tested?
For this fix, I wrote some E2E tests in `e2e/version/src/sign-git-tag.spec.ts` that bump the version and use the `--sign-git-tag` flag. You can see the tests [failing](https://github.com/ivml/lerna/actions/runs/7131053286/job/19418821077#step:6:796) when using `for...in`, but [pass](https://github.com/ivml/lerna/actions/runs/7131253669/job/19419414299) when using `for...of`.

Things get a bit interesting - since the E2E tests run actual `git` commands, the tests need a GPG key, otherwise they will fail. For this reason, I have changed the `ci.yml` workflow to generate a GPG key, store its ID and revocation file, configure git to use the key, and finally, revoke and delete the key after the tests pass.

I have a feeling this might be overkill, and it probably makes testing locally harder, as it implies the user has setup a key themselves.

Therefore, **I would love some feedback on the tests** - whether it was a good idea, whether the implementation was overkill (especially for a one-word change), and whether there are alternatives (e.g. mocking git signing somehow).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
