### PR TITLE
feat(publish): enable throttling when publishing modules

### DIFF
--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -70,6 +70,7 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 - [`--registry <url>`](#--registry-url)
 - [`--tag-version-prefix`](#--tag-version-prefix)
 - [`--temp-tag`](#--temp-tag)
+- [`--throttle`](#--throttle)
 - [`--yes`](#--yes)
 - [`--summary-file <dir>`](#--summary-file)
 
@@ -301,6 +302,20 @@ new version(s) to the dist-tag configured by [`--dist-tag`](#--dist-tag-tag) (de
 
 This is not generally necessary, as Lerna will publish packages in topological
 order (all dependencies before dependents) by default.
+
+### `--throttle`
+
+This option class allows to throttle the timing at which modules are published to the configured registry.
+
+- `--throttle`: Enable throttling when publishing modules
+- `--throttle-size`: The amount of modules that may be published at once (defaults to `25`)
+- `--throttle-delay`: How long to wait after a module was successfully published (defaults to 30 seconds)
+
+This is usefull to avoid errors/retries when publishing to rate-limited repositories on huge monorepos:
+
+```bash
+lerna publish from-git --throttle --throttle-delay=$((3600*24))
+```
 
 ### `--yes`
 

--- a/libs/commands/publish/src/command.ts
+++ b/libs/commands/publish/src/command.ts
@@ -107,6 +107,18 @@ const command: CommandModule = {
         describe: "Create a temporary tag while publishing.",
         type: "boolean",
       },
+      throttle: {
+        describe: "Throttle module publication. This is implicit if a throttle size or delay is provided",
+        type: "boolean",
+      },
+      "throttle-size": {
+        describe: "Bucket size used to throttle module publication.",
+        type: "number",
+      },
+      "throttle-delay": {
+        describe: "Delay between throttle bucket items publications (in seconds).",
+        type: "number",
+      },
       "no-verify-access": {
         // proxy for --verify-access
         describe: "Do not verify package read-write access for current npm user.",

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -978,12 +978,9 @@ class PublishCommand extends Command {
     process.on("log", logListener);
 
     let queue;
-    if (
-      this.options.throttle ||
-      (this.options.throttle === undefined && this.conf.get("registry") !== "https://registry.npmjs.org/")
-    ) {
+    if (this.options.throttle) {
       queue = new TailHeadQueue(
-        this.options.throttleSize !== undefined ? this.options.throttleSize : 20,
+        this.options.throttleSize !== undefined ? this.options.throttleSize : 25,
         (this.options.throttleDelay !== undefined ? this.options.throttleDelay : 30) * 1000
       );
     } else {

--- a/libs/commands/publish/src/lib/throttle-queue.spec.ts
+++ b/libs/commands/publish/src/lib/throttle-queue.spec.ts
@@ -1,41 +1,9 @@
 import * as throttling from "./throttle-queue";
 
-describe("verifyImmediateQueueBehavior", () => {
-  test("immediately runs all provided resolving promises", async () => {
-    const count = 100;
-    const queue = new throttling.ImmediateQueue();
-    const queue_promises = Array(count)
-      .fill(undefined)
-      .map(() => queue.queue(async () => Date.now()));
-    const acc = await Promise.all(queue_promises);
-    expect(acc.length).toBe(count);
-    acc.sort();
-    expect(acc[count - 1] - acc[0]).toBeLessThan(100);
-  });
-  test("immediately runs all provided rejecting promises", async () => {
-    const count = 100;
-    const queue = new throttling.ImmediateQueue();
-    const queue_promises = Array(count)
-      .fill(undefined)
-      .map(() => queue.queue(async () => new Promise((_, r) => r(Date.now()))));
-    const acc = await Promise.allSettled(queue_promises);
-    expect(acc.length).toBe(count);
-    const resolved_sorted_acc = acc
-      .map((r) => {
-        expect(r.status).toBe("rejected");
-        if (r.status === "rejected") {
-          return r.reason;
-        }
-      })
-      .sort();
-    expect(resolved_sorted_acc[count - 1] - resolved_sorted_acc[0]).toBeLessThan(100);
-  });
-});
-
 describe("verifyTailHeadQueueBehavior", () => {
   test("immediately runs all provided resolving promises within queue size", async () => {
     const count = 100;
-    const queue = new throttling.TailHeadQueue(count);
+    const queue = new throttling.TailHeadQueue(count, 1000);
     const queue_promises = Array(count)
       .fill(undefined)
       .map(() => queue.queue(async () => Date.now()));
@@ -46,7 +14,7 @@ describe("verifyTailHeadQueueBehavior", () => {
   });
   test("immediately runs all provided rejecting promises within queue size", async () => {
     const count = 100;
-    const queue = new throttling.TailHeadQueue(count);
+    const queue = new throttling.TailHeadQueue(count, 1000);
     const queue_promises = Array(count)
       .fill(undefined)
       .map(() => queue.queue(async () => new Promise((_, r) => r(Date.now()))));

--- a/libs/commands/publish/src/lib/throttle-queue.spec.ts
+++ b/libs/commands/publish/src/lib/throttle-queue.spec.ts
@@ -1,0 +1,78 @@
+import * as throttling from "./throttle-queue";
+
+describe("verifyImmediateQueueBehavior", () => {
+  test("immediately runs all provided resolving promises", async () => {
+    const count = 100;
+    const queue = new throttling.ImmediateQueue();
+    const queue_promises = Array(count)
+      .fill(undefined)
+      .map(() => queue.queue(async () => Date.now()));
+    const acc = await Promise.all(queue_promises);
+    expect(acc.length).toBe(count);
+    acc.sort();
+    expect(acc[count - 1] - acc[0]).toBeLessThan(100);
+  });
+  test("immediately runs all provided rejecting promises", async () => {
+    const count = 100;
+    const queue = new throttling.ImmediateQueue();
+    const queue_promises = Array(count)
+      .fill(undefined)
+      .map(() => queue.queue(async () => new Promise((_, r) => r(Date.now()))));
+    const acc = await Promise.allSettled(queue_promises);
+    expect(acc.length).toBe(count);
+    const resolved_sorted_acc = acc
+      .map((r) => {
+        expect(r.status).toBe("rejected");
+        if (r.status === "rejected") {
+          return r.reason;
+        }
+      })
+      .sort();
+    expect(resolved_sorted_acc[count - 1] - resolved_sorted_acc[0]).toBeLessThan(100);
+  });
+});
+
+describe("verifyTailHeadQueueBehavior", () => {
+  test("immediately runs all provided resolving promises within queue size", async () => {
+    const count = 100;
+    const queue = new throttling.TailHeadQueue(count);
+    const queue_promises = Array(count)
+      .fill(undefined)
+      .map(() => queue.queue(async () => Date.now()));
+    const acc = await Promise.all(queue_promises);
+    expect(acc.length).toBe(count);
+    acc.sort();
+    expect(acc[count - 1] - acc[0]).toBeLessThan(100);
+  });
+  test("immediately runs all provided rejecting promises within queue size", async () => {
+    const count = 100;
+    const queue = new throttling.TailHeadQueue(count);
+    const queue_promises = Array(count)
+      .fill(undefined)
+      .map(() => queue.queue(async () => new Promise((_, r) => r(Date.now()))));
+    const acc = await Promise.allSettled(queue_promises);
+    expect(acc.length).toBe(count);
+    const resolved_sorted_acc = acc
+      .map((r) => {
+        expect(r.status).toBe("rejected");
+        if (r.status === "rejected") {
+          return r.reason;
+        }
+      })
+      .sort();
+    expect(resolved_sorted_acc[count - 1] - resolved_sorted_acc[0]).toBeLessThan(100);
+  });
+  test("runs all provided resolving promises with a delay if they exceed queue size", async () => {
+    const count = 100;
+    const queue = new throttling.TailHeadQueue(count / 3 + 1, 2 * 1000);
+    const queue_promises = Array(count)
+      .fill(undefined)
+      .map(() => queue.queue(async () => Date.now()));
+    const acc = await Promise.all(queue_promises);
+    expect(acc.length).toBe(count);
+    acc.sort();
+    const total_time = acc[count - 1] - acc[0];
+    expect(total_time).toBeGreaterThan(3.8 * 1000);
+    expect(total_time).toBeLessThan(4.2 * 1000);
+  });
+});

--- a/libs/commands/publish/src/lib/throttle-queue.ts
+++ b/libs/commands/publish/src/lib/throttle-queue.ts
@@ -20,11 +20,6 @@ export class ImmediateQueue implements Queue {
 }
 
 /**
- * Internal queue item representation used by {@link TailHeadQueue}
- */
-type TailHeadQueueItem = { startTime?: number; endTime?: number };
-
-/**
  * A sized queue that adds a delay between the end of an item's execution.
  *
  * Use only with async code, multi-threading is not supported.
@@ -47,20 +42,6 @@ export class TailHeadQueue implements Queue {
     this.queue_size = Math.floor(size);
     this.queue_period = period;
     this.allowance = this.queue_size;
-  }
-
-  /**
-   * Return the item with the smallest endTime in the provided list, for use with {@link TailHeadQueue.queue_list}.reduce
-   * @param p The last received item, this should be `[{}, -1]` at the start of the reduction
-   * @param v A queue item
-   * @param i The queue item's index
-   * @returns An array that contains a queue item and its index
-   */
-  protected static list_reducer(p: TailHeadQueueItem, v: TailHeadQueueItem, i: number): TailHeadQueueItem {
-    if (!p.endTime || (v.endTime && v.endTime < p.endTime)) {
-      return v;
-    }
-    return p;
   }
 
   /**

--- a/libs/commands/publish/src/lib/throttle-queue.ts
+++ b/libs/commands/publish/src/lib/throttle-queue.ts
@@ -1,0 +1,93 @@
+/**
+ * A queue abstraction for tasks that may require a delayed execution
+ */
+export interface Queue {
+  /**
+   * Run a task once the queue is cleared
+   * @param f A function that will be executed once the queue is useable
+   * @return A promise that wraps the value returned by f
+   */
+  queue<T>(f: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * A queue that immediately executes any promise it receives
+ */
+export class ImmediateQueue implements Queue {
+  queue<T>(f: () => Promise<T>): Promise<T> {
+    return f();
+  }
+}
+
+/**
+ * Internal queue item representation used by {@link TailHeadQueue}
+ */
+type TailHeadQueueItem = { startTime?: number; endTime?: number };
+
+/**
+ * A sized queue that adds a delay between the end of an item's execution.
+ *
+ * Use only with async code, multi-threading is not supported.
+ */
+export class TailHeadQueue implements Queue {
+  private queue_list: TailHeadQueueItem[];
+  private queue_size: number;
+  private queue_period: number;
+
+  /**
+   * @param size The number of items that may run concurrently
+   * @param period The time between the end of the execution of an item and the start of the execution of the next one (ms)
+   */
+  constructor(size = 20, period = 30 * 1000) {
+    this.queue_list = [];
+    this.queue_size = Math.floor(size);
+    this.queue_period = period;
+  }
+
+  /**
+   * Return the item with the smallest endTime in the provided list, for use with {@link TailHeadQueue.queue_list}.reduce
+   * @param p The last received item, this should be `[{}, -1]` at the start of the reduction
+   * @param v A queue item
+   * @param i The queue item's index
+   * @returns An array that contains a queue item and its index
+   */
+  protected static list_reducer(
+    p: [TailHeadQueueItem, number],
+    v: TailHeadQueueItem,
+    i: number
+  ): [TailHeadQueueItem, number] {
+    if (!p[0].endTime || (v.endTime && v.endTime < p[0].endTime)) {
+      return [v, i];
+    }
+    return p;
+  }
+
+  async queue<T>(f: () => Promise<T>): Promise<T> {
+    let curtime = Date.now();
+    let smallest: [TailHeadQueueItem, number] = this.queue_list.reduce(TailHeadQueue.list_reducer, [{}, -1]);
+    // Be careful when editing this loop, the position of each element around the async code is important
+    while (this.queue_list.length >= this.queue_size) {
+      if (smallest[0].endTime && smallest[0].endTime + this.queue_period <= curtime) {
+        this.queue_list.splice(smallest[1]);
+        break;
+      }
+      const delay = Math.max((smallest[0].endTime as number) + this.queue_period - curtime, 100);
+      await new Promise((r) => setTimeout(r, delay));
+      smallest = this.queue_list.reduce(TailHeadQueue.list_reducer, [{}, -1]);
+      curtime = Date.now();
+    }
+
+    const task: TailHeadQueueItem = { startTime: curtime };
+    this.queue_list.push(task);
+    return f().then(
+      (r) => {
+        task.endTime = Date.now();
+        return Promise.resolve(r);
+      },
+      (r) => {
+        task.endTime = Date.now();
+        return Promise.reject(r);
+      }
+    );
+  }
+}

--- a/libs/commands/publish/src/lib/throttle-queue.ts
+++ b/libs/commands/publish/src/lib/throttle-queue.ts
@@ -11,15 +11,6 @@ export interface Queue {
 }
 
 /**
- * A queue that immediately executes any promise it receives
- */
-export class ImmediateQueue implements Queue {
-  queue<T>(f: () => Promise<T>): Promise<T> {
-    return f();
-  }
-}
-
-/**
  * A sized queue that adds a delay between the end of an item's execution.
  *
  * Use only with async code, multi-threading is not supported.
@@ -35,7 +26,7 @@ export class TailHeadQueue implements Queue {
    * @param size The number of items that may run concurrently
    * @param period The time between the end of the execution of an item and the start of the execution of the next one (ms)
    */
-  constructor(size = 20, period = 30 * 1000) {
+  constructor(size, period) {
     this.queue_list = [];
     this.queue_size = Math.floor(size);
     this.queue_period = period;


### PR DESCRIPTION
The aim is to provide a way to fix #3962 .

This is opened to validate the implementation design and get feedback on the specific values that should be used as defaults.

Currently known limits when uploading to NPM:

* Burst limit of 25/500 modules per 24h (depending on account/already-published modules)

## Description

Add three publishing options:

* `--throttle` to enable/disable throttling
* `--throttle-size`: the 'bucket size' to use when throttling
* `--throttle-delay`: Once the bucket is full, the minimum time between the end of a module upload and the start of an other module's upload

Throttling is enabled by default when publishing to NPM. The throttling implementation is designed to allow changes in the implementation/maintaining different implementations without too much trouble

## Motivation and Context

See #3962: NPM throttles module publishing, which results in partial publish which are a pain to deal with

## How Has This Been Tested?

Tested on ubuntu with node 20.9.0:

* With the new testfile `libs/commands/publish/src/lib/throttle-queue.spec.ts`
* By publishing to a local verdaccio instance

The removal from draft of this PR will wait for the upload to NPM of a 10000+ modules monorepo

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
