### PR TITLE
docs: fix dead allcontributors.org/docs/en/emoji-key link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ our [guidelines for contributing](https://github.com/lerna/lerna/blob/main/CONTR
 
 ### Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/en/reference/emoji-key/)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
docs: fix dead `allcontributors.org/docs/en/emoji-key` link

The "emoji key" link in the contributors section of `README.md`
points at `https://allcontributors.org/docs/en/emoji-key`, which
returns HTTP 404. The allcontributors site restructured the docs
tree and the new canonical path is
`https://allcontributors.org/en/reference/emoji-key/` (HTTP 200,
title "Emoji Key ✨ | All Contributors"). The legacy `/docs/en/...`
URL is no longer served; the project moved to `/en/reference/...`.

No content text changes.

## Diff

```
 README.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Verification

```
$ curl -sI -A "Mozilla/5.0" -L -o /dev/null -w '%{http_code}\n' \
    "https://allcontributors.org/docs/en/emoji-key"
404
$ curl -sI -A "Mozilla/5.0" -L -o /dev/null -w '%{http_code}\n' \
    "https://allcontributors.org/en/reference/emoji-key/"
200
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation link fix in README with no runtime or security impact.
> 
> **Overview**
> Updates the **emoji key** hyperlink in the Contributors section of `README.md` from the legacy `allcontributors.org/docs/en/emoji-key` path (404) to `allcontributors.org/en/reference/emoji-key/`. No other text or contributor table content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9aa764eb25fb070188e42f2f0d3419a696a89e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->