### PR TITLE
fix(publish): show output from publish and postpublish lifecycle scripts

### DIFF
--- a/e2e/publish/src/publish-lifecycle-output.spec.ts
+++ b/e2e/publish/src/publish-lifecycle-output.spec.ts
@@ -1,0 +1,119 @@
+import { Fixture, normalizeCommitSHAs, normalizeEnvironment, trimEnds } from "@lerna/e2e-utils";
+
+const randomInt = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+const randomVersion = () => `${randomInt(10, 89)}.${randomInt(10, 89)}.${randomInt(10, 89)}`;
+
+expect.addSnapshotSerializer({
+  serialize(str: string) {
+    return trimEnds(
+      normalizeCommitSHAs(normalizeEnvironment(str))
+        .replaceAll(/integrity:\s*.*/g, "integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+        .replaceAll(/\d*B package\.json/g, "XXXB package.json")
+        .replaceAll(/size:\s*\d*\s?B/g, "size: XXXB")
+        .replaceAll(/\d*\.\d*\s?kB/g, "XXX.XXX kb")
+    );
+  },
+  test(val: string) {
+    return val != null && typeof val === "string";
+  },
+});
+
+describe("lerna-publish-lifecycle-output", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await Fixture.create({
+      e2eRoot: process.env.E2E_ROOT,
+      name: "lerna-publish",
+      packageManager: "npm",
+      initializeGit: true,
+      lernaInit: { args: [`--packages="packages/*"`] },
+      installDependencies: true,
+    });
+  });
+  afterEach(() => fixture.destroy());
+
+  // Regression test for https://github.com/lerna/lerna/issues/4090
+  it("should show postpublish lifecycle script output", async () => {
+    await fixture.lerna("create test-1 -y");
+
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/test-1",
+      scripts: {
+        postpublish: "echo POSTPUBLISH_OUTPUT_TEST_1",
+      },
+    });
+
+    await fixture.createInitialGitCommit();
+    await fixture.exec("git push origin test-main");
+
+    const version = randomVersion();
+    await fixture.lerna(`version ${version} -y`);
+
+    await fixture.exec('echo "registry=http://localhost:4873" > .npmrc');
+
+    const output = await fixture.lerna("publish from-git -y");
+    await fixture.exec(`npm unpublish --force test-1@${version} --registry=http://localhost:4873`);
+
+    expect(output.combinedOutput).toContain("POSTPUBLISH_OUTPUT_TEST_1");
+  });
+
+  // Regression test for https://github.com/lerna/lerna/issues/4090
+  it("should show publish lifecycle script output", async () => {
+    await fixture.lerna("create test-1 -y");
+
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/test-1",
+      scripts: {
+        publish: "echo PUBLISH_OUTPUT_TEST_1",
+      },
+    });
+
+    await fixture.createInitialGitCommit();
+    await fixture.exec("git push origin test-main");
+
+    const version = randomVersion();
+    await fixture.lerna(`version ${version} -y`);
+
+    await fixture.exec('echo "registry=http://localhost:4873" > .npmrc');
+
+    const output = await fixture.lerna("publish from-git -y");
+    await fixture.exec(`npm unpublish --force test-1@${version} --registry=http://localhost:4873`);
+
+    expect(output.combinedOutput).toContain("PUBLISH_OUTPUT_TEST_1");
+  });
+
+  // Regression test for https://github.com/lerna/lerna/issues/4090
+  it("should show postpublish output from multiple packages", async () => {
+    await fixture.lerna("create test-1 -y");
+    await fixture.lerna("create test-2 -y");
+
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/test-1",
+      scripts: {
+        postpublish: "echo POSTPUBLISH_PKG1",
+      },
+    });
+    await fixture.addScriptsToPackage({
+      packagePath: "packages/test-2",
+      scripts: {
+        postpublish: "echo POSTPUBLISH_PKG2",
+      },
+    });
+
+    await fixture.createInitialGitCommit();
+    await fixture.exec("git push origin test-main");
+
+    const version = randomVersion();
+    await fixture.lerna(`version ${version} -y`);
+
+    await fixture.exec('echo "registry=http://localhost:4873" > .npmrc');
+
+    const output = await fixture.lerna("publish from-git -y");
+    await fixture.exec(`npm unpublish --force test-1@${version} --registry=http://localhost:4873`);
+    await fixture.exec(`npm unpublish --force test-2@${version} --registry=http://localhost:4873`);
+
+    expect(output.combinedOutput).toContain("POSTPUBLISH_PKG1");
+    expect(output.combinedOutput).toContain("POSTPUBLISH_PKG2");
+  });
+});

--- a/libs/core/src/lib/npm-publish.spec.ts
+++ b/libs/core/src/lib/npm-publish.spec.ts
@@ -214,9 +214,10 @@ describe("npm-publish", () => {
     }
   );
 
-  it("calls publish lifecycles", async () => {
+  it("calls publish lifecycles with stdio inherit", async () => {
     const options = expect.objectContaining({
       projectScope: "@scope",
+      stdio: "inherit",
     });
 
     await npmPublish(pkg, tarFilePath, {}, conf);

--- a/libs/core/src/lib/npm-publish.ts
+++ b/libs/core/src/lib/npm-publish.ts
@@ -104,6 +104,13 @@ export async function npmPublish(
     result = await otplease((innerOpts) => publish(manifestContent, tarData, innerOpts), opts, otpCache);
   }
 
+  // ensure lifecycle script output is visible on the terminal,
+  // matching the behavior of prepublishOnly in pack-directory.ts
+  // TODO: refactor based on TS feedback
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  opts.stdio = "inherit";
+
   await runLifecycle(pkg, "publish", opts);
   await runLifecycle(pkg, "postpublish", opts);
 


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Set `stdio` to `"inherit"` for `publish` and `postpublish` lifecycle script execution in `npm-publish.ts`, matching the existing pattern used for `prepublishOnly` in `pack-directory.ts`
- This ensures script stdout and stderr flow directly to the terminal instead of being piped through `@npmcli/run-script` and potentially lost
- Added 3 e2e regression tests covering single-package postpublish output, single-package publish output, and multi-package postpublish output

Closes #4090

## Root Cause

In `npm-publish.ts`, the `publish` and `postpublish` lifecycle scripts were called without setting `stdio`, causing `run-lifecycle.ts` to default to `"pipe"` mode. In pipe mode, `@npmcli/run-script` captures stdout internally — the re-emission via `process.stdout.write()` was unreliable, and in the error path, captured stdout was never re-emitted at all. Meanwhile, `prepublishOnly` already had `stdio: "inherit"` set explicitly in `pack-directory.ts`, which is why its output was visible.

## Test plan

- [x] Unit tests pass (`nx test core` — 497 tests)
- [x] Publish command tests pass (`nx test commands-publish` — 130 tests)
- [x] Lifecycle integration tests pass (3 suites)
- [x] All publish e2e tests pass (9 suites, 23 tests)
- [x] New e2e regression tests verify postpublish/publish output visibility
- [x] Lint and format checks pass