### PR TITLE
fix: incorrectly removes `package-lock.json` dependencies on `lerna version`

### DIFF
--- a/libs/core/src/lib/cli.ts
+++ b/libs/core/src/lib/cli.ts
@@ -1,6 +1,3 @@
-// Plugin isolation is not relevant to lerna
-process.env["NX_ISOLATE_PLUGINS"] = "false";
-
 import dedent from "dedent";
 import os from "node:os";
 import yargs from "yargs";

--- a/libs/core/src/lib/test-helpers/create-project-graph.ts
+++ b/libs/core/src/lib/test-helpers/create-project-graph.ts
@@ -1,7 +1,6 @@
 // We always need fresh copies of the graph in the unit test fixtures
 process.env.NX_DAEMON = "false";
 process.env.NX_CACHE_PROJECT_GRAPH = "false";
-process.env.NX_ISOLATE_PLUGINS = "false";
 
 import { ProjectGraphDependency, ProjectGraphProjectNode } from "@nx/devkit";
 import { resetWorkspaceContext } from "nx/src/utils/workspace-context";

--- a/libs/test-helpers/src/lib/cli.ts
+++ b/libs/test-helpers/src/lib/cli.ts
@@ -40,7 +40,6 @@ export function commandRunner(commandModule: yargs.CommandModule) {
       // We always need fresh copies of the graph in the unit test fixtures
       process.env.NX_DAEMON = "false";
       process.env.NX_CACHE_PROJECT_GRAPH = "false";
-      process.env.NX_ISOLATE_PLUGINS = "false";
 
       // Update the global workspaceRoot to the current test's cwd
       setWorkspaceRoot(cwd);

--- a/packages/lerna/src/index.ts
+++ b/packages/lerna/src/index.ts
@@ -1,6 +1,3 @@
-// Plugin isolation is not relevant to lerna
-process.env["NX_ISOLATE_PLUGINS"] = "false";
-
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 // Currently external until the usage of LERNA_MODULE_DATA can be refactored


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

@JamesHenry  Hello,  

I've fixed the issue mentioned in [#4167](https://github.com/lerna/lerna/issues/4167).

resolve: #4167

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, running `npx lerna version (version) --no-git-tag-version` results in the removal of incorrect dependencies from the `package-lock.json`.

I was able to reproduce the issue from [#4167](https://github.com/lerna/lerna/issues/4167) in a similar manner. **This issue occurs in Lerna `v8.2.0` and `v8.2.1`**, but it works as expected in `v8.1.9`.

This is essentially a partial revert of the changes made in [#4151](https://github.com/lerna/lerna/pull/4151). (https://github.com/lerna/lerna/compare/v8.1.9...v8.2.0)

The bug was caused by the plugin isolation code: `process.env["NX_ISOLATE_PLUGINS"] = "false";`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After fixing the code, running `npx lerna version (version) --no-git-tag-version` now works correctly, just as it did in Lerna `v8.1.9`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
