### PR TITLE
fix(version): truncate release body based on maximum size of VCS client

### DIFF
--- a/libs/commands/version/src/index.ts
+++ b/libs/commands/version/src/index.ts
@@ -36,7 +36,7 @@ import pReduce from "p-reduce";
 import pWaterfall from "p-waterfall";
 import path from "path";
 import semver, { ReleaseType } from "semver";
-import { createRelease, createReleaseClient } from "./lib/create-release";
+import { createRelease, createReleaseClient, ReleaseClientType } from "./lib/create-release";
 import { getCurrentBranch } from "./lib/get-current-branch";
 import { gitAdd } from "./lib/git-add";
 import { gitCommit } from "./lib/git-commit";
@@ -76,7 +76,7 @@ interface VersionCommandConfigOptions extends CommandConfigOptions {
   forceGitTag?: boolean;
   tagVersionPrefix?: string;
   tagVersionSeparator?: string;
-  createRelease?: "github" | "gitlab";
+  createRelease?: ReleaseClientType;
   changelog?: boolean;
   exact?: boolean;
   conventionalPrerelease?: string;
@@ -390,6 +390,7 @@ class VersionCommand extends Command {
         createRelease(
           this.releaseClient,
           {
+            type: this.options.createRelease,
             tags: this.tags,
             tagVersionSeparator: this.options.tagVersionSeparator || "@",
             releaseNotes: this.releaseNotes,

--- a/libs/commands/version/src/lib/create-release.spec.ts
+++ b/libs/commands/version/src/lib/create-release.spec.ts
@@ -1,0 +1,44 @@
+import { truncateReleaseBody } from "./create-release";
+
+describe("truncateReleaseBody", () => {
+  const generateRandomString = (length: number): string => {
+    const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let result = "";
+    for (let i = 0; i < length; i++) {
+      result += letters.charAt(Math.floor(Math.random() * letters.length));
+    }
+    return result;
+  };
+
+  it("should not truncate when body length is within limit for GitHub", () => {
+    const body = generateRandomString(124999);
+    const truncatedBody = truncateReleaseBody(body, "github");
+    expect(truncatedBody).toBe(body);
+  });
+
+  it("should not truncate when body length is within limit for GitLab", () => {
+    const body = generateRandomString(999999);
+    const truncatedBody = truncateReleaseBody(body, "gitlab");
+    expect(truncatedBody).toBe(body);
+  });
+
+  it("should truncate when body length exceeds limit for GitHub", () => {
+    const body = generateRandomString(125001);
+    const truncatedBody = truncateReleaseBody(body, "github");
+    expect(truncatedBody.length).toBe(125000);
+    expect(truncatedBody.endsWith("...")).toBe(true);
+  });
+
+  it("should truncate when body length exceeds limit for GitLab", () => {
+    const body = generateRandomString(1000001);
+    const truncatedBody = truncateReleaseBody(body, "gitlab");
+    expect(truncatedBody.length).toBe(1000000);
+    expect(truncatedBody.endsWith("...")).toBe(true);
+  });
+
+  it("should return the body as is when type is undefined", () => {
+    const body = generateRandomString(150000);
+    const truncatedBody = truncateReleaseBody(body);
+    expect(truncatedBody).toBe(body);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request introduces the truncateReleaseBody function, which ensures that release body content does not exceed the specified maximum length for GitHub and GitLab release descriptions, thereby preventing errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/lerna/lerna/issues/3833

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/lerna/lerna/issues/3833

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
