### PR TITLE
fix(docs): remove mention of useWorkspaces

### DIFF
--- a/website/docs/recipes/using-pnpm-with-lerna.md
+++ b/website/docs/recipes/using-pnpm-with-lerna.md
@@ -5,7 +5,7 @@ Lerna can be used in a [`pnpm` workspace](https://pnpm.io/workspaces) to get the
 When used in a `pnpm` workspace, Lerna will:
 
 - resolve package locations with `pnpm-workspace.yaml` (https://pnpm.io/workspaces)
-- enforce `useWorkspaces: true` in `lerna.json` (and ignore `packages:` in `package.json`).
+- ignore `packages:` in `package.json
 - block usage of `bootstrap`, `link`, and `add` commands. Instead, you should use `pnpm` commands directly to manage dependencies (https://pnpm.io/cli/install).
 - respect the [workspace protocol](https://pnpm.io/workspaces#workspace-protocol-workspace) for package dependencies.
   - During `lerna version`, dependencies will be updated as normal, but will preserve the `workspace:` prefix if it exists.

--- a/website/docs/recipes/using-pnpm-with-lerna.md
+++ b/website/docs/recipes/using-pnpm-with-lerna.md
@@ -5,7 +5,7 @@ Lerna can be used in a [`pnpm` workspace](https://pnpm.io/workspaces) to get the
 When used in a `pnpm` workspace, Lerna will:
 
 - resolve package locations with `pnpm-workspace.yaml` (https://pnpm.io/workspaces)
-- ignore `packages:` in `package.json
+- ignore `"workspaces"` in `package.json`
 - block usage of `bootstrap`, `link`, and `add` commands. Instead, you should use `pnpm` commands directly to manage dependencies (https://pnpm.io/cli/install).
 - respect the [workspace protocol](https://pnpm.io/workspaces#workspace-protocol-workspace) for package dependencies.
   - During `lerna version`, dependencies will be updated as normal, but will preserve the `workspace:` prefix if it exists.


### PR DESCRIPTION
## Description
`useWorkspaces` has been removed since 7.0.0 and should not be mentioned.

## Motivation and Context
Mentioning `useWorkspaces` is confusing as it has been removed.

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
