### PR TITLE
refactor(core): remove get-stream dependency

### DIFF
--- a/libs/core/src/lib/conventional-commits/update-changelog.ts
+++ b/libs/core/src/lib/conventional-commits/update-changelog.ts
@@ -1,6 +1,5 @@
 import conventionalChangelogCore from "conventional-changelog-core";
 import fs from "fs-extra";
-import getStream from "get-stream";
 import log from "../npmlog";
 import { Package } from "../package";
 import { BLANK_LINE, BaseChangelogOptions, CHANGELOG_HEADER, ChangelogType, EOL } from "./constants";
@@ -65,7 +64,7 @@ export function updateChangelog(
     const changelogStream = conventionalChangelogCore(options, context, gitRawCommitsOpts);
 
     return Promise.all([
-      getStream(changelogStream).then(makeBumpOnlyFilter(pkg)),
+      streamToString(changelogStream).then(makeBumpOnlyFilter(pkg)),
       readExistingChangelog(pkg),
     ]).then(([newEntry, [changelogFileLoc, changelogContents]]) => {
       // Append any additional markdown to the new entry, if provided
@@ -92,4 +91,12 @@ export function updateChangelog(
       });
     });
   });
+}
+
+async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: string[] = [];
+  for await (const chunk of stream) {
+    chunks.push(String(chunk));
+  }
+  return chunks.join("");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17871,7 +17871,6 @@
         "envinfo": "7.13.0",
         "execa": "5.0.0",
         "fs-extra": "^11.2.0",
-        "get-stream": "6.0.0",
         "git-url-parse": "14.0.0",
         "glob-parent": "6.0.2",
         "has-unicode": "2.0.1",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -60,7 +60,6 @@
     "envinfo": "7.13.0",
     "execa": "5.0.0",
     "fs-extra": "^11.2.0",
-    "get-stream": "6.0.0",
     "git-url-parse": "14.0.0",
     "glob-parent": "6.0.2",
     "has-unicode": "2.0.1",


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Replace `get-stream` with an inline `for await...of` helper in `update-changelog.ts` (single usage site)
- The stream is a text changelog stream, so simple string concatenation suffices

## Test plan

- [x] All 46 conventional-commits tests pass