### PR TITLE
fix(version): create release when using custom tag-version-separator

### DIFF
--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -389,7 +389,11 @@ class VersionCommand extends Command {
       tasks.push(() =>
         createRelease(
           this.releaseClient,
-          { tags: this.tags, releaseNotes: this.releaseNotes },
+          {
+            tags: this.tags,
+            tagVersionSeparator: this.options.tagVersionSeparator || "@",
+            releaseNotes: this.releaseNotes,
+          },
           { gitRemote: this.options.gitRemote, execOpts: this.execOpts }
         )
       );

--- a/libs/commands/version/src/lib/create-release.ts
+++ b/libs/commands/version/src/lib/create-release.ts
@@ -16,21 +16,26 @@ export function createReleaseClient(type: "github" | "gitlab") {
 
 export function createRelease(
   client: ReturnType<typeof createReleaseClient>,
-  { tags, releaseNotes }: { tags: string[]; releaseNotes: { name: string; notes: string }[] },
+  {
+    tags,
+    releaseNotes,
+    tagVersionSeparator,
+  }: { tags: string[]; tagVersionSeparator: string; releaseNotes: { name: string; notes: string }[] },
   { gitRemote, execOpts }: { gitRemote: string; execOpts: ExecOptions }
 ) {
   const repo = parseGitRepo(gitRemote, execOpts);
 
   return Promise.all(
     releaseNotes.map(({ notes, name }) => {
-      const tag = name === "fixed" ? tags[0] : tags.find((t) => t.startsWith(`${name}@`));
+      const tag =
+        name === "fixed" ? tags[0] : tags.find((t) => t.startsWith(`${name}${tagVersionSeparator}`));
 
       /* istanbul ignore if */
       if (!tag) {
         return Promise.resolve();
       }
 
-      const prereleaseParts = semver.prerelease(tag.replace(`${name}@`, "")) || [];
+      const prereleaseParts = semver.prerelease(tag.replace(`${name}${tagVersionSeparator}`, "")) || [];
 
       return client.repos.createRelease({
         owner: repo.owner,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After the [8.1.0](https://github.com/lerna/lerna/releases/tag/v8.1.0), the version command does not create a GitHub release when using a custom version seperator. This was because the `createRelease` function had a hard coded `@` in tag name filter.

## Motivation and Context
Fixes: https://github.com/lerna/lerna/issues/3974

## How Has This Been Tested?
To test, I create a test repo made changes to a packages and commit them. I then ran:
```
node /tmp/lerna/dist/packages/lerna/dist/cli.js version --tag-version-separator '-' --conventional-commits --create-release github --yes
``` 
And was able to see the new GitHub release created with the appropriate tag


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
