### PR TITLE
refactor(core): remove slash dependency

### DIFF
--- a/libs/commands/create/__tests__/create-command.spec.ts
+++ b/libs/commands/create/__tests__/create-command.spec.ts
@@ -3,7 +3,7 @@ import execa from "execa";
 import fs from "fs-extra";
 import _pacote from "pacote";
 import path from "path";
-import slash from "slash";
+import { slash } from "@lerna/core";
 
 jest.mock("pacote");
 

--- a/libs/commands/create/src/index.ts
+++ b/libs/commands/create/src/index.ts
@@ -11,7 +11,7 @@ import os from "os";
 import pReduce from "p-reduce";
 import pacote from "pacote";
 import path from "path";
-import slash from "slash";
+import { slash } from "@lerna/core";
 import { URL } from "url";
 import { camelCase } from "yargs-parser";
 

--- a/libs/commands/version/src/lib/git-add.spec.ts
+++ b/libs/commands/version/src/lib/git-add.spec.ts
@@ -2,7 +2,7 @@ import { initFixtureFactory } from "@lerna/test-helpers";
 import execa from "execa";
 import fs from "fs-extra";
 import path from "path";
-import slash from "slash";
+import { slash } from "@lerna/core";
 import { gitAdd } from "./git-add";
 
 const initFixture = initFixtureFactory(__dirname);

--- a/libs/commands/version/src/lib/git-add.ts
+++ b/libs/commands/version/src/lib/git-add.ts
@@ -3,7 +3,7 @@ import { readJsonFile, workspaceRoot } from "@nx/devkit";
 import { ExecOptions } from "child_process";
 import fs from "fs";
 import path from "path";
-import slash from "slash";
+import { slash } from "@lerna/core";
 
 const childProcess = require("@lerna/child-process");
 

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -23,6 +23,7 @@ export { hasNpmVersion } from "./lib/has-npm-version";
 export { formatJSON, listableFormatProjects } from "./lib/listable-format-projects";
 export { multimatch } from "./lib/multimatch";
 export { ListableOptions, listableOptions } from "./lib/listable-options";
+export { slash } from "./lib/slash";
 export { logPacked } from "./lib/log-packed";
 export { Conf } from "./lib/npm-conf/conf";
 export { npmInstall, npmInstallDependencies } from "./lib/npm-install";

--- a/libs/core/src/lib/__tests__/slash.spec.ts
+++ b/libs/core/src/lib/__tests__/slash.spec.ts
@@ -1,0 +1,29 @@
+import { slash } from "../slash";
+
+describe("slash", () => {
+  it("should convert backslashes to forward slashes", () => {
+    expect(slash("foo\\bar")).toBe("foo/bar");
+    expect(slash("foo\\bar\\baz")).toBe("foo/bar/baz");
+  });
+
+  it("should leave forward slashes unchanged", () => {
+    expect(slash("foo/bar")).toBe("foo/bar");
+    expect(slash("foo/bar/baz")).toBe("foo/bar/baz");
+  });
+
+  it("should handle mixed slashes", () => {
+    expect(slash("foo\\bar/baz")).toBe("foo/bar/baz");
+  });
+
+  it("should handle empty string", () => {
+    expect(slash("")).toBe("");
+  });
+
+  it("should not modify extended-length paths", () => {
+    expect(slash("\\\\?\\some\\path")).toBe("\\\\?\\some\\path");
+  });
+
+  it("should handle paths with no slashes", () => {
+    expect(slash("foo")).toBe("foo");
+  });
+});

--- a/libs/core/src/lib/collect-updates/make-diff-predicate.ts
+++ b/libs/core/src/lib/collect-updates/make-diff-predicate.ts
@@ -2,7 +2,7 @@ const { execSync } = require("@lerna/child-process");
 import { ExecOptions } from "child_process";
 import minimatch from "minimatch";
 import { relative } from "path";
-import slash from "slash";
+import { slash } from "../slash";
 import log from "../npmlog";
 import { getPackage, ProjectGraphProjectNodeWithPackage } from "../project-graph-with-packages";
 

--- a/libs/core/src/lib/slash.ts
+++ b/libs/core/src/lib/slash.ts
@@ -1,0 +1,13 @@
+/**
+ * Convert Windows backslash paths to forward slash paths.
+ * Preserves Windows extended-length paths (\\?\) as-is.
+ */
+export function slash(path: string): string {
+  const isExtendedLengthPath = path.startsWith("\\\\?\\");
+
+  if (isExtendedLengthPath) {
+    return path;
+  }
+
+  return path.replace(/\\/g, "/");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16077,6 +16077,7 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17900,7 +17901,6 @@
         "read-cmd-shim": "4.0.0",
         "semver": "7.7.2",
         "signal-exit": "3.0.7",
-        "slash": "3.0.0",
         "ssri": "12.0.0",
         "string-width": "^4.2.3",
         "tar": "7.5.11",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -90,7 +90,6 @@
     "read-cmd-shim": "4.0.0",
     "semver": "7.7.2",
     "signal-exit": "3.0.7",
-    "slash": "3.0.0",
     "ssri": "12.0.0",
     "string-width": "^4.2.3",
     "tar": "7.5.11",


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Replace `slash` package with an internal utility in `@lerna/core`
- The function is trivial: converts backslashes to forward slashes, preserving Windows extended-length paths (`\\?\`)
- Updated 3 source files and 2 test files to use the internal utility
- Added unit tests for the internal implementation

## Test plan

- [x] New `slash.spec.ts` unit tests pass
- [x] Core tests pass (524 tests)
- [x] Version command tests pass (195 tests)
- [x] Create command tests pass