### PR TITLE
ci: migrate linux jobs to nx agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           --distribute-on="8 linux-lerna"
           --stop-agents-after="build,lint,test,integration,run-e2e-tests-ci"
           --require-explicit-completion
-          --with-env-vars="CI,GITHUB_ACTIONS,PUBLISHED_VERSION"
+          --with-env-vars="PUBLISHED_VERSION"
 
       - name: Install primary node version (see volta config in package.json) and dependencies
         uses: ./.github/actions/install-node-and-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NX_CI_EXECUTION_ENV: "linux"
+      PUBLISHED_VERSION: 999.9.9-e2e.0
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -34,7 +35,12 @@ jobs:
       - uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4
 
       - name: Start Nx Cloud CI Run - Linux
-        run: npx nx-cloud start-ci-run --stop-agents-after="run-e2e-tests-ci"
+        run: >
+          npx nx-cloud start-ci-run
+          --distribute-on="8 linux-lerna"
+          --stop-agents-after="build,lint,test,integration,run-e2e-tests-ci"
+          --require-explicit-completion
+          --with-env-vars="CI,GITHUB_ACTIONS,PUBLISHED_VERSION"
 
       - name: Install primary node version (see volta config in package.json) and dependencies
         uses: ./.github/actions/install-node-and-dependencies
@@ -49,84 +55,15 @@ jobs:
           cmd5: npx nx run integration:integration --ci --maxWorkers=2
 
       # e2e tests for everything except the primary task runner (atomized per spec file)
-      - run: PUBLISHED_VERSION=999.9.9-e2e.0 npx nx run-many -t run-e2e-tests-ci --parallel=1
+      - run: npx nx run-many -t run-e2e-tests-ci --parallel=1
 
       - name: Run Nx Cloud Self-Healing CI
         if: ${{ always() }}
         run: npx nx-cloud fix-ci
 
-      - name: Stop all running agents
-        # It's important that we always run this step, otherwise in the case of any failures in preceding non-Nx steps, the agents will keep running and waste billable minutes
+      - name: Complete Nx Cloud CI Run
         if: ${{ always() }}
-        run: npx nx-cloud stop-all-agents
-
-  agents:
-    name: Nx Cloud - Agent ${{ matrix.agent }}
-    runs-on: ubuntu-latest
-    env:
-      NX_CI_EXECUTION_ENV: "linux"
-    strategy:
-      matrix:
-        agent: [1, 2, 3, 4, 5, 6, 7, 8]
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-
-      - name: Configure git metadata
-        run: |
-          git config --global user.email test@example.com
-          git config --global user.name "Tester McPerson"
-
-      # - name: Generate and configure GPG for signing commits and tags in E2E tests
-      #   run: |
-      #     # Generate a GPG key for test@example.com and store the output from stderr
-      #     GPG_OUTPUT=$(echo "Key-Type: default
-      #     Key-Length: 2048
-      #     Subkey-Type: default
-      #     Subkey-Length: 2048
-      #     Name-Real: Tester McPerson
-      #     Name-Email: test@example.com
-      #     Expire-Date: 0
-      #     %no-protection" | gpg --pinentry-mode loopback --batch --generate-key 2>&1)
-
-      #     # Find and extract the revocation file path from sdterr
-      #     REVOCATION_FILE=$(echo "$GPG_OUTPUT" | grep '.rev' | tr '\n' ' ' | awk -F "'" '{print $4}')
-
-      #     # Get the GPG key ID and the full fingerprint
-      #     export GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)
-      #     export GPG_FULL_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep "$GPG_KEY_ID" | grep -v "sec" | awk '{print $1}' | cut -d'/' -f2)
-
-      #     # Export fingerprint and the path to the revocation file to GITHUB_ENV
-      #     # This allows the last step in this job to revoke and delete the key
-      #     echo "GPG_FULL_KEY_ID=$GPG_FULL_KEY_ID" >> $GITHUB_ENV
-      #     echo "REVOCATION_FILE=$REVOCATION_FILE" >> $GITHUB_ENV
-
-      #     # Setup git signing for commits and tags
-      #     git config commit.gpgsign true
-      #     git config tag.gpgsign true
-      #     git config --global user.signingkey $GPG_KEY_ID
-
-      - name: Install primary node version (see volta config in package.json) and dependencies
-        uses: ./.github/actions/install-node-and-dependencies
-
-      - name: Start Nx Agent ${{ matrix.agent }}
-        run: npx nx-cloud start-agent
-        env:
-          NX_AGENT_NAME: ${{ matrix.agent }}
-
-      - name: Run Nx Cloud Self-Healing CI
-        if: ${{ always() }}
-        run: npx nx-cloud fix-ci
-
-      # - name: Revoke and delete GPG key
-      #   # It's important that we always run this step, otherwise the key will remain active if any of the steps above fail
-      #   if: ${{ always() }}
-      #   run: |
-      #     # As instructed in the text of revocation file, there is a colon that needs to be removed manually
-      #     sed -i "s/:-----BEGIN PGP PUBLIC KEY BLOCK-----/-----BEGIN PGP PUBLIC KEY BLOCK-----/" $REVOCATION_FILE
-
-      #     # Revoke the key and delete it
-      #     gpg --yes --import $REVOCATION_FILE
-      #     gpg --batch --yes --delete-secret-and-public-key $GPG_FULL_KEY_ID
+        run: npx nx-cloud complete-ci-run
 
   windows-main:
     name: Nx Cloud - Windows Main Job
@@ -141,7 +78,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Start Nx Cloud CI Run - Windows
-        run: npx nx-cloud start-ci-run --stop-agents-after="test"
+        run: npx nx-cloud start-ci-run --distribute-on=manual --stop-agents-after="test,integration"
 
       - name: Install primary node version (see volta config in package.json) and dependencies
         uses: ./.github/actions/install-node-and-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-  NX_VERBOSE_LOGGING: false
+  NX_VERBOSE_LOGGING: true
 
 # Minimal permissions by default
 permissions:

--- a/.github/workflows/other-node-versions.yml
+++ b/.github/workflows/other-node-versions.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NX_CI_EXECUTION_ENV: linux-node-${{ matrix.node }}
+      PUBLISHED_VERSION: 999.9.9-e2e.0
     strategy:
       # Do not kill all versions of node just because one version failed
       fail-fast: false
@@ -50,6 +51,14 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
+
+      - name: Start Nx Cloud CI Run - node-${{ matrix.node }}
+        run: >
+          npx nx-cloud start-ci-run
+          --distribute-on="4 linux-node${{ matrix.node }}-lerna"
+          --stop-agents-after="build,test,integration,e2e"
+          --require-explicit-completion
+          --with-env-vars="CI,GITHUB_ACTIONS,PUBLISHED_VERSION"
 
       - name: Install node v${{ matrix.node }} and dependencies
         uses: ./.github/actions/install-node-and-dependencies
@@ -119,7 +128,7 @@ jobs:
           cmd3: npx nx run integration:integration --ci --maxWorkers=2
 
       # e2e tests for everything except the primary task runner
-      - run: PUBLISHED_VERSION=999.9.9-e2e.0 npx nx run-many --t e2e --parallel=1
+      - run: npx nx run-many --t e2e --parallel=1
 
       - name: Run e2e tests for task-runner
         run: |
@@ -135,86 +144,9 @@ jobs:
           NO_COLOR: "1"
           FORCE_COLOR: "0"
 
-      - name: Stop all running agents
-        # It's important that we always run this step, otherwise in the case of any failures in preceding non-Nx steps, the agents will keep running and waste billable minutes
+      - name: Complete Nx Cloud CI Run
         if: ${{ always() }}
-        run: npx nx-cloud stop-all-agents
-
-      # - name: Revoke and delete GPG key
-      #   # It's important that we always run this step, otherwise the key will remain active if any of the steps above fail
-      #   if: ${{ always() }}
-      #   run: |
-      #     # As instructed in the text of revocation file, there is a colon that needs to be removed manually
-      #     sed -i "s/:-----BEGIN PGP PUBLIC KEY BLOCK-----/-----BEGIN PGP PUBLIC KEY BLOCK-----/" $REVOCATION_FILE
-
-      #     # Revoke the key and delete it
-      #     gpg --yes --import $REVOCATION_FILE
-      #     gpg --batch --yes --delete-secret-and-public-key $GPG_FULL_KEY_ID
-
-  agents:
-    name: Nx Cloud - Agent - node-${{ matrix.node }}-agent-${{ matrix.agent }}
-    needs: set-node-versions
-    runs-on: ubuntu-latest
-    env:
-      NX_CI_EXECUTION_ENV: linux-node-${{ matrix.node }}
-    strategy:
-      # Do not kill all versions of node just because one version failed
-      fail-fast: false
-      matrix:
-        node: ${{ fromJson(needs.set-node-versions.outputs.node-versions) }}
-        # Create 4 agents per node version
-        agent: [1, 2, 3, 4]
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-
-      - name: Configure git metadata
-        run: |
-          git config --global user.email test@example.com
-          git config --global user.name "Tester McPerson"
-
-      # - name: Generate and configure GPG for signing commits and tags in E2E tests
-      #   run: |
-      #     # Generate a GPG key for test@example.com and store the output from stderr
-      #     GPG_OUTPUT=$(echo "Key-Type: default
-      #     Key-Length: 2048
-      #     Subkey-Type: default
-      #     Subkey-Length: 2048
-      #     Name-Real: Tester McPerson
-      #     Name-Email: test@example.com
-      #     Expire-Date: 0
-      #     %no-protection" | gpg --pinentry-mode loopback --batch --generate-key 2>&1)
-
-      #     # Find and extract the revocation file path from sdterr
-      #     REVOCATION_FILE=$(echo "$GPG_OUTPUT" | grep '.rev' | tr '\n' ' ' | awk -F "'" '{print $4}')
-
-      #     # Get the GPG key ID and the full fingerprint
-      #     export GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)
-      #     export GPG_FULL_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep "$GPG_KEY_ID" | grep -v "sec" | awk '{print $1}' | cut -d'/' -f2)
-
-      #     # Export fingerprint and the path to the revocation file to GITHUB_ENV
-      #     # This allows the last step in this job to revoke and delete the key
-      #     echo "GPG_FULL_KEY_ID=$GPG_FULL_KEY_ID" >> $GITHUB_ENV
-      #     echo "REVOCATION_FILE=$REVOCATION_FILE" >> $GITHUB_ENV
-
-      #     # Setup git signing for commits and tags
-      #     git config commit.gpgsign true
-      #     git config tag.gpgsign true
-      #     git config --global user.signingkey $GPG_KEY_ID
-
-      - name: Install node v${{ matrix.node }} and dependencies
-        uses: ./.github/actions/install-node-and-dependencies
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Remove the volta key from package.json to ensure the explicitly installed version is respected
-        run: |
-          jq 'del(.volta)' package.json > package.json.tmp
-          mv package.json.tmp package.json
-
-      - name: Start Nx Agent node-${{ matrix.node }}-agent-${{ matrix.agent }}
-        run: npx nx-cloud start-agent
-        env:
-          NX_AGENT_NAME: node-${{ matrix.node }}-agent-${{ matrix.agent }}
+        run: npx nx-cloud complete-ci-run
 
       # - name: Revoke and delete GPG key
       #   # It's important that we always run this step, otherwise the key will remain active if any of the steps above fail

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -1,0 +1,79 @@
+launch-templates:
+  linux-lerna:
+    resource-class: "docker_linux_amd64/medium"
+    image: "ubuntu22.04-node24.14-v1"
+    env:
+      COREPACK_ENABLE_AUTO_PIN: "0"
+      COREPACK_ENABLE_STRICT: "0"
+    init-steps:
+      - name: Checkout
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml"
+
+      - name: Install Node From Volta
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/install-node/main.yaml"
+
+      - name: Install Package Manager Fixtures
+        script: |
+          corepack enable
+          corepack install -g pnpm@8
+          yarn set version classic
+
+      - name: Print Tool Versions
+        script: |
+          node --version
+          npm --version
+          yarn --version
+          pnpm --version
+
+      - name: Install Node Modules
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml"
+        inputs:
+          npm_legacy_install: "false"
+
+      - name: Configure Git Metadata
+        script: |
+          git config --global user.email test@example.com
+          git config --global user.name "Tester McPerson"
+
+  linux-node20-lerna:
+    resource-class: "docker_linux_amd64/medium"
+    image: "ubuntu22.04-node24.14-v1"
+    env:
+      COREPACK_ENABLE_AUTO_PIN: "0"
+      COREPACK_ENABLE_STRICT: "0"
+    init-steps:
+      - name: Checkout
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml"
+
+      - name: Install Node 20
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/install-node/main.yaml"
+        inputs:
+          node_version: "20"
+
+      - name: Install Package Manager Fixtures
+        script: |
+          corepack enable
+          corepack install -g pnpm@8
+          yarn set version classic
+
+      - name: Print Tool Versions
+        script: |
+          node --version
+          npm --version
+          yarn --version
+          pnpm --version
+
+      - name: Install Node Modules
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml"
+        inputs:
+          npm_legacy_install: "false"
+
+      - name: Remove Volta Pin
+        script: |
+          jq 'del(.volta)' package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+      - name: Configure Git Metadata
+        script: |
+          git config --global user.email test@example.com
+          git config --global user.name "Tester McPerson"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrate to Nx Agents

## Motivation and Context

Make CI faster + more efficient

## How Has This Been Tested?

Pipeline should be green

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (change that has absolutely no effect on users)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI orchestration, but misconfigured agents or completion could leave runs hanging or skip tests; Windows path is largely unchanged.
> 
> **Overview**
> **Linux CI** no longer spins up eight (or four per Node version) GitHub Actions `start-agent` matrix jobs. Instead, `start-ci-run` uses **`--distribute-on`** with Nx Cloud workflow launch templates (`8 linux-lerna` in `ci.yml`, `4 linux-node20-lerna` in `other-node-versions.yml`), **`--require-explicit-completion`**, and **`--with-env-vars`** so `PUBLISHED_VERSION` is set at the job level rather than inline on e2e commands.
> 
> A new **`.nx/workflows/agents.yaml`** defines those templates: checkout, Node install (Volta or pinned Node 20), corepack/pnpm/yarn setup, `install-node-modules`, and test git identity—work that previously lived on GHA agent runners.
> 
> Teardown on Linux/matrix Node jobs switches from **`stop-all-agents`** to **`complete-ci-run`**. **`stop-agents-after`** now covers more targets (e.g. build/lint on main CI). **Windows** keeps manual GHA agents but widens **`stop-agents-after`** to include integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5120c368825592118adfe30a7bf5fc69092b3c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->