### PR TITLE
fix(publish): ensure README file names are populated on package.json

### DIFF
--- a/libs/core/src/lib/npm-publish.spec.ts
+++ b/libs/core/src/lib/npm-publish.spec.ts
@@ -10,7 +10,7 @@ jest.mock("@npmcli/package-json");
 jest.mock("libnpmpublish");
 jest.mock("fs-extra");
 
-const { load: readJSON } = require("@npmcli/package-json");
+const { prepare: readJSON } = require("@npmcli/package-json");
 
 // helpers
 import path from "path";
@@ -26,7 +26,7 @@ const otplease = jest.mocked(_otplease);
 
 describe("npm-publish", () => {
   const mockTarData = Buffer.from("MOCK") as never;
-  const mockManifest = { _normalized: true };
+  const mockManifest = { _prepared: true, readmeFilename: "README.md", _normalized: true };
 
   fs.readFile.mockName("fs.readFile").mockResolvedValue(mockTarData);
   // TODO: refactor based on TS feedback
@@ -220,5 +220,18 @@ describe("npm-publish", () => {
 
     expect(runLifecycle).toHaveBeenCalledWith(pkg, "publish", options);
     expect(runLifecycle).toHaveBeenLastCalledWith(pkg, "postpublish", options);
+  });
+
+  it("ensures package.json is prepared and has readmeFilename added to it", async () => {
+    await npmPublish(pkg, tarFilePath);
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _prepared: true,
+        readmeFilename: "README.md",
+      }),
+      expect.anything(),
+      expect.anything()
+    );
   });
 });

--- a/libs/core/src/lib/npm-publish.ts
+++ b/libs/core/src/lib/npm-publish.ts
@@ -1,4 +1,4 @@
-import { load } from "@npmcli/package-json";
+import { prepare } from "@npmcli/package-json";
 import fs from "fs-extra";
 import { publish } from "libnpmpublish";
 import npa from "npm-package-arg";
@@ -66,7 +66,7 @@ export async function npmPublish(
 
     const [tarData, npmCliPackageJson] = await Promise.all([
       fs.readFile(tarFilePath),
-      await load(path.dirname(manifestLocation)),
+      await prepare(path.dirname(manifestLocation)),
     ]);
 
     const manifestContent = npmCliPackageJson.content;


### PR DESCRIPTION
## Description
#4133 reported an issue about `README.md` not being visible in verdaccio when publishing. Looking into the issue I found https://github.com/lerna/lerna/issues/1843 that says that `verdaccio` requires `readmeFilename` field to exist on the package.json that is published. 

with the 8.1.5 release, the [read-package-json](https://www.npmjs.com/package/read-package-json) was swapped out for [@npmcli/package-json](https://www.npmjs.com/package/@npmcli/package-json), and the `npm-publish.ts` file was updated to use `load`, but it should be using `prepare` since the npm-publish needs to normalize the package.json data and the documentation states that `prepare` should be used before publishing.

## Motivation and Context
Currently if you run the project locally and visit the verdaccio web ui there is no README.md file. Any user using verdaccio can't see their README.md files when publishing to their private registry due to how the npm-publish file was updated.

You can re-create the issue locally:


1. Run `npm run e2e-build-package-publish`
2. View the packages in the verdaccio web ui, all packages show up with the following content for the README:

<img width="1831" height="1681" alt="lerna-before" src="https://github.com/user-attachments/assets/0850afdd-d0bd-400d-9798-1a91180cc88f" />

## How Has This Been Tested?
- npm-publish.spec.ts was updated to include a test for `readmeFilename` and `_prepared`
- Documentation from [@npmcli/package-json](https://www.npmjs.com/package/@npmcli/package-json) suggests this should be used instead of `load()` for publishing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. *

*I had an error for `pack-directory` in the `core:test` in the `main` branch from the start of working on this issue so existing tests that were failing are still failing.
(CI tests seem to be passing though so I've marked it with a checkmark.)