### PR TITLE
fix(deps): bump tar from 7.5.8 to 7.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16959,9 +16959,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -18471,7 +18471,7 @@
         "slash": "^3.0.0",
         "ssri": "12.0.0",
         "string-width": "^4.2.3",
-        "tar": "7.5.10",
+        "tar": "7.5.11",
         "temp-dir": "1.0.0",
         "through": "2.3.8",
         "tinyglobby": "0.2.12",
@@ -18645,7 +18645,7 @@
         "slash": "3.0.0",
         "ssri": "12.0.0",
         "string-width": "^4.2.3",
-        "tar": "7.5.10",
+        "tar": "7.5.11",
         "temp-dir": "1.0.0",
         "through": "2.3.8",
         "tinyglobby": "0.2.12",

--- a/packages/legacy-structure/commands/create/package.json
+++ b/packages/legacy-structure/commands/create/package.json
@@ -86,7 +86,7 @@
     "slash": "^3.0.0",
     "ssri": "12.0.0",
     "string-width": "^4.2.3",
-    "tar": "7.5.10",
+    "tar": "7.5.11",
     "temp-dir": "1.0.0",
     "through": "2.3.8",
     "tinyglobby": "0.2.12",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -102,7 +102,7 @@
     "slash": "3.0.0",
     "ssri": "12.0.0",
     "string-width": "^4.2.3",
-    "tar": "7.5.10",
+    "tar": "7.5.11",
     "temp-dir": "1.0.0",
     "through": "2.3.8",
     "tinyglobby": "0.2.12",


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary
- Bumps `tar` from 7.5.8 to 7.5.11 in `packages/lerna` and `packages/legacy-structure/commands/create`
- While [GHSA-qffp-2rhf-9h96](https://github.com/advisories/GHSA-qffp-2rhf-9h96) is not practically exploitable in the context of a local dev tool like Lerna, this update removes the advisory from `npm audit` output to reduce noise for users

Closes #4292

## Test plan
- [x] `npm install` succeeds and lockfile updated
- [x] `npm audit` no longer reports the tar advisory