### PR TITLE
fix: use searchStrategy: global to fix breaking change behaviour after upgrading cosmiconfig to 9.0.0

### DIFF
--- a/libs/core/src/lib/project/index.ts
+++ b/libs/core/src/lib/project/index.ts
@@ -259,6 +259,7 @@ export class Project {
           },
         },
         searchPlaces: ["lerna.json", "package.json"],
+        searchStrategy: "global", // Fix breaking change behaviour in cosmiconfig@9.0.0
         transform(obj) {
           // cosmiconfig returns null when nothing is found
           if (!obj) {

--- a/libs/legacy-core/src/lib/get-filtered-packages.spec.ts
+++ b/libs/legacy-core/src/lib/get-filtered-packages.spec.ts
@@ -23,7 +23,7 @@ async function buildGraph(cwd: string) {
 }
 
 function parseOptions(...args: string[]) {
-  return filterOptions(yargs().exitProcess(false).showHelpOnFail(false)).parse(args);
+  return filterOptions(yargs().locale('en').exitProcess(false).showHelpOnFail(false)).parse(args);
 }
 
 // working dir is never mutated


### PR DESCRIPTION
## Description
cosmiconfig have been upgrade to 9.0.0 in #4062
But there is a breaking change in cosmiconfig 9.0.0
See https://github.com/cosmiconfig/cosmiconfig/blob/main/CHANGELOG.md#900
> Breaking change: This is the default value if you don't pass a stopDir option, which means that cosmiconfig no longer traverses directories by default, and instead just looks in the current working directory.
If you want to achieve maximum backwards compatibility without adding an explicit stopDir, add the searchStrategy: 'global' option.

Any lerna commands run in subdirectories are broken now.

## Motivation and Context
Fix issue #4118

## How Has This Been Tested?
Run `npm test && npm run integration`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
