### PR TITLE
chore(deps): remove tacks and tempy dev dependencies

### DIFF
--- a/integration/__tests__/lerna-init.spec.ts
+++ b/integration/__tests__/lerna-init.spec.ts
@@ -1,7 +1,8 @@
 import { cliRunner, initFixtureFactory } from "@lerna/test-helpers";
 import loadJsonFile from "load-json-file";
-import path from "path";
-import tempy from "tempy";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 const initFixture = initFixtureFactory(__dirname);
 
@@ -11,7 +12,7 @@ describe("lerna init", () => {
   const loadMetaData = (cwd: string) => Promise.all([parsePackageJson(cwd), parseLernaJson(cwd)]);
 
   test("initializes empty directory", async () => {
-    const cwd = tempy.directory();
+    const cwd = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "lerna-test-"));
 
     const { stderr } = await cliRunner(cwd)("init");
     expect(stderr).toMatchInlineSnapshot(`
@@ -49,7 +50,7 @@ describe("lerna init", () => {
   });
 
   test("works with dryRun", async () => {
-    const cwd = tempy.directory();
+    const cwd = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "lerna-test-"));
 
     const { stderr } = await cliRunner(cwd)("init", "--dryRun");
     const stderrWithoutVersion = stderr.replace(/\^[\d.]+-?[\w.]+/g, "<lerna-version>");

--- a/integration/__tests__/lerna-publish-validation.spec.ts
+++ b/integration/__tests__/lerna-publish-validation.spec.ts
@@ -1,8 +1,8 @@
 import { changelogSerializer, cliRunner, cloneFixtureFactory, gitAdd, gitCommit } from "@lerna/test-helpers";
 import execa from "execa";
 import fs from "fs-extra";
-import path from "path";
-import tempy from "tempy";
+import os from "node:os";
+import path from "node:path";
 
 const cloneFixture = cloneFixtureFactory(path.resolve(__dirname, "../../libs/commands/publish"));
 
@@ -18,7 +18,7 @@ const env = {
 
 test("lerna publish exits with EBEHIND when behind upstream remote", async () => {
   const { cwd, repository } = await cloneFixture("normal");
-  const cloneDir = tempy.directory();
+  const cloneDir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "lerna-test-"));
 
   // simulate upstream change from another clone
   await execa("git", ["clone", repository, cloneDir]);

--- a/libs/commands/version/src/lib/version-bump-prerelease.spec.ts
+++ b/libs/commands/version/src/lib/version-bump-prerelease.spec.ts
@@ -11,9 +11,8 @@ import {
   showCommit,
 } from "@lerna/test-helpers";
 import fs from "fs-extra";
-import path from "path";
-import Tacks from "tacks";
-import tempy from "tempy";
+import os from "node:os";
+import path from "node:path";
 
 jest.mock("./git-push");
 jest.mock("./is-anything-committed", () => ({
@@ -45,8 +44,6 @@ const promptTextInput = jest.mocked(_promptTextInput);
 const promptSelectOne = _promptSelectOne as any;
 
 const initFixture = initFixtureFactory(path.resolve(__dirname, "../../../publish"));
-
-const { File, Dir } = Tacks;
 
 // test command
 
@@ -138,36 +135,24 @@ describe("version bump prerelease", () => {
   });
 
   test("independent version prerelease does not bump on every unrelated change", async () => {
-    const cwd = tempy.directory();
-    const fixture = new Tacks(
-      Dir({
-        "lerna.json": File({
-          version: "independent",
-          packages: ["packages/*"],
-        }),
-        "package.json": File({
-          name: "unrelated-bumps",
-        }),
-        packages: Dir({
-          "pkg-a": Dir({
-            "package.json": File({
-              name: "pkg-a",
-              version: "1.0.0",
-            }),
-          }),
-          "pkg-b": Dir({
-            "package.json": File({
-              name: "pkg-b",
-              version: "1.0.0-bumps.1",
-              // TODO: (major) make --no-private the default
-              private: true,
-            }),
-          }),
-        }),
-      })
-    );
+    const cwd = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "lerna-test-"));
 
-    fixture.create(cwd);
+    fs.mkdirSync(path.join(cwd, "packages", "pkg-a"), { recursive: true });
+    fs.mkdirSync(path.join(cwd, "packages", "pkg-b"), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, "lerna.json"),
+      JSON.stringify({ version: "independent", packages: ["packages/*"] })
+    );
+    fs.writeFileSync(path.join(cwd, "package.json"), JSON.stringify({ name: "unrelated-bumps" }));
+    fs.writeFileSync(
+      path.join(cwd, "packages", "pkg-a", "package.json"),
+      JSON.stringify({ name: "pkg-a", version: "1.0.0" })
+    );
+    fs.writeFileSync(
+      path.join(cwd, "packages", "pkg-b", "package.json"),
+      // TODO: (major) make --no-private the default
+      JSON.stringify({ name: "pkg-b", version: "1.0.0-bumps.1", private: true })
+    );
 
     await gitInit(cwd, ".");
     await gitAdd(cwd, "-A");
@@ -210,37 +195,23 @@ Publish
   });
 
   test("independent version prerelease respects --no-private", async () => {
-    const cwd = tempy.directory();
-    const fixture = new Tacks(
-      Dir({
-        "lerna.json": File({
-          version: "independent",
-          packages: ["packages/*"],
-        }),
-        "package.json": File({
-          name: "no-private-versioning",
-        }),
-        packages: Dir({
-          "pkg-1": Dir({
-            "package.json": File({
-              name: "pkg-1",
-              version: "1.0.0",
-              devDependencies: {
-                "pkg-2": "^2.0.0",
-              },
-            }),
-          }),
-          "pkg-2": Dir({
-            "package.json": File({
-              name: "pkg-2",
-              version: "2.0.0",
-              private: true,
-            }),
-          }),
-        }),
-      })
+    const cwd = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "lerna-test-"));
+
+    fs.mkdirSync(path.join(cwd, "packages", "pkg-1"), { recursive: true });
+    fs.mkdirSync(path.join(cwd, "packages", "pkg-2"), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, "lerna.json"),
+      JSON.stringify({ version: "independent", packages: ["packages/*"] })
     );
-    fixture.create(cwd);
+    fs.writeFileSync(path.join(cwd, "package.json"), JSON.stringify({ name: "no-private-versioning" }));
+    fs.writeFileSync(
+      path.join(cwd, "packages", "pkg-1", "package.json"),
+      JSON.stringify({ name: "pkg-1", version: "1.0.0", devDependencies: { "pkg-2": "^2.0.0" } })
+    );
+    fs.writeFileSync(
+      path.join(cwd, "packages", "pkg-2", "package.json"),
+      JSON.stringify({ name: "pkg-2", version: "2.0.0", private: true })
+    );
 
     await gitInit(cwd, ".");
     await gitAdd(cwd, "-A");

--- a/libs/core/src/lib/command/index.spec.ts
+++ b/libs/core/src/lib/command/index.spec.ts
@@ -6,7 +6,7 @@ import { createProjectGraph } from "../test-helpers/create-project-graph";
 
 const fs = require("fs-extra");
 const path = require("path");
-const tempy = require("tempy");
+const nodeFs = require("node:fs");
 
 // partially mocked
 const childProcess = require("@lerna/child-process");
@@ -347,7 +347,7 @@ describe("command", () => {
 
   describe("validations", () => {
     it("throws ENOGIT when repository is not initialized", async () => {
-      const cwd = tempy.directory();
+      const cwd = nodeFs.mkdtempSync(path.join(nodeFs.realpathSync(os.tmpdir()), "lerna-test-"));
 
       const lernaConfigPath = path.join(cwd, "lerna.json");
       await fs.writeJson(lernaConfigPath, { version: "1.0.0", packages: [] });

--- a/libs/core/src/lib/listable-format-projects.spec.ts
+++ b/libs/core/src/lib/listable-format-projects.spec.ts
@@ -2,7 +2,9 @@
 // nx-ignore-next-line
 import { loggingOutput, tempDirSerializer, windowsPathSerializer } from "@lerna/test-helpers";
 import chalk from "chalk";
-import tempy from "tempy";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { formatJSON, listableFormatProjects } from "./listable-format-projects";
 import { ListableOptions } from "./listable-options";
 import { Package, RawManifest } from "./package";
@@ -41,7 +43,7 @@ describe("listableFormatProjects", () => {
     listableFormatProjects(projectNodes, projectGraph, { _: ["ls"], ...opts });
 
   beforeAll(() => {
-    const cwd = tempy.directory();
+    const cwd = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "lerna-test-"));
     process.chdir(cwd);
 
     projectNodes = createProjectNodes(cwd);

--- a/libs/core/src/lib/npm-conf/config-chain/tests/find-file.spec.ts
+++ b/libs/core/src/lib/npm-conf/config-chain/tests/find-file.spec.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { directory } from "tempy";
 
 const cc = require("../index");
 
@@ -8,7 +8,7 @@ const objx = {
   rand: Math.random(),
 };
 
-const tmpDir = directory();
+const tmpDir = fs.mkdtempSync(join(fs.realpathSync(tmpdir()), "lerna-test-"));
 const tmpFile = join(tmpDir, "random-test-config.json");
 
 fs.writeFileSync(tmpFile, JSON.stringify(objx));

--- a/libs/core/src/lib/npm-conf/config-chain/tests/save.spec.ts
+++ b/libs/core/src/lib/npm-conf/config-chain/tests/save.spec.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs";
 // @ts-expect-error - No types
 import ini from "ini";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { directory } from "tempy";
 
 const CC = require("../index").ConfigChain;
 
-const tmpDir = directory();
+const tmpDir = fs.mkdtempSync(join(fs.realpathSync(tmpdir()), "lerna-test-"));
 const f1 = join(tmpDir, "f1.ini");
 const f2 = join(tmpDir, "f2.json");
 

--- a/libs/test-helpers/__mocks__/load-json-file.js
+++ b/libs/test-helpers/__mocks__/load-json-file.js
@@ -8,8 +8,8 @@ const asyncRegistry = new Map();
 const syncRegistry = new Map();
 
 function incrementCalled(registry, manifestLocation) {
-  // tempy creates dirnames that are 32 characters long, but we want a readable key
-  const subPath = manifestLocation.split(/[0-9a-f]{32}/).pop();
+  // mkdtempSync creates dirnames with "lerna-test-" prefix and 6 random chars
+  const subPath = manifestLocation.split(/lerna-test-[A-Za-z0-9]{6}/).pop();
   const key = normalizePath(path.dirname(subPath));
 
   // keyed off directory subpath, _not_ pkg.name (we don't know it yet)

--- a/libs/test-helpers/src/lib/fixtures.ts
+++ b/libs/test-helpers/src/lib/fixtures.ts
@@ -1,9 +1,10 @@
 import execa from "execa";
 import findUp from "find-up";
 import { copy, ensureDir } from "fs-extra";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { directory } from "tempy";
 import { gitAdd, gitCommit, gitInit } from "./git";
 
 export function cloneFixtureFactory(startDir: any) {
@@ -14,7 +15,7 @@ export function cloneFixtureFactory(startDir: any) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     initFixture(...args).then((cwd) => {
-      const repoDir = directory();
+      const repoDir = mkdtempSync(join(realpathSync(tmpdir()), "lerna-test-"));
       const repoUrl = pathToFileURL(repoDir).toString();
 
       return execa("git", ["init", "--bare"], { cwd: repoDir })
@@ -44,7 +45,7 @@ export function copyFixture(targetDir: string, fixtureName: string, cwd: any) {
 
 export function initFixtureFactory(startDir: any) {
   return (fixtureName: string, commitMessage: string | false = "Init commit") => {
-    const cwd = directory();
+    const cwd = mkdtempSync(join(realpathSync(tmpdir()), "lerna-test-"));
     let chain = Promise.resolve();
 
     chain = chain.then(() => process.chdir(cwd));
@@ -74,7 +75,7 @@ export function initNamedFixtureFactory(startDir: any) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return (dirName: string, fixtureName: string, commitMessage = "Init commit") => {
-    const cwd = join(directory(), dirName);
+    const cwd = join(mkdtempSync(join(realpathSync(tmpdir()), "lerna-test-")), dirName);
     let chain = Promise.resolve();
 
     chain = chain.then(() => ensureDir(cwd));

--- a/libs/test-helpers/src/lib/serializers/serialize-tempdir.ts
+++ b/libs/test-helpers/src/lib/serializers/serialize-tempdir.ts
@@ -3,8 +3,8 @@ import { Config } from "pretty-format";
 
 const normalizePath = require("normalize-path");
 
-// tempy creates subdirectories with hexadecimal names that are 32 characters long
-const TEMP_DIR_REGEXP = /([^\s"]*[\\/][0-9a-f]{32})([^\s"]*)/g;
+// Match temp directories created by mkdtempSync with "lerna-test-" prefix (6 random chars)
+const TEMP_DIR_REGEXP = /([^\s"]*[\\/]lerna-test-[A-Za-z0-9]{6})([^\s"]*)/g;
 // the excluded quotes are due to other snapshot serializers mutating the raw input
 
 export const tempDirSerializer = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,8 +66,6 @@
         "prettier": "^2.2.1",
         "signal-exit": "3.0.7",
         "string-width": "^4.2.3",
-        "tacks": "1.2.6",
-        "tempy": "1.0.1",
         "touch": "^3.1.1",
         "ts-jest": "29.4.1",
         "ts-node": "10.9.2",
@@ -6117,8 +6115,6 @@
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7723,14 +7719,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "license": "MIT",
@@ -8828,14 +8816,6 @@
         "node": ">= 0.12.0"
       }
     },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -9231,16 +9211,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -9427,68 +9397,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/del/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
@@ -9555,19 +9463,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dot-prop": {
@@ -11120,27 +11015,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -11701,14 +11575,6 @@
         }
       }
     },
-    "node_modules/invert-kv": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ip-address": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
@@ -11842,26 +11708,6 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13021,17 +12867,6 @@
     "node_modules/kind-of": {
       "version": "6.0.3",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lcid": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14306,14 +14141,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/nx": {
       "version": "22.0.3",
       "resolved": "https://registry.npmjs.org/nx/-/nx-22.0.3.tgz",
@@ -14556,17 +14383,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/os-locale": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/oxc-resolver": {
@@ -16658,148 +16474,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tacks": {
-      "version": "1.2.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.1",
-        "yargs": "^3.32.0"
-      },
-      "bin": {
-        "tacks": "cmdline.js"
-      }
-    },
-    "node_modules/tacks/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tacks/node_modules/camelcase": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tacks/node_modules/cliui": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/tacks/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tacks/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tacks/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/tacks/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tacks/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tacks/node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tacks/node_modules/y18n": {
-      "version": "3.2.2",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/tacks/node_modules/yargs": {
-      "version": "3.32.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
-      }
-    },
     "node_modules/tar": {
       "version": "7.5.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
@@ -16848,49 +16522,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tempy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "del": "^6.0.0",
-        "is-stream": "^2.0.0",
-        "temp-dir": "^2.0.0",
-        "type-fest": "^0.16.0",
-        "unique-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tempy/node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tempy/node_modules/type-fest": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/test-exclude": {
@@ -17517,19 +17148,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
@@ -17980,17 +17598,6 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "node_modules/window-size": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "window-size": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "dev": true,
@@ -18164,6 +17771,85 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/legacy-structure/commands/create": {
+      "name": "@lerna/create",
+      "version": "9.0.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@npmcli/arborist": "9.1.6",
+        "@npmcli/package-json": "7.0.2",
+        "@npmcli/run-script": "10.0.3",
+        "@nx/devkit": ">=21.5.2 < 23.0.0",
+        "@octokit/plugin-enterprise-rest": "6.0.1",
+        "@octokit/rest": "20.1.2",
+        "aproba": "2.0.0",
+        "byte-size": "8.1.1",
+        "chalk": "4.1.0",
+        "ci-info": "4.3.1",
+        "cmd-shim": "6.0.3",
+        "color-support": "1.1.3",
+        "columnify": "1.6.0",
+        "console-control-strings": "^1.1.0",
+        "conventional-changelog-core": "5.0.1",
+        "conventional-recommended-bump": "7.0.1",
+        "cosmiconfig": "9.0.0",
+        "dedent": "1.5.3",
+        "execa": "5.0.0",
+        "fs-extra": "^11.2.0",
+        "get-stream": "6.0.0",
+        "git-url-parse": "14.0.0",
+        "glob-parent": "6.0.2",
+        "has-unicode": "2.0.1",
+        "ini": "^1.3.8",
+        "init-package-json": "8.2.2",
+        "inquirer": "12.9.6",
+        "is-ci": "3.0.1",
+        "is-stream": "2.0.0",
+        "js-yaml": "4.1.1",
+        "libnpmpublish": "11.1.2",
+        "load-json-file": "6.2.0",
+        "make-dir": "4.0.0",
+        "make-fetch-happen": "15.0.2",
+        "minimatch": "3.1.4",
+        "multimatch": "5.0.0",
+        "npm-package-arg": "13.0.1",
+        "npm-packlist": "10.0.3",
+        "npm-registry-fetch": "19.1.0",
+        "nx": ">=21.5.3 < 23.0.0",
+        "p-map": "4.0.0",
+        "p-map-series": "2.1.0",
+        "p-queue": "6.6.2",
+        "p-reduce": "^2.1.0",
+        "pacote": "21.0.1",
+        "pify": "5.0.0",
+        "read-cmd-shim": "4.0.0",
+        "resolve-from": "5.0.0",
+        "rimraf": "^6.1.2",
+        "semver": "7.7.2",
+        "set-blocking": "^2.0.0",
+        "signal-exit": "3.0.7",
+        "slash": "^3.0.0",
+        "ssri": "12.0.0",
+        "string-width": "^4.2.3",
+        "tar": "7.5.11",
+        "temp-dir": "1.0.0",
+        "through": "2.3.8",
+        "tinyglobby": "0.2.12",
+        "upath": "2.0.1",
+        "uuid": "^11.1.0",
+        "validate-npm-package-license": "3.0.4",
+        "validate-npm-package-name": "6.0.2",
+        "wide-align": "1.1.5",
+        "write-file-atomic": "5.0.1",
+        "write-pkg": "4.0.0",
+        "yargs": "17.7.2",
+        "yargs-parser": "21.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "packages/lerna": {

--- a/package.json
+++ b/package.json
@@ -85,8 +85,6 @@
     "prettier": "^2.2.1",
     "signal-exit": "3.0.7",
     "string-width": "^4.2.3",
-    "tacks": "1.2.6",
-    "tempy": "1.0.1",
     "touch": "^3.1.1",
     "ts-jest": "29.4.1",
     "ts-node": "10.9.2",


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Replace `tacks` and `tempy` dev dependencies with Node.js built-in APIs (`fs.mkdtempSync`, `fs.realpathSync`, `fs.mkdirSync`, `fs.writeFileSync`)
- Update `tempDirSerializer` regex and `load-json-file` mock to match the new `lerna-test-XXXXXX` temp directory naming pattern
- Remove both packages from root `package.json` devDependencies

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes (35/35 projects)
- [x] `npm run test` passes (all 19 projects)
- [x] `npm run integration` passes (no regressions vs main)
- [x] CI passes