### PR TITLE
fix(core): support OIDC trusted publishing on CircleCI

### DIFF
--- a/libs/core/src/lib/oidc.spec.ts
+++ b/libs/core/src/lib/oidc.spec.ts
@@ -1,0 +1,70 @@
+jest.mock("ci-info", () => ({
+  __esModule: true,
+  default: { GITHUB_ACTIONS: false, GITLAB: false, CIRCLE: false },
+}));
+jest.mock("npm-registry-fetch", () => ({
+  __esModule: true,
+  default: { json: jest.fn() },
+}));
+
+// mocked modules
+import ciInfo from "ci-info";
+import npmFetch from "npm-registry-fetch";
+
+// file under test
+import { oidc } from "./oidc";
+
+const ci = ciInfo as unknown as { GITHUB_ACTIONS: boolean; GITLAB: boolean; CIRCLE: boolean };
+const registryFetchJson = jest.mocked(npmFetch.json);
+
+describe("oidc", () => {
+  const registry = "https://registry.npmjs.org/";
+  const authTokenKey = "//registry.npmjs.org/:_authToken";
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env["NPM_ID_TOKEN"];
+    ci.GITHUB_ACTIONS = false;
+    ci.GITLAB = false;
+    ci.CIRCLE = false;
+    registryFetchJson.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("exchanges the NPM_ID_TOKEN for a registry auth token on CircleCI", async () => {
+    ci.CIRCLE = true;
+    process.env["NPM_ID_TOKEN"] = "id-token";
+    registryFetchJson.mockResolvedValue({ token: "exchanged-token" });
+
+    const opts: any = {};
+    const config: any = { set: jest.fn() };
+
+    await oidc({ packageName: "@scope/pkg", registry, opts, config });
+
+    expect(registryFetchJson).toHaveBeenCalledTimes(1);
+    const [exchangeUrl, exchangeOpts] = registryFetchJson.mock.calls[0];
+    expect(exchangeUrl.toString()).toBe(
+      "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2fpkg"
+    );
+    expect(exchangeOpts).toMatchObject({ method: "POST", [authTokenKey]: "id-token" });
+    expect(opts[authTokenKey]).toBe("exchanged-token");
+    expect(config.set).toHaveBeenCalledWith(authTokenKey, "exchanged-token", "user");
+  });
+
+  it("does not attempt a token exchange outside of a supported CI environment", async () => {
+    process.env["NPM_ID_TOKEN"] = "id-token";
+
+    const opts: any = {};
+    const config: any = { set: jest.fn() };
+
+    await oidc({ packageName: "@scope/pkg", registry, opts, config });
+
+    expect(registryFetchJson).not.toHaveBeenCalled();
+    expect(opts[authTokenKey]).toBeUndefined();
+    expect(config.set).not.toHaveBeenCalled();
+  });
+});

--- a/libs/core/src/lib/oidc.ts
+++ b/libs/core/src/lib/oidc.ts
@@ -22,8 +22,8 @@ interface OidcOptions {
 /**
  * Handles OpenID Connect (OIDC) token retrieval and exchange for CI environments.
  *
- * This function is designed to work in Continuous Integration (CI) environments such as GitHub Actions
- * and GitLab. It retrieves an OIDC token from the CI environment, exchanges it for an npm token, and
+ * This function is designed to work in Continuous Integration (CI) environments such as GitHub Actions,
+ * GitLab, and CircleCI. It retrieves an OIDC token from the CI environment, exchanges it for an npm token, and
  * sets the token in the provided configuration for authentication with the npm registry.
  *
  * This function is intended to never throw, as it mutates the state of the `opts` and `config` objects on success.
@@ -31,6 +31,7 @@ interface OidcOptions {
  *
  * @see https://github.com/watson/ci-info for CI environment detection.
  * @see https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect for GitHub Actions OIDC.
+ * @see https://circleci.com/docs/openid-connect-tokens/ for CircleCI OIDC.
  */
 export async function oidc({ packageName, registry, opts, config }: OidcOptions) {
   /*
@@ -45,7 +46,9 @@ export async function oidc({ packageName, registry, opts, config }: OidcOptions)
         (
           ciInfo.GITHUB_ACTIONS ||
           /** @see https://github.com/watson/ci-info/blob/v4.2.0/vendors.json#L161C13-L161C22 */
-          ciInfo.GITLAB
+          ciInfo.GITLAB ||
+          /** @see https://github.com/watson/ci-info/blob/v4.2.0/vendors.json#L78 */
+          ciInfo.CIRCLE
         )
       )
     ) {


### PR DESCRIPTION
On CircleCI, `lerna publish` with npm Trusted Publishing fails with an E404 because `oidc()` returns early for any CI other than GitHub Actions or GitLab, so it never reads the `NPM_ID_TOKEN` that CircleCI exposes. This adds a `CIRCLE` check to that guard so the existing `NPM_ID_TOKEN` path runs on CircleCI too, the same way GitLab is handled today (and matching npm's own oidc util). Also added a unit test for the CircleCI token exchange.

Fixes #4358

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small extension of an existing CI gate and token-exchange path, with unit tests; behavior on GitHub Actions and GitLab is unchanged.
> 
> **Overview**
> **CircleCI** is now treated as a supported CI for npm OIDC trusted publishing. `oidc()` previously exited before reading `NPM_ID_TOKEN` unless the job was on GitHub Actions or GitLab, which broke `lerna publish` on CircleCI (e.g. E404). The early-return guard now includes `ciInfo.CIRCLE`, so CircleCI uses the same `NPM_ID_TOKEN` → registry token exchange path as GitLab.
> 
> Docs/comments were updated for CircleCI. New unit tests cover a successful exchange on CircleCI and confirm no exchange runs when no supported CI is detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 954596f8d58b4fbdc377874bdcaee79a7a4d6349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->