### PR TITLE
chore(ci): add color env vars to other-node-versions task runner e2e

### DIFF
--- a/.github/workflows/other-node-versions.yml
+++ b/.github/workflows/other-node-versions.yml
@@ -131,6 +131,9 @@ jobs:
           # Silently disable nx cloud for task runner e2e (using NX_NO_CLOUD produces a warning log)
           NX_CLOUD_ACCESS_TOKEN: ""
           NX_CLOUD_DISTRIBUTED_EXECUTION: false
+          # Disable colored output so captured stdout matches local (non-TTY) snapshots
+          NO_COLOR: "1"
+          FORCE_COLOR: "0"
 
       - name: Stop all running agents
         # It's important that we always run this step, otherwise in the case of any failures in preceding non-Nx steps, the agents will keep running and waste billable minutes


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Adds `NO_COLOR=1` and `FORCE_COLOR=0` env vars to the task runner e2e step in the `other-node-versions.yml` workflow, matching what was already added to `ci.yml` in #4298
- Without these, captured stdout includes ANSI color codes that don't match the local (non-TTY) snapshots, causing nightly CI failures

## Test plan

- [x] Verify the nightly `Other Node Versions` workflow passes after this change