### PR TITLE
refactor: use native object spreading

### DIFF
--- a/e2e/version/src/positional-arguments-pnpm.spec.ts
+++ b/e2e/version/src/positional-arguments-pnpm.spec.ts
@@ -75,7 +75,7 @@ describe("lerna-version-positional-arguments-pnpm", () => {
           devDependencies: Object {
             lerna: Object {
               specifier: ^999.9.9-e2e.0,
-              version: 999.9.9-e2e.0(@type/noe@24.2.1),
+              version: 999.9.9-e2e.0,
             },
           },
         },
@@ -140,7 +140,7 @@ describe("lerna-version-positional-arguments-pnpm", () => {
           devDependencies: Object {
             lerna: Object {
               specifier: ^999.9.9-e2e.0,
-              version: 999.9.9-e2e.0(@type/noe@24.2.1),
+              version: 999.9.9-e2e.0,
             },
           },
         },
@@ -209,7 +209,7 @@ describe("lerna-version-positional-arguments-pnpm", () => {
           devDependencies: Object {
             lerna: Object {
               specifier: ^999.9.9-e2e.0,
-              version: 999.9.9-e2e.0(@type/noe@24.2.1),
+              version: 999.9.9-e2e.0,
             },
           },
         },

--- a/e2e/version/src/positional-arguments-pnpm.spec.ts
+++ b/e2e/version/src/positional-arguments-pnpm.spec.ts
@@ -75,7 +75,7 @@ describe("lerna-version-positional-arguments-pnpm", () => {
           devDependencies: Object {
             lerna: Object {
               specifier: ^999.9.9-e2e.0,
-              version: 999.9.9-e2e.0,
+              version: 999.9.9-e2e.0(@type/noe@24.2.1),
             },
           },
         },
@@ -140,7 +140,7 @@ describe("lerna-version-positional-arguments-pnpm", () => {
           devDependencies: Object {
             lerna: Object {
               specifier: ^999.9.9-e2e.0,
-              version: 999.9.9-e2e.0,
+              version: 999.9.9-e2e.0(@type/noe@24.2.1),
             },
           },
         },
@@ -209,7 +209,7 @@ describe("lerna-version-positional-arguments-pnpm", () => {
           devDependencies: Object {
             lerna: Object {
               specifier: ^999.9.9-e2e.0,
-              version: 999.9.9-e2e.0,
+              version: 999.9.9-e2e.0(@type/noe@24.2.1),
             },
           },
         },

--- a/libs/core/src/lib/command/index.ts
+++ b/libs/core/src/lib/command/index.ts
@@ -1,6 +1,5 @@
 import { ProjectFileMap } from "@nx/devkit";
 import { ExecOptions as NodeExecOptions } from "child_process";
-import cloneDeep from "clone-deep";
 import dedent from "dedent";
 import { daemonClient } from "nx/src/daemon/client/client";
 import os from "os";
@@ -81,7 +80,7 @@ export class Command<T extends CommandConfigOptions = CommandConfigOptions> {
   }
 
   constructor(
-    _argv: Arguments<T>,
+    readonly _argv: Arguments<T>,
     {
       skipValidations,
       preInitializedProjectData,
@@ -93,7 +92,7 @@ export class Command<T extends CommandConfigOptions = CommandConfigOptions> {
     log.pause();
     log.heading = "lerna";
 
-    const argv = cloneDeep(_argv);
+    const argv = { ..._argv };
     log.silly("argv", argv);
 
     // "FooCommand" => "foo"

--- a/libs/legacy-core/src/lib/command/index.ts
+++ b/libs/legacy-core/src/lib/command/index.ts
@@ -1,5 +1,4 @@
 import { CommandConfigOptions, Logger, Project, ValidationError, log } from "@lerna/core";
-import cloneDeep from "clone-deep";
 import dedent from "dedent";
 import execa from "execa";
 import os from "os";
@@ -35,11 +34,11 @@ export class Command<T extends CommandConfigOptions = CommandConfigOptions> {
     this._project = project;
   }
 
-  constructor(_argv: any, { skipValidations } = { skipValidations: false }) {
+  constructor(readonly _argv: any, { skipValidations } = { skipValidations: false }) {
     log.pause();
     log.heading = "lerna";
 
-    const argv = cloneDeep(_argv);
+    const argv = { ..._argv };
     log.silly("argv", argv);
 
     // "FooCommand" => "foo"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@swc-node/register": "1.10.10",
         "@swc/core": "1.13.3",
         "@types/byte-size": "^8.1.2",
-        "@types/clone-deep": "^4.0.4",
         "@types/cmd-shim": "^5.0.2",
         "@types/columnify": "^1.5.4",
         "@types/conventional-recommended-bump": "^6.1.0",
@@ -4999,11 +4998,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/clone-deep": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/cmd-shim": {
       "version": "5.0.2",
       "dev": true,
@@ -7430,28 +7424,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clone-deep/node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cmd-shim": {
@@ -10440,13 +10412,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/isstream": {
@@ -14475,16 +14440,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -16456,7 +16411,6 @@
         "aproba": "2.0.0",
         "byte-size": "8.1.1",
         "chalk": "4.1.0",
-        "clone-deep": "4.0.1",
         "cmd-shim": "6.0.3",
         "color-support": "1.1.3",
         "columnify": "1.6.0",
@@ -16558,7 +16512,6 @@
         "aproba": "2.0.0",
         "byte-size": "8.1.1",
         "chalk": "4.1.0",
-        "clone-deep": "4.0.1",
         "cmd-shim": "6.0.3",
         "color-support": "1.1.3",
         "columnify": "1.6.0",
@@ -16671,7 +16624,6 @@
         "aproba": "2.0.0",
         "byte-size": "8.1.1",
         "chalk": "4.1.0",
-        "clone-deep": "4.0.1",
         "cmd-shim": "6.0.3",
         "color-support": "1.1.3",
         "columnify": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@swc-node/register": "1.10.10",
     "@swc/core": "1.13.3",
     "@types/byte-size": "^8.1.2",
-    "@types/clone-deep": "^4.0.4",
     "@types/cmd-shim": "^5.0.2",
     "@types/columnify": "^1.5.4",
     "@types/conventional-recommended-bump": "^6.1.0",

--- a/packages/legacy-package-management/package.json
+++ b/packages/legacy-package-management/package.json
@@ -34,7 +34,6 @@
     "aproba": "2.0.0",
     "byte-size": "8.1.1",
     "chalk": "4.1.0",
-    "clone-deep": "4.0.1",
     "cmd-shim": "6.0.3",
     "color-support": "1.1.3",
     "columnify": "1.6.0",

--- a/packages/legacy-structure/commands/create/package.json
+++ b/packages/legacy-structure/commands/create/package.json
@@ -39,7 +39,6 @@
     "aproba": "2.0.0",
     "byte-size": "8.1.1",
     "chalk": "4.1.0",
-    "clone-deep": "4.0.1",
     "cmd-shim": "6.0.3",
     "color-support": "1.1.3",
     "columnify": "1.6.0",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -47,7 +47,6 @@
     "aproba": "2.0.0",
     "byte-size": "8.1.1",
     "chalk": "4.1.0",
-    "clone-deep": "4.0.1",
     "cmd-shim": "6.0.3",
     "color-support": "1.1.3",
     "columnify": "1.6.0",


### PR DESCRIPTION
~~[`structuredClone`](https://nodejs.org/api/globals.html#structuredclonevalue-options) is natively available as of Node v17, so no need to have an extra dependency for this anymore~~

We could use Object spreading since we're only accessing root properties

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

I'm sure people from the wider @e18e ecosystem cleanup (like @43081j, @benmccann, @Fuzzyma, @outslept & @talentlessguy) will be very happy to see these kind of changes as well
