### PR TITLE
feat(version): custom tag-version-separator for independent projects

### DIFF
--- a/e2e/version/src/tag-version-separator.spec.ts
+++ b/e2e/version/src/tag-version-separator.spec.ts
@@ -1,0 +1,92 @@
+import { Fixture, normalizeCommitSHAs, normalizeEnvironment } from "@lerna/e2e-utils";
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return normalizeCommitSHAs(normalizeEnvironment(str));
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-version-tag-version-separator qqqq", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-version-tag-version-separator",
+      packageManager: "npm",
+      initializeGit: true,
+      lernaInit: { args: [`--packages="packages/*" --independent`] },
+      installDependencies: true,
+    });
+    await fixture.lerna("create package-a -y");
+    await fixture.lerna("create package-b -y");
+    await fixture.updateJson("lerna.json", (json) => ({
+      ...json,
+      command: {
+        version: {
+          tagVersionSeparator: "__",
+        },
+      },
+    }));
+    await fixture.createInitialGitCommit();
+    await fixture.exec("git push origin test-main");
+  });
+  afterEach(() => fixture.destroy());
+
+  it("should create and read tags based on the custom tag-version-separator", async () => {
+    await fixture.lerna("version 3.3.3 -y");
+
+    // It should create one tag for each independently versioned package using the custom separator
+    const checkPackageTagsArePresentLocally = await fixture.exec("git describe --abbrev=0");
+    expect(checkPackageTagsArePresentLocally.combinedOutput).toMatchInlineSnapshot(`
+        package-a__3.3.3
+
+      `);
+
+    const checkPackageATagIsPresentOnRemote = await fixture.exec(
+      "git ls-remote origin refs/tags/package-a__3.3.3"
+    );
+    expect(checkPackageATagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/package-a__3.3.3
+
+      `);
+    const checkPackageBTagIsPresentOnRemote = await fixture.exec(
+      "git ls-remote origin refs/tags/package-b__3.3.3"
+    );
+    expect(checkPackageBTagIsPresentOnRemote.combinedOutput).toMatchInlineSnapshot(`
+        {FULL_COMMIT_SHA}	refs/tags/package-b__3.3.3
+
+      `);
+
+    // Update package-a and version using conventional commits (to read from the tag)
+    await fixture.updateJson("packages/package-a/package.json", (json) => {
+      return {
+        ...json,
+        description: json.description + "...with an update!",
+      };
+    });
+    await fixture.exec("git add packages/package-a/package.json");
+    await fixture.exec("git commit -m 'feat: update package-a'");
+    await fixture.exec("git push origin test-main");
+
+    const output = await fixture.lerna("version --conventional-commits -y", { silenceError: true });
+    expect(output.combinedOutput).toMatchInlineSnapshot(`
+      lerna notice cli v999.9.9-e2e.0
+      lerna info versioning independent
+      lerna info Looking for changed packages since package-a__3.3.3
+      lerna info getChangelogConfig Successfully resolved preset "conventional-changelog-angular"
+
+      Changes:
+       - package-a: 3.3.3 => 3.4.0
+
+      lerna info auto-confirmed 
+      lerna info execute Skipping releases
+      lerna info git Pushing tags...
+      lerna success version finished
+
+    `);
+  });
+});

--- a/libs/commands/version/src/command.ts
+++ b/libs/commands/version/src/command.ts
@@ -212,6 +212,12 @@ const command: CommandModule = {
         requiresArg: true,
         defaultDescription: "v",
       },
+      "tag-version-separator": {
+        describe: "Customize the tag version separator used when creating tags for independent versioning.",
+        type: "string",
+        requiresArg: true,
+        defaultDescription: "@",
+      },
       "git-tag-command": {
         describe:
           "Allows users to specify a custom command to be used when applying git tags. For example, this may be useful for providing a wrapper command in CI/CD pipelines that have no direct write access.",

--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -75,6 +75,7 @@ interface VersionCommandConfigOptions extends CommandConfigOptions {
   signGitTag?: boolean;
   forceGitTag?: boolean;
   tagVersionPrefix?: string;
+  tagVersionSeparator?: string;
   createRelease?: "github" | "gitlab";
   changelog?: boolean;
   exact?: boolean;
@@ -864,9 +865,10 @@ class VersionCommand extends Command {
   }
 
   async gitCommitAndTagVersionForUpdates() {
+    const tagVersionSeparator = this.options.tagVersionSeparator || "@";
     const tags = this.updates.map((node) => {
       const pkg = getPackage(node);
-      return `${pkg.name}@${this.updatesVersions.get(node.name)}`;
+      return `${pkg.name}${tagVersionSeparator}${this.updatesVersions.get(node.name)}`;
     });
     const subject = this.options.message || "Publish";
     const message = tags.reduce((msg, tag) => `${msg}${os.EOL} - ${tag}`, `${subject}${os.EOL}`);

--- a/libs/core/src/lib/collect-updates/collect-project-updates.ts
+++ b/libs/core/src/lib/collect-updates/collect-project-updates.ts
@@ -29,6 +29,8 @@ export interface ProjectUpdateCollectorOptions {
   conventionalGraduate?: string | boolean;
   forceConventionalGraduate?: boolean;
   excludeDependents?: boolean;
+  // Separator used within independent version tags, defaults to @
+  tagVersionSeparator?: string;
 }
 
 /**
@@ -46,6 +48,7 @@ export function collectProjectUpdates(
     forceConventionalGraduate,
     conventionalGraduate,
     excludeDependents,
+    tagVersionSeparator,
   } = commandOptions;
 
   // If --conventional-commits and --conventional-graduate are both set, ignore --force-publish but consider --force-conventional-graduate
@@ -59,7 +62,10 @@ export function collectProjectUpdates(
     // TODO: refactor to address type issues
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    const { sha, refCount, lastTagName } = describeRefSync(execOpts, commandOptions.includeMergedTags);
+    const { sha, refCount, lastTagName } = describeRefSync(
+      { ...execOpts, separator: tagVersionSeparator },
+      commandOptions.includeMergedTags
+    );
 
     if (refCount === "0" && forced.size === 0 && !committish) {
       // no commits since previous release

--- a/libs/core/src/lib/describe-ref.spec.ts
+++ b/libs/core/src/lib/describe-ref.spec.ts
@@ -130,6 +130,43 @@ describe("parser", () => {
     expect(result.isDirty).toBe(true);
   });
 
+  describe("custom tag-version-separator", () => {
+    it("matches independent tags using a custom tag-version-separator, CASE 1", () => {
+      childProcess.execSync.mockReturnValueOnce("pkg-name__1.2.3-4-g567890a");
+
+      const result = describeRefSync({ separator: "__" }) as DescribeRefDetailedResult;
+
+      expect(result.lastTagName).toBe("pkg-name__1.2.3");
+      expect(result.lastVersion).toBe("1.2.3");
+    });
+
+    it("matches independent tags using a custom tag-version-separator, CASE 2", () => {
+      childProcess.execSync.mockReturnValueOnce("pkg-name-1.2.3-4-g567890a");
+
+      const result = describeRefSync({ separator: "-" }) as DescribeRefDetailedResult;
+
+      expect(result.lastTagName).toBe("pkg-name-1.2.3");
+      expect(result.lastVersion).toBe("1.2.3");
+    });
+
+    it("matches independent tags for scoped packages", () => {
+      childProcess.execSync.mockReturnValueOnce("@scope/pkg-name_1.2.3-4-g567890a");
+
+      const result = describeRefSync({ separator: "_" }) as DescribeRefDetailedResult;
+
+      expect(result.lastTagName).toBe("@scope/pkg-name_1.2.3");
+      expect(result.lastVersion).toBe("1.2.3");
+    });
+
+    it("matches dirty annotations", () => {
+      childProcess.execSync.mockReturnValueOnce("pkg-name@@1.2.3-4-g567890a-dirty");
+
+      const result = describeRefSync({ separator: "@@" });
+
+      expect(result.isDirty).toBe(true);
+    });
+  });
+
   it("handles non-matching strings safely", () => {
     childProcess.execSync.mockReturnValueOnce("poopy-pants");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allows users to customize the tag version separator for independent projects in cases where they do not want to use the default of `@`.

Example usage can be seen in the e2e test for this project.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #3902 #3837

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

e2e and unit tests added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
