### PR TITLE
fix(core): remove upath dependency

### DIFF
--- a/libs/core/src/lib/profiler.ts
+++ b/libs/core/src/lib/profiler.ts
@@ -1,5 +1,5 @@
 import fs from "fs-extra";
-import upath from "upath";
+import path from "path";
 import npmlog, { Logger } from "./npmlog";
 
 const hrtimeToMicroseconds = (hrtime: number[]) => {
@@ -25,7 +25,7 @@ const getTimeBasedFilename = () => {
 };
 
 export function generateProfileOutputPath(outputDirectory?: string) {
-  return upath.join(upath.resolve(outputDirectory || "."), getTimeBasedFilename());
+  return path.join(path.resolve(outputDirectory || "."), getTimeBasedFilename());
 }
 
 interface ProfilerConfig {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17595,14 +17595,6 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
-    "node_modules/upath": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4",
-        "yarn": "*"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -18228,7 +18220,6 @@
         "tar": "7.5.11",
         "through": "2.3.8",
         "tinyglobby": "0.2.12",
-        "upath": "2.0.1",
         "validate-npm-package-license": "3.0.4",
         "validate-npm-package-name": "6.0.2",
         "wide-align": "1.1.5",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -96,7 +96,6 @@
     "tar": "7.5.11",
     "through": "2.3.8",
     "tinyglobby": "0.2.12",
-    "upath": "2.0.1",
     "validate-npm-package-license": "3.0.4",
     "validate-npm-package-name": "6.0.2",
     "wide-align": "1.1.5",


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Replace `upath` with native `path` module in the profiler (single usage site)
- `upath` only normalizes backslashes to forward slashes, which is unnecessary for local filesystem paths

## Test plan

- [x] All 518 core tests pass
- [x] Profiler tests pass with native `path`