### PR TITLE
fix: add extends property in schema

### DIFF
--- a/packages/lerna/schemas/lerna-schema.json
+++ b/packages/lerna/schemas/lerna-schema.json
@@ -9,6 +9,10 @@
       "type": "string",
       "description": "The JSON schema version used to validate this configuration file"
     },
+    "extends": {
+      "type": "string",
+      "description": "A shareable configuration preset that will be used as the base for this configuration"
+    },
     "version": {
       "type": "string",
       "description": "The version of the repository, or \"independent\" for a repository with independently versioned packages.",


### PR DESCRIPTION
Fixing warning "Property extends is not allowed" on "extends" property in user's lerna.json.

## Description
When user has "extends" property in user's lerna.json, for example,

```json
"extends": "my-base-config"
```

VS Code shows "squiggly" warning _"Property extends is not allowed"_ on the `extends` property:

![image](https://github.com/user-attachments/assets/e2e34003-5578-41fd-8c66-26b1d5721762)

## Motivation and Context

Fix the VS Code warning on the `extends` property.

This is follow-up on the "extends" feature implemented the [commit](https://github.com/lerna/lerna/commit/0b28ef5fe8e4fc376870848acc8f6ccc0905a7b2), which was for [Issue #1281](https://github.com/lerna/lerna/issues/1281).

## How Has This Been Tested?

Use the updated `lerna-schema.json` file in the `lerna` package installation.  After the fix, VS Code no longer shows that warning:

![image](https://github.com/user-attachments/assets/9c9de7c5-7835-49f6-91b8-d6edd08af58d)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
