### PR TITLE
docs(version): update conventional-commits info in version docs

### DIFF
--- a/libs/commands/version/README.md
+++ b/libs/commands/version/README.md
@@ -184,6 +184,10 @@ If the preset exports a builder function (e.g. `conventional-changelog-conventio
 }
 ```
 
+If you use any preset other than the default, you should also install the matching `conventional-changelog` package as a devDependency.
+
+The value of this argument will also be used to determine the version bump for each package if the [`--conventional-commits`](#--conventional-commits) flag is passed.
+
 ### `--changelog-entry-additional-markdown`
 
 ```sh
@@ -210,7 +214,11 @@ If your text is static, and does not change from release to release, you could c
 lerna version --conventional-commits
 ```
 
-When run with this flag, `lerna version` will use the [Conventional Commits Specification](https://conventionalcommits.org/) to [determine the version bump](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump) and [generate CHANGELOG.md files](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli).
+When run with this flag, `lerna version` will use the `conventional-changelog` package to [determine the version bump](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump) and [generate CHANGELOG.md files](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli).
+
+If you do not also set the [`--changelog-preset`](#--changelog-preset) option, lerna will use the default configuration from the `conventional-changelog` package, which is currently the [`angular` spec](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
+
+If you want your versions bumped according to a different spec, such as [Conventional Commits Specification](https://conventionalcommits.org/) which supports the use of `!` in the header to denote breaking changes, you must pass the `--conventional-changelog` flag with a spec name like `conventionalcommits`.
 
 Passing [`--no-changelog`](#--no-changelog) will disable the generation (or updating) of `CHANGELOG.md` files.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds information about using conventional-commits with `lerna version`. In particular, adds details about how the use of the `--conventional-commits` flag interacts with the `--changelog-preset` flag.

View the markdown preview of this change [here](https://github.com/maribethb/lerna/blob/d3104b1d3c42e235b4db2ddc4c55bf9ecee03eba/libs/commands/version/README.md)

## Motivation and Context
The previous docs stated that passing `--conventional-commits` flag would have lerna bump versions according to the conventionalcommits.org spec. However, this was not actually true, because the conventionalcommits.org spec allows using `!` in the header to denote a breaking change. If you only set the `--conventional-commits` flag, you would then be surprised to learn that your changes marked with `!` did not cause a new major version bump. You can see many examples of this confusion in https://github.com/lerna/lerna/issues/2668.

This change updates the documentation to explain the use of the `angular` spec as default, and explains how to change the spec used. It also updates the `--changelog-preset` option to explain that you need to install the spec used as a devDependency if you don't use the default.

## How Has This Been Tested?
This is a documentation change only.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
