### PR TITLE
fix(publish): handle npm overrides with scoped dependency syntax

### DIFF
--- a/__fixtures__/pack-directory-overrides/lerna.json
+++ b/__fixtures__/pack-directory-overrides/lerna.json
@@ -1,0 +1,4 @@
+{
+  "packages": ["packages/*"],
+  "version": "independent"
+}

--- a/__fixtures__/pack-directory-overrides/package.json
+++ b/__fixtures__/pack-directory-overrides/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pack-directory-overrides",
+  "version": "0.0.0-monorepo",
+  "private": true,
+  "devDependencies": {
+    "lerna": "*"
+  }
+}

--- a/__fixtures__/pack-directory-overrides/packages/a/index.js
+++ b/__fixtures__/pack-directory-overrides/packages/a/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = "A";

--- a/__fixtures__/pack-directory-overrides/packages/a/package.json
+++ b/__fixtures__/pack-directory-overrides/packages/a/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pkg-with-overrides",
+  "version": "1.0.0",
+  "files": [
+    "index.js"
+  ],
+  "overrides": {
+    "@graphql-tools/url-loader@6>extract-files": "10.0.0",
+    "some-package": "2.0.0"
+  }
+}

--- a/libs/core/src/lib/pack-directory.spec.ts
+++ b/libs/core/src/lib/pack-directory.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import { initFixtureFactory } from "@lerna/test-helpers";
+import fs from "fs-extra";
 import normalizePath from "normalize-path";
 import path from "path";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -288,5 +289,30 @@ describe("pack-directory", () => {
         "version": "2.0.0",
       }
     `);
+  });
+
+  it("handles package.json with npm overrides using scoped dependency syntax", async () => {
+    const cwd = await initFixture("pack-directory-overrides");
+    const conf = npmConf({ prefix: cwd }).snapshot;
+    const pkgs = await getPackages(cwd);
+
+    const pkg = pkgs[0]!;
+    const manifestPath = path.join(pkg.contents, "package.json");
+    const originalManifest = await fs.readFile(manifestPath, "utf8");
+
+    // Should not throw despite overrides containing "@graphql-tools/url-loader@6>extract-files"
+    const result = await packDirectory(pkg, pkg.location, conf);
+
+    expect(result.name).toBe("pkg-with-overrides");
+    expect(result.version).toBe("1.0.0");
+    expect(result.files.map((f: any) => f.path)).toContain("package.json");
+
+    // Verify the package.json was restored with its original content (including overrides)
+    const restoredManifest = await fs.readFile(manifestPath, "utf8");
+    expect(restoredManifest).toBe(originalManifest);
+    expect(JSON.parse(restoredManifest).overrides).toEqual({
+      "@graphql-tools/url-loader@6>extract-files": "10.0.0",
+      "some-package": "2.0.0",
+    });
   });
 });

--- a/libs/core/src/lib/pack-directory.ts
+++ b/libs/core/src/lib/pack-directory.ts
@@ -1,4 +1,5 @@
 import Arborist from "@npmcli/arborist";
+import fs from "fs-extra";
 import packlist from "npm-packlist";
 import path from "path";
 import { IntegrityMap } from "ssri";
@@ -69,11 +70,33 @@ export async function packDirectory(
   await runLifecycle(pkg, "prepack", opts);
   await pkg.refresh();
 
-  const arborist = new Arborist({
-    path: pkg.contents,
-  });
-  const tree = await arborist.loadActual();
-  const files = await packlist(tree);
+  // Temporarily strip overrides from package.json to prevent arborist from
+  // failing on npm override keys that use scoped dependency syntax (e.g.
+  // "@graphql-tools/url-loader@6>extract-files"). Overrides are only relevant
+  // for dependency resolution, not for determining which files to pack.
+  // See: https://github.com/lerna/lerna/issues/4050
+  const manifestPath = path.join(pkg.contents, "package.json");
+  const originalManifest = await fs.readFile(manifestPath, "utf8");
+  const manifestJson = JSON.parse(originalManifest);
+  const hadOverrides = "overrides" in manifestJson;
+
+  if (hadOverrides) {
+    const { overrides, ...rest } = manifestJson;
+    await fs.writeFile(manifestPath, JSON.stringify(rest, null, 2) + "\n");
+  }
+
+  let files: string[];
+  try {
+    const arborist = new Arborist({
+      path: pkg.contents,
+    });
+    const tree = await arborist.loadActual();
+    files = await packlist(tree);
+  } finally {
+    if (hadOverrides) {
+      await fs.writeFile(manifestPath, originalManifest);
+    }
+  }
 
   const stream = tar.create(
     {


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Fixes `lerna publish` failing with `Invalid tag name` errors when `package.json` contains npm `overrides` using scoped dependency syntax (e.g. `"@graphql-tools/url-loader@6>extract-files": "10.0.0"`)
- Temporarily strips the `overrides` field from `package.json` before `@npmcli/arborist` processes it during packing, then restores it afterward
- Overrides are only relevant for dependency resolution during `npm install`, not for determining which files to include in the tarball
- Adds test coverage and fixture for this scenario

Fixes #4050

## Test plan

- [x] Added unit test verifying packages with scoped override syntax can be packed without errors
- [x] Test verifies `package.json` is fully restored (including overrides) after packing
- [x] All 735 existing core tests continue to pass
- [x] Linting passes across all projects