### PR TITLE
feat(publish): support full file path for --summary-file

### DIFF
--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -334,7 +334,8 @@ Useful in [Continuous integration (CI)](https://en.wikipedia.org/wiki/Continuous
 lerna publish --canary --yes --summary-file
 # Will create a summary file in the provided directory, i.e. `./some/other/dir/lerna-publish-summary.json`
 lerna publish --canary --yes --summary-file ./some/other/dir
-
+# Will create a summary file with the provided name, i.e. `./some/other/dir/my-summary.json`
+lerna publish --canary --yes --summary-file ./some/other/dir/my-summary.json
 ```
 
 When run with this flag, a json summary report will be generated after all packages have been successfully published (see below for an example).

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -252,8 +252,8 @@ class PublishCommand extends Command {
     // don't execute recursively if run from a poorly-named script
     this.runRootLifecycle = /^(pre|post)?publish$/.test(process.env.npm_lifecycle_event)
       ? (stage) => {
-        this.logger.warn("lifecycle", "Skipping root %j because it has already been called", stage);
-      }
+          this.logger.warn("lifecycle", "Skipping root %j because it has already been called", stage);
+        }
       : (stage) => this.runPackageLifecycle(this.project.manifest, stage);
 
     this.projectsWithPackage = Object.values(this.projectGraph.nodes).filter((node) => !!node.package);
@@ -587,17 +587,17 @@ class PublishCommand extends Command {
 
     const makeVersion =
       (fallback: string) =>
-        ({ lastVersion = fallback, refCount, sha }) => {
-          // the next version is bumped without concern for preid or current index
-          const nextVersion = semver.inc(
-            lastVersion.replace(this.tagPrefix, ""),
-            release.replace("pre", "") as ReleaseType
-          );
+      ({ lastVersion = fallback, refCount, sha }) => {
+        // the next version is bumped without concern for preid or current index
+        const nextVersion = semver.inc(
+          lastVersion.replace(this.tagPrefix, ""),
+          release.replace("pre", "") as ReleaseType
+        );
 
-          // semver.inc() starts a new prerelease at .0, git describe starts at .1
-          // and build metadata is always ignored when comparing dependency ranges
-          return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}+${sha}`;
-        };
+        // semver.inc() starts a new prerelease at .0, git describe starts at .1
+        // and build metadata is always ignored when comparing dependency ranges
+        return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}+${sha}`;
+      };
 
     let updatesVersions: [string, string][];
     if (this.project.isIndependent()) {
@@ -684,8 +684,8 @@ class PublishCommand extends Command {
       const list =
         names.length > 1
           ? `${names.slice(0, -1).join(", ")}${names.length > 2 ? "," : ""} and ${
-            names[names.length - 1] /* oxford commas _are_ that important */
-          }`
+              names[names.length - 1] /* oxford commas _are_ that important */
+            }`
           : names[0];
 
       this.logger.warn(

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -415,17 +415,7 @@ class PublishCommand extends Command {
     output("Successfully published:");
 
     if (this.options.summaryFile !== undefined) {
-      const summaryFilePath = fs.lstatSync(this.options.summaryFile);
-
-      let filePath: string;
-
-      if (summaryFilePath.isFile()) {
-        filePath = this.options.summaryFile;
-      } else if (summaryFilePath.isDirectory()) {
-        filePath = join(this.options.summaryFile, "lerna-publish-summary.json");
-      } else {
-        filePath = "./lerna-publish-summary.json";
-      }
+      const filePath = this.getSummaryFilePath();
 
       const jsonObject = publishedPackagesSorted.map((pkg) => {
         return {
@@ -1228,6 +1218,28 @@ class PublishCommand extends Command {
         );
       }
     }
+  }
+
+  private getSummaryFilePath(): string {
+    if (this.options.summaryFile === undefined) {
+      throw new Error("summaryFile options is not defined. Unable to get path.");
+    }
+
+    if (this.options.summaryFile === "") {
+      return path.join(process.cwd(), "./lerna-publish-summary.json");
+    }
+
+    const normalizedPath = path.normalize(this.options.summaryFile);
+
+    if (normalizedPath === "") {
+      throw new Error("summaryFile is not a valid path.");
+    }
+
+    if (normalizedPath.endsWith(".json")) {
+      return path.join(process.cwd(), normalizedPath);
+    }
+
+    return path.join(process.cwd(), normalizedPath, "lerna-publish-summary.json");
   }
 }
 

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -252,8 +252,8 @@ class PublishCommand extends Command {
     // don't execute recursively if run from a poorly-named script
     this.runRootLifecycle = /^(pre|post)?publish$/.test(process.env.npm_lifecycle_event)
       ? (stage) => {
-          this.logger.warn("lifecycle", "Skipping root %j because it has already been called", stage);
-        }
+        this.logger.warn("lifecycle", "Skipping root %j because it has already been called", stage);
+      }
       : (stage) => this.runPackageLifecycle(this.project.manifest, stage);
 
     this.projectsWithPackage = Object.values(this.projectGraph.nodes).filter((node) => !!node.package);
@@ -415,16 +415,25 @@ class PublishCommand extends Command {
     output("Successfully published:");
 
     if (this.options.summaryFile !== undefined) {
-      // create a json object and output it to a file location.
-      const filePath = this.options.summaryFile
-        ? `${this.options.summaryFile}/lerna-publish-summary.json`
-        : "./lerna-publish-summary.json";
+      const summaryFilePath = fs.lstatSync(this.options.summaryFile);
+
+      let filePath: string;
+
+      if (summaryFilePath.isFile()) {
+        filePath = this.options.summaryFile;
+      } else if (summaryFilePath.isDirectory()) {
+        filePath = join(this.options.summaryFile, "lerna-publish-summary.json");
+      } else {
+        filePath = "./lerna-publish-summary.json";
+      }
+
       const jsonObject = publishedPackagesSorted.map((pkg) => {
         return {
           packageName: pkg.name,
           version: pkg.version,
         };
       });
+
       output(jsonObject);
       try {
         fs.writeFileSync(filePath, JSON.stringify(jsonObject));
@@ -578,17 +587,17 @@ class PublishCommand extends Command {
 
     const makeVersion =
       (fallback: string) =>
-      ({ lastVersion = fallback, refCount, sha }) => {
-        // the next version is bumped without concern for preid or current index
-        const nextVersion = semver.inc(
-          lastVersion.replace(this.tagPrefix, ""),
-          release.replace("pre", "") as ReleaseType
-        );
+        ({ lastVersion = fallback, refCount, sha }) => {
+          // the next version is bumped without concern for preid or current index
+          const nextVersion = semver.inc(
+            lastVersion.replace(this.tagPrefix, ""),
+            release.replace("pre", "") as ReleaseType
+          );
 
-        // semver.inc() starts a new prerelease at .0, git describe starts at .1
-        // and build metadata is always ignored when comparing dependency ranges
-        return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}+${sha}`;
-      };
+          // semver.inc() starts a new prerelease at .0, git describe starts at .1
+          // and build metadata is always ignored when comparing dependency ranges
+          return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}+${sha}`;
+        };
 
     let updatesVersions: [string, string][];
     if (this.project.isIndependent()) {
@@ -675,8 +684,8 @@ class PublishCommand extends Command {
       const list =
         names.length > 1
           ? `${names.slice(0, -1).join(", ")}${names.length > 2 ? "," : ""} and ${
-              names[names.length - 1] /* oxford commas _are_ that important */
-            }`
+            names[names.length - 1] /* oxford commas _are_ that important */
+          }`
           : names[0];
 
       this.logger.warn(

--- a/libs/commands/publish/src/lib/publish-command.spec.ts
+++ b/libs/commands/publish/src/lib/publish-command.spec.ts
@@ -404,6 +404,24 @@ Map {
         JSON.stringify(expectedJsonResponse)
       );
     });
+
+    it("creates the summary file in the provided file path", async () => {
+      const cwd = await initFixture("normal");
+      const fsSpy = jest.spyOn(fsmain, "writeFileSync");
+      await lernaPublish(cwd)("--summary-file", "./outputs/lerna-publish-summary.json");
+
+      const expectedJsonResponse = [
+        { packageName: "package-1", version: "1.0.1" },
+        { packageName: "package-2", version: "1.0.1" },
+        { packageName: "package-3", version: "1.0.1" },
+        { packageName: "package-4", version: "1.0.1" },
+      ];
+      expect(fsSpy).toHaveBeenCalled();
+      expect(fsSpy).toHaveBeenCalledWith(
+        "./outputs/lerna-publish-summary.json",
+        JSON.stringify(expectedJsonResponse)
+      );
+    });
   });
   describe("--verify-access", () => {
     it("publishes packages after verifying the user's access to each package", async () => {

--- a/libs/commands/publish/src/lib/publish-command.spec.ts
+++ b/libs/commands/publish/src/lib/publish-command.spec.ts
@@ -382,7 +382,7 @@ Map {
       ];
       expect(fsSpy).toHaveBeenCalled();
       expect(fsSpy).toHaveBeenCalledWith(
-        "./outputs/lerna-publish-summary.json",
+        path.join(process.cwd(), "outputs/lerna-publish-summary.json"),
         JSON.stringify(expectedJsonResponse)
       );
     });
@@ -398,9 +398,10 @@ Map {
         { packageName: "package-3", version: "1.0.1" },
         { packageName: "package-4", version: "1.0.1" },
       ];
+
       expect(fsSpy).toHaveBeenCalled();
       expect(fsSpy).toHaveBeenCalledWith(
-        "./lerna-publish-summary.json",
+        path.join(process.cwd(), "./lerna-publish-summary.json"),
         JSON.stringify(expectedJsonResponse)
       );
     });
@@ -418,7 +419,7 @@ Map {
       ];
       expect(fsSpy).toHaveBeenCalled();
       expect(fsSpy).toHaveBeenCalledWith(
-        "./outputs/lerna-publish-summary.json",
+        path.join(process.cwd(), "outputs/lerna-publish-summary.json"),
         JSON.stringify(expectedJsonResponse)
       );
     });


### PR DESCRIPTION
Add possibility to provide a filepath to the `--summary-file` option in the publish command  


## Description

This PR introduces a new capability to the Lerna library, allowing users to specify a filepath instead of a directory path for the `--summary-file` option. 

Previously, users could only provide a directory path and the created filename is statically defined in the code as `lerna-publish-summary.json` , which limited the flexibility in defining the location and name of the summary file. 

## Motivation and Context

With this change, users can now directly specify the full path, including the filename, where the summary should be saved.

## How Has This Been Tested?

In the `publish-command.spec.ts` file, adding a new test case where a filepath is passed as input parameter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
