### PR TITLE
refactor(core): replace wide-align with internal implementation

### DIFF
--- a/libs/core/src/lib/npmlog/gauge/render-template.ts
+++ b/libs/core/src/lib/npmlog/gauge/render-template.ts
@@ -6,7 +6,7 @@
  */
 
 "use strict";
-var align = require("wide-align");
+var align = require("./wide-align");
 var validate = require("aproba");
 var wideTruncate = require("./wide-truncate");
 var error = require("./error");

--- a/libs/core/src/lib/npmlog/gauge/tests/wide-align.spec.ts
+++ b/libs/core/src/lib/npmlog/gauge/tests/wide-align.spec.ts
@@ -1,0 +1,108 @@
+export {};
+
+const align = require("../wide-align");
+
+describe("wide-align", () => {
+  describe("align.left", () => {
+    it("should pad a narrow string to the target width", () => {
+      expect(align.left("abc", 6)).toBe("abc   ");
+    });
+
+    it("should handle wide (CJK) characters", () => {
+      // "古" is 2 columns wide, so "古古" = 4 columns, needs 2 more to reach 6
+      expect(align.left("古古", 6)).toBe("古古  ");
+    });
+
+    it("should handle emoji characters", () => {
+      // emoji are typically 2 columns wide
+      const result = align.left("😀", 4);
+      expect(result.length).toBeGreaterThanOrEqual(2);
+      expect(result).toMatch(/^😀/);
+    });
+
+    it("should return trimmed string when wider than target width", () => {
+      expect(align.left("abcdef", 3)).toBe("abcdef");
+    });
+
+    it("should return trimmed string when equal to target width", () => {
+      expect(align.left("abc", 3)).toBe("abc");
+    });
+
+    it("should handle empty string", () => {
+      expect(align.left("", 5)).toBe("     ");
+    });
+
+    it("should trim trailing whitespace before padding", () => {
+      expect(align.left("abc   ", 6)).toBe("abc   ");
+    });
+
+    it("should return original string when all whitespace and length >= width", () => {
+      expect(align.left("      ", 4)).toBe("      ");
+    });
+  });
+
+  describe("align.right", () => {
+    it("should pad a narrow string to the target width", () => {
+      expect(align.right("abc", 6)).toBe("   abc");
+    });
+
+    it("should handle wide (CJK) characters", () => {
+      expect(align.right("古古", 6)).toBe("  古古");
+    });
+
+    it("should return trimmed string when wider than target width", () => {
+      expect(align.right("abcdef", 3)).toBe("abcdef");
+    });
+
+    it("should return trimmed string when equal to target width", () => {
+      expect(align.right("abc", 3)).toBe("abc");
+    });
+
+    it("should handle empty string", () => {
+      expect(align.right("", 5)).toBe("     ");
+    });
+
+    it("should trim leading whitespace before padding", () => {
+      expect(align.right("   abc", 6)).toBe("   abc");
+    });
+
+    it("should return original string when all whitespace and length >= width", () => {
+      expect(align.right("      ", 4)).toBe("      ");
+    });
+  });
+
+  describe("align.center", () => {
+    it("should center a narrow string within the target width", () => {
+      expect(align.center("abc", 7)).toBe("  abc  ");
+    });
+
+    it("should handle odd padding by putting extra space on the right", () => {
+      expect(align.center("abc", 6)).toBe(" abc  ");
+    });
+
+    it("should handle wide (CJK) characters", () => {
+      // "古" = 2 columns, need 4 more padding for width 6: 2 left + 2 right
+      expect(align.center("古", 6)).toBe("  古  ");
+    });
+
+    it("should return trimmed string when wider than target width", () => {
+      expect(align.center("abcdef", 3)).toBe("abcdef");
+    });
+
+    it("should return trimmed string when equal to target width", () => {
+      expect(align.center("abc", 3)).toBe("abc");
+    });
+
+    it("should handle empty string", () => {
+      expect(align.center("", 5)).toBe("     ");
+    });
+
+    it("should trim both sides before padding", () => {
+      expect(align.center("  abc  ", 7)).toBe("  abc  ");
+    });
+
+    it("should return original string when all whitespace and length >= width", () => {
+      expect(align.center("      ", 4)).toBe("      ");
+    });
+  });
+});

--- a/libs/core/src/lib/npmlog/gauge/wide-align.ts
+++ b/libs/core/src/lib/npmlog/gauge/wide-align.ts
@@ -1,0 +1,51 @@
+/* eslint-disable */
+// @ts-nocheck
+
+/**
+ * Inlined from deprecated package https://github.com/iarna/wide-align
+ */
+
+"use strict";
+var stringWidth = require("string-width");
+
+function alignLeft(str: string, width: number): string {
+  var trimmed = str.trimEnd();
+  if (trimmed.length === 0 && str.length >= width) return str;
+  var strWidth = stringWidth(trimmed);
+
+  if (strWidth < width) {
+    return trimmed + " ".repeat(width - strWidth);
+  }
+
+  return trimmed;
+}
+
+function alignRight(str: string, width: number): string {
+  var trimmed = str.trimStart();
+  if (trimmed.length === 0 && str.length >= width) return str;
+  var strWidth = stringWidth(trimmed);
+
+  if (strWidth < width) {
+    return " ".repeat(width - strWidth) + trimmed;
+  }
+
+  return trimmed;
+}
+
+function alignCenter(str: string, width: number): string {
+  var trimmed = str.trim();
+  if (trimmed.length === 0 && str.length >= width) return str;
+  var strWidth = stringWidth(trimmed);
+
+  if (strWidth < width) {
+    var padLeftBy = Math.floor((width - strWidth) / 2);
+    var padRightBy = width - strWidth - padLeftBy;
+    return " ".repeat(padLeftBy) + trimmed + " ".repeat(padRightBy);
+  }
+
+  return trimmed;
+}
+
+exports.left = alignLeft;
+exports.right = alignRight;
+exports.center = alignCenter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17542,13 +17542,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "dev": true,
@@ -17858,7 +17851,6 @@
         "tinyglobby": "0.2.12",
         "validate-npm-package-license": "3.0.4",
         "validate-npm-package-name": "6.0.2",
-        "wide-align": "1.1.5",
         "write-file-atomic": "5.0.1",
         "yargs": "17.7.2"
       },

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -89,7 +89,6 @@
     "tinyglobby": "0.2.12",
     "validate-npm-package-license": "3.0.4",
     "validate-npm-package-name": "6.0.2",
-    "wide-align": "1.1.5",
     "write-file-atomic": "5.0.1",
     "yargs": "17.7.2"
   },


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Replace the `wide-align` npm package with an inlined TypeScript implementation in `libs/core/src/lib/npmlog/gauge/wide-align.ts`
- Modernize the implementation: `String.prototype.repeat()` instead of lodash-style padding loop, `trimEnd`/`trimStart` instead of deprecated `trimRight`/`trimLeft`
- Add comprehensive test suite (23 tests) covering CJK characters, emoji, edge cases, and trimming behavior
- Remove `wide-align` from production dependencies

`wide-align` was only used in the inlined gauge module's `render-template.ts` for text alignment with Unicode-aware width calculation.

## Test plan

- [x] All existing `render-template` tests pass
- [x] All existing `plumbing` and `progress-bar` tests pass (indirect consumers)
- [x] New `wide-align.spec.ts` tests pass (23 tests)
- [x] Build passes (`nx run lerna:compile`)
- [x] Lint passes
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)