### PR TITLE
fix(core): avoid reading empty .config.json, upgrade cosmiconfig@v9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8364,14 +8364,14 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dependencies": {
+        "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "engines": {
         "node": ">=14"
@@ -19028,7 +19028,7 @@
         "console-control-strings": "^1.1.0",
         "conventional-changelog-core": "5.0.1",
         "conventional-recommended-bump": "7.0.1",
-        "cosmiconfig": "^8.2.0",
+        "cosmiconfig": "9.0.0",
         "dedent": "1.5.3",
         "execa": "5.0.0",
         "file-url": "3.0.0",
@@ -19133,7 +19133,7 @@
         "console-control-strings": "^1.1.0",
         "conventional-changelog-core": "5.0.1",
         "conventional-recommended-bump": "7.0.1",
-        "cosmiconfig": "^8.2.0",
+        "cosmiconfig": "9.0.0",
         "dedent": "1.5.3",
         "execa": "5.0.0",
         "fs-extra": "^11.2.0",
@@ -19241,7 +19241,7 @@
         "conventional-changelog-angular": "7.0.0",
         "conventional-changelog-core": "5.0.1",
         "conventional-recommended-bump": "7.0.1",
-        "cosmiconfig": "^8.2.0",
+        "cosmiconfig": "9.0.0",
         "dedent": "1.5.3",
         "envinfo": "7.13.0",
         "execa": "5.0.0",

--- a/packages/legacy-package-management/package.json
+++ b/packages/legacy-package-management/package.json
@@ -41,7 +41,7 @@
     "console-control-strings": "^1.1.0",
     "conventional-changelog-core": "5.0.1",
     "conventional-recommended-bump": "7.0.1",
-    "cosmiconfig": "^8.2.0",
+    "cosmiconfig": "9.0.0",
     "dedent": "1.5.3",
     "execa": "5.0.0",
     "file-url": "3.0.0",

--- a/packages/legacy-structure/commands/create/package.json
+++ b/packages/legacy-structure/commands/create/package.json
@@ -46,7 +46,7 @@
     "console-control-strings": "^1.1.0",
     "conventional-changelog-core": "5.0.1",
     "conventional-recommended-bump": "7.0.1",
-    "cosmiconfig": "^8.2.0",
+    "cosmiconfig": "9.0.0",
     "dedent": "1.5.3",
     "execa": "5.0.0",
     "fs-extra": "^11.2.0",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -55,7 +55,7 @@
     "conventional-changelog-angular": "7.0.0",
     "conventional-changelog-core": "5.0.1",
     "conventional-recommended-bump": "7.0.1",
-    "cosmiconfig": "^8.2.0",
+    "cosmiconfig": "9.0.0",
     "dedent": "1.5.3",
     "envinfo": "7.13.0",
     "execa": "5.0.0",


### PR DESCRIPTION
The credit should go to @ghiscoding - I'm just back-porting his fix to the same bug in lerna-lite to lerna here.

## Description

The newer version of cosmicconfig does not suffer from the issue that
it defaults to looking for .config.json the way 8.x does.
This upgrade implicitly fixes the underlying issue that lerna has for the
same reason.


## Motivation and Context

Fixes #4061

lerna-lite used to have the same bug, you can read the full context here:
1. https://github.com/lerna-lite/lerna-lite/issues/729
2. https://github.com/cosmiconfig/cosmiconfig/issues/313
3. https://github.com/cosmiconfig/cosmiconfig/pull/311


## How Has This Been Tested?

`npm test && npm run integration`

The tests all passed, but for the integratin tests 2 of them failed with the logs pasted below. They were failing the same way on `main` prior to my changes so I'm assuming this to be a false positive but you tell me.

```sh
Summary of all failing tests
 FAIL  __tests__/lerna-publish-validation.spec.ts
  ● lerna publish exits with EBEHIND when behind upstream remote

    Command failed with exit code 128: git commit -m upstream change
    Author identity unknown

    *** Please tell me who you are.

    Run

      git config --global user.email "you@example.com"
      git config --global user.name "Your Name"

    to set your account's default identity.
    Omit --global to set the identity only in this repository.

    fatal: empty ident name (for <peter@C11-73JFIMZA8J6.dir.svc.accenture.com>) not allowed

      26 |   await fs.outputFile(path.join(cloneDir, "README.md"), "upstream change");
      27 |   await gitAdd(cloneDir, "-A");
    > 28 |   await gitCommit(cloneDir, "upstream change");
         |   ^
      29 |   await execa("git", ["push", "origin", "main"], { cwd: cloneDir });
      30 |
      31 |   // throws during interactive publish (local)

      at makeError (../node_modules/execa/lib/error.js:59:11)
      at handlePromise (../node_modules/execa/index.js:114:26)
      at Object.<anonymous> (__tests__/lerna-publish-validation.spec.ts:28:3)

 FAIL  __tests__/lerna-bootstrap-yarn.spec.ts
  ● lerna bootstrap --npm-client yarn

    Command failed with exit code 1: node /home/peter/a/lerna/packages/lerna/dist/cli.js bootstrap --npm-client yarn
    lerna notice cli v8.1.8
    lerna info ci enabled
    lerna info Bootstrapping 4 packages
    lerna info lifecycle package-4@1.0.0~preinstall: package-4@1.0.0
    lerna info Installing external dependencies
    lerna ERR! yarn install --mutex network:42424 --non-interactive exited 1 in '@integration/package-2'
    lerna ERR! yarn install --mutex network:42424 --non-interactive stdout:
    Unknown Syntax Error: Unsupported option name ("--mutex").

    $ yarn install [--json] [--immutable] [--immutable-cache] [--refresh-lockfile] [--check-cache] [--check-resolutions] [--inline-builds] [--mode #0]
    lerna ERR! yarn install --mutex network:42424 --non-interactive exited 1 in '@integration/package-2'
    lerna WARN complete Waiting for 2 child processes to exit. CTRL-C to exit immediately.

    > package-4@1.0.0 preinstall /tmp/dd16a3ecb8e9a0c03b35291c2f37dd47/package-4
    > exit 0

       9 |   const lerna = cliRunner(cwd);
      10 |
    > 11 |   const { stderr } = await lerna("bootstrap", "--npm-client", "yarn");
         |                      ^
      12 |   expect(stderr).toMatchInlineSnapshot(`
      13 | lerna notice cli __TEST_VERSION__
      14 | lerna info ci enabled

      at makeError (../node_modules/execa/lib/error.js:59:11)
      at handlePromise (../node_modules/execa/index.js:114:26)
      at Object.<anonymous> (__tests__/lerna-bootstrap-yarn.spec.ts:11:22)


Test Suites: 2 failed, 31 passed, 33 total
Tests:       2 failed, 83 passed, 85 total
Snapshots:   93 passed, 93 total
Time:        68.037 s, estimated 83 s
Ran all test suites.

——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Ran target integration for project integration and 6 task(s) they depend on (1m)

      With additional flags:
        --maxWorkers=2

   ✖  1/7 failed
   ✔  6/7 succeeded [4 read from cache]

View structured, searchable error logs at https://nx.app/runs/8xAbKEIHdj
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
