### PR TITLE
fix(version): skip config resolution in prettier getFileInfo check

### DIFF
--- a/libs/commands/version/src/lib/git-add.ts
+++ b/libs/commands/version/src/lib/git-add.ts
@@ -35,7 +35,7 @@ async function maybeFormatFile(filePath) {
   const ignorePath = path.join(workspaceRoot, ".prettierignore");
   const fullFilePath = path.join(workspaceRoot, filePath);
 
-  const fileInfo = await resolvedPrettier.getFileInfo(fullFilePath, { ignorePath });
+  const fileInfo = await resolvedPrettier.getFileInfo(fullFilePath, { ignorePath, resolveConfig: false });
 
   if (fileInfo.ignored) {
     log.silly("version", `Skipped applying prettier to ignored file: ${filePath}`);


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Pass `resolveConfig: false` to `prettier.getFileInfo()` in `git-add.ts` to prevent unnecessary plugin resolution when checking if a file is ignored
- Fixes monorepo setups where a nested project has a prettier plugin (e.g., `prettier-plugin-tailwindcss`) not installed at the root, which caused `lerna version` to fail with `Cannot find package`
- The full config is already resolved separately via `resolveConfig()` for the actual formatting step, so this change has no effect on formatting behavior

Fixes #4238

## Test plan

- [x] All 195 version command unit tests pass
- [x] Full test suite passes (`npm run test`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [x] Build passes (`nx run-many -t build`)
- [x] CI passes on this PR