### PR TITLE
refactor(core): replace aproba with internal validate implementation

### DIFF
--- a/libs/core/src/lib/npmlog/gauge/plumbing.ts
+++ b/libs/core/src/lib/npmlog/gauge/plumbing.ts
@@ -8,7 +8,7 @@
 "use strict";
 var consoleControl = require("./console-control-strings");
 var renderTemplate = require("./render-template");
-var validate = require("aproba");
+var validate = require("./validate");
 
 var Plumbing = (module.exports = function (theme, template, width) {
   if (!width) {

--- a/libs/core/src/lib/npmlog/gauge/progress-bar.ts
+++ b/libs/core/src/lib/npmlog/gauge/progress-bar.ts
@@ -6,7 +6,7 @@
  */
 
 "use strict";
-var validate = require("aproba");
+var validate = require("./validate");
 var renderTemplate = require("./render-template.js");
 var wideTruncate = require("./wide-truncate");
 var stringWidth = require("string-width");

--- a/libs/core/src/lib/npmlog/gauge/render-template.ts
+++ b/libs/core/src/lib/npmlog/gauge/render-template.ts
@@ -7,7 +7,7 @@
 
 "use strict";
 var align = require("./wide-align");
-var validate = require("aproba");
+var validate = require("./validate");
 var wideTruncate = require("./wide-truncate");
 var error = require("./error");
 var TemplateItem = require("./template-item");

--- a/libs/core/src/lib/npmlog/gauge/tests/validate.spec.ts
+++ b/libs/core/src/lib/npmlog/gauge/tests/validate.spec.ts
@@ -1,0 +1,194 @@
+export {};
+
+const validate = require("../validate");
+
+describe("validate", () => {
+  describe("basic type checks", () => {
+    it("accepts a string with S schema", () => {
+      expect(() => validate("S", ["hello"])).not.toThrow();
+    });
+
+    it("accepts a number with N schema", () => {
+      expect(() => validate("N", [42])).not.toThrow();
+    });
+
+    it("accepts a boolean with B schema", () => {
+      expect(() => validate("B", [true])).not.toThrow();
+      expect(() => validate("B", [false])).not.toThrow();
+    });
+
+    it("accepts a function with F schema", () => {
+      expect(() => validate("F", [() => {}])).not.toThrow();
+    });
+
+    it("accepts an object with O schema", () => {
+      expect(() => validate("O", [{ a: 1 }])).not.toThrow();
+    });
+
+    it("accepts an array with A schema", () => {
+      expect(() => validate("A", [[1, 2, 3]])).not.toThrow();
+    });
+
+    it("accepts an error with E schema", () => {
+      expect(() => validate("E", [new Error("test")])).not.toThrow();
+    });
+
+    it("accepts null with Z schema", () => {
+      expect(() => validate("Z", [null])).not.toThrow();
+    });
+
+    it("accepts undefined with Z schema", () => {
+      expect(() => validate("Z", [undefined])).not.toThrow();
+    });
+
+    it("accepts anything with * schema", () => {
+      expect(() => validate("*", ["hello"])).not.toThrow();
+      expect(() => validate("*", [42])).not.toThrow();
+      expect(() => validate("*", [null])).not.toThrow();
+      expect(() => validate("*", [undefined])).not.toThrow();
+      expect(() => validate("*", [{}])).not.toThrow();
+    });
+  });
+
+  describe("multi-argument schemas", () => {
+    it("validates OAN (object, array, number)", () => {
+      expect(() => validate("OAN", [{}, [1], 5])).not.toThrow();
+    });
+
+    it("validates ONN (object, number, number)", () => {
+      expect(() => validate("ONN", [{}, 1, 2])).not.toThrow();
+    });
+
+    it("validates OON (object, object, number)", () => {
+      expect(() => validate("OON", [{}, {}, 3])).not.toThrow();
+    });
+  });
+
+  describe("pipe-separated multi-schema", () => {
+    it("accepts either schema separated by pipe", () => {
+      expect(() => validate("SO|N", ["hello", {}])).not.toThrow();
+      expect(() => validate("SO|N", [42])).not.toThrow();
+    });
+
+    it("rejects values matching neither schema", () => {
+      expect(() => validate("S|N", [{}])).toThrow();
+    });
+  });
+
+  describe("error type expansion", () => {
+    it("accepts Error with E schema", () => {
+      expect(() => validate("SE", ["test", new Error()])).not.toThrow();
+    });
+
+    it("accepts null in place of Error (Z expansion)", () => {
+      expect(() => validate("SE", ["test", null])).not.toThrow();
+    });
+
+    it("allows E schema with zero args when schema length is 1", () => {
+      expect(() => validate("E", [])).not.toThrow();
+    });
+
+    it("allows truncated form (just E) for longer schemas", () => {
+      // "SE" expands to also accept just "SE" truncated to "E" at the E position
+      // and "SZ" (replacing E with Z)
+      expect(() => validate("SE", ["test", new Error()])).not.toThrow();
+      expect(() => validate("SE", ["test", null])).not.toThrow();
+    });
+  });
+
+  describe("isArguments detection", () => {
+    it("accepts an arguments-like object with A schema", () => {
+      const argsLike = { 0: "a", 1: "b", length: 2, callee: () => {} };
+      expect(() => validate("A", [argsLike])).not.toThrow();
+    });
+
+    it("does not treat a regular object as arguments", () => {
+      expect(() => validate("A", [{ a: 1 }])).toThrow();
+    });
+  });
+
+  describe("O type excludes arrays and errors", () => {
+    it("rejects an array for O schema", () => {
+      expect(() => validate("O", [[1, 2]])).toThrow();
+    });
+
+    it("rejects an Error for O schema", () => {
+      expect(() => validate("O", [new Error("test")])).toThrow();
+    });
+  });
+
+  describe("error codes", () => {
+    it("throws EWRONGARGCOUNT for wrong number of args", () => {
+      try {
+        validate("SN", ["hello"]);
+        fail("should have thrown");
+      } catch (err: any) {
+        expect(err.code).toBe("EWRONGARGCOUNT");
+        expect(err.message).toMatch(/Expected/);
+        expect(err.message).toMatch(/but got 1/);
+      }
+    });
+
+    it("throws EUNKNOWNTYPE for unknown type codes", () => {
+      try {
+        validate("X", ["hello"]);
+        fail("should have thrown");
+      } catch (err: any) {
+        expect(err.code).toBe("EUNKNOWNTYPE");
+        expect(err.message).toMatch(/Unknown type X/);
+      }
+    });
+
+    it("throws EINVALIDTYPE for type mismatch", () => {
+      try {
+        validate("S", [42]);
+        fail("should have thrown");
+      } catch (err: any) {
+        expect(err.code).toBe("EINVALIDTYPE");
+        expect(err.message).toMatch(/Expected string but got number/);
+      }
+    });
+
+    it("throws EMISSINGARG when rawSchemas is falsy", () => {
+      try {
+        validate("", ["hello"]);
+        fail("should have thrown");
+      } catch (err: any) {
+        expect(err.code).toBe("EMISSINGARG");
+        expect(err.message).toMatch(/Missing required argument #1/);
+      }
+    });
+
+    it("throws ETOOMANYERRORTYPES for multiple E in schema", () => {
+      try {
+        validate("EE", [new Error(), new Error()]);
+        fail("should have thrown");
+      } catch (err: any) {
+        expect(err.code).toBe("ETOOMANYERRORTYPES");
+        expect(err.message).toMatch(/Only one error type per argument signature/);
+      }
+    });
+  });
+
+  describe("descriptive error messages", () => {
+    it("uses english list with 'or' for multiple expected types", () => {
+      try {
+        validate("S|N", [{}]);
+        fail("should have thrown");
+      } catch (err: any) {
+        expect(err.code).toBe("EINVALIDTYPE");
+        expect(err.message).toMatch(/string or number/);
+      }
+    });
+
+    it("includes argument position in error messages", () => {
+      try {
+        validate("SN", ["hello", "world"]);
+        fail("should have thrown");
+      } catch (err: any) {
+        expect(err.code).toBe("EINVALIDTYPE");
+        expect(err.message).toMatch(/Argument #2/);
+      }
+    });
+  });
+});

--- a/libs/core/src/lib/npmlog/gauge/validate.ts
+++ b/libs/core/src/lib/npmlog/gauge/validate.ts
@@ -1,5 +1,3 @@
-export {};
-
 /**
  * Inlined from deprecated package https://github.com/npm/aproba/blob/v2.0.0/index.js
  */
@@ -128,4 +126,4 @@ function newException(code: string, msg: string): ValidateError {
   return err;
 }
 
-module.exports = validate;
+export = validate;

--- a/libs/core/src/lib/npmlog/gauge/validate.ts
+++ b/libs/core/src/lib/npmlog/gauge/validate.ts
@@ -1,3 +1,5 @@
+export {};
+
 /**
  * Inlined from deprecated package https://github.com/npm/aproba/blob/v2.0.0/index.js
  */

--- a/libs/core/src/lib/npmlog/gauge/validate.ts
+++ b/libs/core/src/lib/npmlog/gauge/validate.ts
@@ -1,0 +1,129 @@
+/**
+ * Inlined from deprecated package https://github.com/npm/aproba/blob/v2.0.0/index.js
+ */
+
+"use strict";
+
+interface ValidateError extends Error {
+  code: string;
+}
+
+interface TypeDef {
+  label: string;
+  check: (value: any) => boolean;
+}
+
+interface TypeMap {
+  [key: string]: TypeDef;
+}
+
+function isArguments(thingy: any): boolean {
+  return (
+    thingy != null && typeof thingy === "object" && Object.prototype.hasOwnProperty.call(thingy, "callee")
+  );
+}
+
+const types: TypeMap = {
+  "*": { label: "any", check: () => true },
+  A: { label: "array", check: (_: any) => Array.isArray(_) || isArguments(_) },
+  S: { label: "string", check: (_: any) => typeof _ === "string" },
+  N: { label: "number", check: (_: any) => typeof _ === "number" },
+  F: { label: "function", check: (_: any) => typeof _ === "function" },
+  O: {
+    label: "object",
+    check: (_: any) => typeof _ === "object" && _ != null && !types.A.check(_) && !types.E.check(_),
+  },
+  B: { label: "boolean", check: (_: any) => typeof _ === "boolean" },
+  E: { label: "error", check: (_: any) => _ instanceof Error },
+  Z: { label: "null", check: (_: any) => _ == null },
+};
+
+function addSchema(schema: string, arity: { [key: number]: string[] }): void {
+  const group = (arity[schema.length] = arity[schema.length] || []);
+  if (group.indexOf(schema) === -1) group.push(schema);
+}
+
+function validate(rawSchemas: string, args: any[] | IArguments): void {
+  if (arguments.length !== 2) throw wrongNumberOfArgs(["SA"], arguments.length);
+  if (!rawSchemas) throw missingRequiredArg(0);
+  if (!args) throw missingRequiredArg(1);
+  if (!types.S.check(rawSchemas)) throw invalidType(0, ["string"], rawSchemas);
+  if (!types.A.check(args)) throw invalidType(1, ["array"], args);
+  const schemas = rawSchemas.split("|");
+  const arity: { [key: number]: string[] } = {};
+
+  schemas.forEach((schema) => {
+    for (let ii = 0; ii < schema.length; ++ii) {
+      const type = schema[ii];
+      if (!types[type]) throw unknownType(ii, type);
+    }
+    if (/E.*E/.test(schema)) throw moreThanOneError(schema);
+    addSchema(schema, arity);
+    if (/E/.test(schema)) {
+      addSchema(schema.replace(/E.*$/, "E"), arity);
+      addSchema(schema.replace(/E/, "Z"), arity);
+      if (schema.length === 1) addSchema("", arity);
+    }
+  });
+  let matching = arity[args.length];
+  if (!matching) {
+    throw wrongNumberOfArgs(Object.keys(arity).map(Number), args.length);
+  }
+  for (let ii = 0; ii < args.length; ++ii) {
+    const newMatching = matching.filter((schema) => {
+      const type = schema[ii];
+      const typeCheck = types[type].check;
+      return typeCheck(args[ii]);
+    });
+    if (!newMatching.length) {
+      const labels = matching.map((_) => types[_[ii]].label).filter((_) => _ != null);
+      throw invalidType(ii, labels, args[ii]);
+    }
+    matching = newMatching;
+  }
+}
+
+function missingRequiredArg(num: number): ValidateError {
+  return newException("EMISSINGARG", "Missing required argument #" + (num + 1));
+}
+
+function unknownType(num: number, type: string): ValidateError {
+  return newException("EUNKNOWNTYPE", "Unknown type " + type + " in argument #" + (num + 1));
+}
+
+function invalidType(num: number, expectedTypes: (string | number)[], value: any): ValidateError {
+  let valueType: string | undefined;
+  Object.keys(types).forEach((typeCode) => {
+    if (types[typeCode].check(value)) valueType = types[typeCode].label;
+  });
+  return newException(
+    "EINVALIDTYPE",
+    "Argument #" + (num + 1) + ": Expected " + englishList(expectedTypes) + " but got " + valueType
+  );
+}
+
+function englishList(list: (string | number)[]): string {
+  return list.join(", ").replace(/, ([^,]+)$/, " or $1");
+}
+
+function wrongNumberOfArgs(expected: (string | number)[], got: number): ValidateError {
+  const english = englishList(expected);
+  const args = expected.every((ex) => String(ex).length === 1) ? "argument" : "arguments";
+  return newException("EWRONGARGCOUNT", "Expected " + english + " " + args + " but got " + got);
+}
+
+function moreThanOneError(schema: string): ValidateError {
+  return newException(
+    "ETOOMANYERRORTYPES",
+    'Only one error type per argument signature is allowed, more than one found in "' + schema + '"'
+  );
+}
+
+function newException(code: string, msg: string): ValidateError {
+  const err = new Error(msg) as ValidateError;
+  err.code = code;
+  if (Error.captureStackTrace) Error.captureStackTrace(err, validate);
+  return err;
+}
+
+module.exports = validate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7685,10 +7685,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/aproba": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
@@ -17774,7 +17770,6 @@
         "@nx/devkit": ">=21.5.2 < 23.0.0",
         "@octokit/plugin-enterprise-rest": "6.0.1",
         "@octokit/rest": "20.1.2",
-        "aproba": "2.0.0",
         "ci-info": "4.3.1",
         "cmd-shim": "6.0.3",
         "columnify": "1.6.0",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -44,7 +44,6 @@
     "@nx/devkit": ">=21.5.2 < 23.0.0",
     "@octokit/plugin-enterprise-rest": "6.0.1",
     "@octokit/rest": "20.1.2",
-    "aproba": "2.0.0",
     "ci-info": "4.3.1",
     "cmd-shim": "6.0.3",
     "columnify": "1.6.0",


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Replace the external `aproba@2.0.0` dependency with a TypeScript implementation inlined into the gauge module (`libs/core/src/lib/npmlog/gauge/validate.ts`)
- Update all 3 consumer files (`plumbing.ts`, `progress-bar.ts`, `render-template.ts`) to import from `./validate` instead of `aproba`
- Remove `aproba` from `packages/lerna/package.json`
- Add comprehensive test suite covering all type codes (`*`, `A`, `S`, `N`, `F`, `O`, `B`, `E`, `Z`), multi-schema pipes, error type expansion, and all error conditions

## Test plan

- [x] All 77 core test suites pass (734 tests)
- [x] New `validate.spec.ts` covers all type codes, multi-schema, error expansion, and error codes
- [x] Existing gauge tests (plumbing, progress-bar, render-template) continue to pass
- [x] `npm run format:check` passes
- [x] `nx lint core` passes (no new errors)