### PR TITLE
Add docusaurus-plugin-copy-page-button to docs site

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -25,7 +25,7 @@ const config = {
     locales: ["en"],
   },
 
-  plugins: [],
+  plugins: ['docusaurus-plugin-copy-page-button'],
 
   presets: [
     [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,6 +13,7 @@
         "@mdx-js/react": "3.1.1",
         "clsx": "2.1.1",
         "copy-to-clipboard": "3.3.3",
+        "docusaurus-plugin-copy-page-button": "^0.8.1",
         "prism-react-renderer": "2.4.1",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -7904,6 +7905,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.8.1.tgz",
+      "integrity": "sha512-TGzSETve01PRdPm79GVckA8lqiFo3kHHVxemzLbSZE7/lqO0MquZHgJtEnq9m3yZGcYdUUTXRlcLgr8d+Qg7Ow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/dom-converter": {

--- a/website/package.json
+++ b/website/package.json
@@ -21,6 +21,7 @@
     "@mdx-js/react": "3.1.1",
     "clsx": "2.1.1",
     "copy-to-clipboard": "3.3.3",
+    "docusaurus-plugin-copy-page-button": "^0.8.1",
     "prism-react-renderer": "2.4.1",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
This PR
- adds docusaurus-plugin-copy-page-button to website/package.json
- adds the plugin string to plugins in website/docusaurus.config.js
- puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
- adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

why useful for Lerna specifically:
monorepo config has a lot of per-page nuance — lerna.json, versioning modes, publishing, task running/caching. when someone's debugging a publish or version flow the usual move is pasting the relevant docs page into an LLM alongside their error. this makes that one click and keeps the markdown clean.

zero config, auto-injects into the TOC sidebar, theme-aware.

shipping on React Native, Redux Toolkit, Puppeteer, pnpm, PlayCanvas, Arbitrum, Cardano, Sui, Nillion, Flare, Kaia, and ~20 other docs sites. listed on the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
