### PR TITLE
fix(version): disable legacy peer deps behavior by default

### DIFF
--- a/libs/core/src/lib/cli.ts
+++ b/libs/core/src/lib/cli.ts
@@ -1,5 +1,9 @@
 // Plugin isolation is not relevant to lerna
 process.env["NX_ISOLATE_PLUGINS"] = "false";
+// If plugin isolation is off, also make sure we're not using the legacy peer deps behavior.
+// See: https://github.com/lerna/lerna/issues/4167
+// This could be removed if Nx is not setting this to true by default.
+process.env["npm_config_legacy_peer_deps"] ??= "false";
 
 import dedent from "dedent";
 import os from "node:os";


### PR DESCRIPTION
This PR fixes the lockfile bug as described here: https://github.com/lerna/lerna/issues/4167
## Description

When `NX_ISOLATE_PLUGIN` was set to `false`, it uncovered an issue where Nx defaults `npm_config_legacy_peer_deps` environment variable to `true`.  This means that subsequent `npm install` command is updating the lockfile (i.e. `package-lock.json`) in an unexpected manner.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #4167

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually making the changes locally and testing it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
