### PR TITLE
docs: use ndjson spec link instead of ndjson.org

### DIFF
--- a/libs/commands/list/README.md
+++ b/libs/commands/list/README.md
@@ -67,7 +67,7 @@ package-3
 
 ### `--ndjson`
 
-Show information as [newline-delimited JSON](http://ndjson.org).
+Show information as [newline-delimited JSON](https://github.com/ndjson/ndjson-spec).
 
 ```sh
 $ lerna ls --ndjson


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

ndjson.org domain expired and has been taken over by a website with malware. This update will use the official ndjson spec readme.


## Description

Discussion: https://github.com/ndjson/ndjson.github.io/issues/24

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
