### PR TITLE
docs: update lerna-and-nx-version-matrix.md to allow nx v19

### DIFF
--- a/website/docs/lerna-and-nx-version-matrix.md
+++ b/website/docs/lerna-and-nx-version-matrix.md
@@ -16,7 +16,7 @@ We provide a recommended version, and it is usually the latest minor version of 
 
 | Lerna Version       | **Nx Version _(recommended)_** | Nx Version _(range)_ |
 | ------------------- | ------------------------------ | -------------------- |
-| `>=8.0.0 <= latest` | **latest**                     | `>=17.1.2 < 19`      |
+| `>=8.0.0 <= latest` | **latest**                     | `>=17.1.2 < 20`      |
 | `>=7.1.4 < 8.0.0`   | `16.10.0`                      | `>=16.5.1 < 17`      |
 | `>= 7.0.0 < 7.1.4`  | `16.10.0`                      | `>=16.3.1 < 17`      |
 | `>= 6.5.0 < 7.0.0`  | `15.9.4`                       | `>=15.5.2 < 16`      |


### PR DESCRIPTION
## Description

Lerna depends on nx < 20, not < 19, according to its current `package.json`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I ended up with a weird nx version mismatch because `lerna` was installing v19 but I was installing v18 in my package.json. I ultimately removed `nx` and allowed `lerna` to manage `nx` itself, but the docs should still be updated.

## How Has This Been Tested?

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
