### PR TITLE
fix(core): support changelog presets that only expose the ESM import condition

### DIFF
--- a/libs/core/src/lib/conventional-commits/get-changelog-config.ts
+++ b/libs/core/src/lib/conventional-commits/get-changelog-config.ts
@@ -70,7 +70,7 @@ async function resolveConfigPromise(presetPackageName: string, presetConfig: obj
   try {
     config = require(presetPackageName);
   } catch (requireError: any) {
-    if (requireError.code === "ERR_REQUIRE_ESM") {
+    if (requireError.code === "ERR_REQUIRE_ESM" || requireError.code === "ERR_PACKAGE_PATH_NOT_EXPORTED") {
       log.verbose("getChangelogConfig", "Preset is ESM, using dynamic import for %j", presetPackageName);
       const imported = await import(presetPackageName);
       config = imported.default || imported;


### PR DESCRIPTION
After `conventional-changelog-conventionalcommits` v10 switched to pure ESM, its `exports` map only declares the `import` condition (no `require`/`default`/`main`). Loading it with `require()` now throws `ERR_PACKAGE_PATH_NOT_EXPORTED` rather than the `ERR_REQUIRE_ESM` that the existing dynamic `import()` fallback (from #4302) handles, so `lerna changed`/`lerna version` fail with `EPRESET Unable to load conventional-changelog preset 'conventionalcommits'`.

This extends that fallback to also treat `ERR_PACKAGE_PATH_NOT_EXPORTED` as an ESM preset and load it via `import()`.

Verified with `conventional-changelog-conventionalcommits@10.2.1` on Node 20, 22 and 24: `require()` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` before the change, and the preset loads and produces a valid config after it.

Fixes #4384

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-condition change in preset resolution error handling; reuses the existing dynamic import path with no new APIs or behavior beyond fixing a broken load path.
> 
> **Overview**
> **Fixes preset loading** when `require()` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` (not just `ERR_REQUIRE_ESM`), which happens with packages like `conventional-changelog-conventionalcommits` v10 that only declare an `import` entry in `package.json` exports.
> 
> In `resolveConfigPromise`, the existing dynamic `import()` fallback now runs for both error codes, so `lerna changed` / `lerna version` can load the `conventionalcommits` preset again instead of throwing `EPRESET`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1e69232a5e6f8bbb71428af118c338771f4bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->