### PR TITLE
fix: Bump tar to 7.5.8 to Fix CVE-2026-26960

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16928,9 +16928,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.8.tgz",
+      "integrity": "sha512-SYkBtK99u0yXa+IWL0JRzzcl7RxNpvX/U08Z+8DKnysfno7M+uExnTZH8K+VGgShf2qFPKtbNr9QBl8n7WBP6Q==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -18445,7 +18445,7 @@
         "slash": "^3.0.0",
         "ssri": "12.0.0",
         "string-width": "^4.2.3",
-        "tar": "7.5.7",
+        "tar": "7.5.8",
         "temp-dir": "1.0.0",
         "through": "2.3.8",
         "tinyglobby": "0.2.12",
@@ -18603,7 +18603,7 @@
         "slash": "3.0.0",
         "ssri": "12.0.0",
         "string-width": "^4.2.3",
-        "tar": "7.5.7",
+        "tar": "7.5.8",
         "temp-dir": "1.0.0",
         "through": "2.3.8",
         "tinyglobby": "0.2.12",

--- a/packages/legacy-structure/commands/create/package.json
+++ b/packages/legacy-structure/commands/create/package.json
@@ -85,7 +85,7 @@
     "slash": "^3.0.0",
     "ssri": "12.0.0",
     "string-width": "^4.2.3",
-    "tar": "7.5.7",
+    "tar": "7.5.8",
     "temp-dir": "1.0.0",
     "through": "2.3.8",
     "tinyglobby": "0.2.12",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -101,7 +101,7 @@
     "slash": "3.0.0",
     "ssri": "12.0.0",
     "string-width": "^4.2.3",
-    "tar": "7.5.7",
+    "tar": "7.5.8",
     "temp-dir": "1.0.0",
     "through": "2.3.8",
     "tinyglobby": "0.2.12",


### PR DESCRIPTION
## Description

Bumps `tar` from 7.5.7 to 7.5.8 to fix [CVE-2026-26960](https://advisories.gitlab.com/pkg/npm/tar/CVE-2026-26960/) — arbitrary file read/write via hardlink target escape through symlink chain during `tar.extract()` with default options.

## Motivation and Context

Follow-up to #4265, which bumped tar to 7.5.7 to address CVE-2026-23745, CVE-2026-23950, and CVE-2026-24842. A new CVE (CVE-2026-26960) has since been disclosed that requires tar >= 7.5.8.

## How Has This Been Tested?

Patch-level dependency bump only (7.5.7 → 7.5.8). No API changes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.