### PR TITLE
docs: fix 5 dead nx.dev and facebook.github.io/jest links

### DIFF
--- a/website/docs/features/cache-tasks.md
+++ b/website/docs/features/cache-tasks.md
@@ -82,7 +82,7 @@ header/
 └── dist/  <-- this folder gets recreated
 ```
 
-If your task creates output artifacts in a different location, you can [change the output folder(s)](https://nx.dev/reference/project-configuration#outputs) that are cached. You can also [customize which inputs](https://nx.dev/more-concepts/customizing-inputs) will invalidate the cache if they are changed.
+If your task creates output artifacts in a different location, you can [change the output folder(s)](https://nx.dev/reference/project-configuration#outputs) that are cached. You can also [customize which inputs](https://nx.dev/docs/guides/tasks--caching/configure-inputs) will invalidate the cache if they are changed.
 
 ## Advanced Caching
 

--- a/website/docs/features/distribute-tasks.md
+++ b/website/docs/features/distribute-tasks.md
@@ -44,7 +44,7 @@ Every organization manages their CI/CD pipelines differently, so it's not possib
 
 Note that only cacheable operations can be distributed because they have to be replayed on the main job.
 
-For more details on setting up DTE, read [this guide](https://nx.dev/nx-cloud/set-up/set-up-dte).
+For more details on setting up DTE, read [this guide](https://nx.dev/docs/features/ci-features/distribute-task-execution).
 
 ## CI Execution Flow
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -126,7 +126,7 @@ Lerna always uses `npm` tooling to publish packages, regardless of the `npmClien
 
 ## Jest / Visual Studio Code Debugging
 
-It is possible to debug [Jest](https://facebook.github.io/jest/) tests in a Lerna-managed package using [Visual Studio Code](https://code.visualstudio.com/). Debugging with breakpoints works with the vscode launch configuration below in the monorepo's `<root>/.vscode/launch.json` file. This example launches Jest for a single package `my-package` located in the monorepo.
+It is possible to debug [Jest](https://jestjs.io/) tests in a Lerna-managed package using [Visual Studio Code](https://code.visualstudio.com/). Debugging with breakpoints works with the vscode launch configuration below in the monorepo's `<root>/.vscode/launch.json` file. This example launches Jest for a single package `my-package` located in the monorepo.
 
 ```javascript
 {
@@ -152,7 +152,7 @@ It is possible to debug [Jest](https://facebook.github.io/jest/) tests in a Lern
 }
 ```
 
-- [`--runInBand`](https://facebook.github.io/jest/docs/en/cli.html#runinband) avoids parallelizing tests across multiple processes
-- [`--no-cache`](https://facebook.github.io/jest/docs/en/cli.html#cache) helps avoid caching issues
+- [`--runInBand`](https://jestjs.io/docs/cli#--runinband) avoids parallelizing tests across multiple processes
+- [`--no-cache`](https://jestjs.io/docs/cli#--cache) helps avoid caching issues
 
 Tested with Visual Studio Code v1.19.3 and Jest v22.1.4.


### PR DESCRIPTION
## Summary

Five stale documentation links in the `website/docs/` tree. All are 404 on curl, all verified replacements return 200.

| File | Old URL (404) | New URL (200) |
|---|---|---|
| `website/docs/features/cache-tasks.md:85` | `https://nx.dev/more-concepts/customizing-inputs` | `https://nx.dev/docs/guides/tasks--caching/configure-inputs` |
| `website/docs/features/distribute-tasks.md:47` | `https://nx.dev/nx-cloud/set-up/set-up-dte` | `https://nx.dev/docs/features/ci-features/distribute-task-execution` |
| `website/docs/troubleshooting.md:129` | `https://facebook.github.io/jest/` | `https://jestjs.io/` |
| `website/docs/troubleshooting.md:155` | `https://facebook.github.io/jest/docs/en/cli.html#runinband` | `https://jestjs.io/docs/cli#--runinband` |
| `website/docs/troubleshooting.md:156` | `https://facebook.github.io/jest/docs/en/cli.html#cache` | `https://jestjs.io/docs/cli#--cache` |

## Verification

Each replacement was curl-verified with `-A 'Mozilla/5.0' -L` against the new URL (returns 200) and the old URL (returns 404).

The `facebook.github.io/jest` host no longer serves traffic (the site moved to `jestjs.io`). The `nx.dev/more-concepts/...` and `nx.dev/nx-cloud/set-up/set-up-dte` paths were retired when Nx restructured its docs; the new docs paths under `/docs/...` cover the same content.

Note: the entire "Jest / Visual Studio Code Debugging" section in `troubleshooting.md` still references Jest v22.1.4, which is the test runner that lerna dropped in #4389. This PR only fixes the link rot; a follow-up to migrate the section to vitest or remove it is out of scope here.

## Why

Doc-only, 3 files, +5 / -5 lines. No code changes. No changeset needed (lerna's CONTRIBUTING.md does not require changesets for docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation hyperlink updates only; no application code, configuration, or security-sensitive paths are modified.
> 
> **Overview**
> Updates **five broken outbound links** in `website/docs/` so readers land on current Nx and Jest documentation instead of 404s.
> 
> In **cache tasks**, the “customize which inputs” link now points to Nx’s **configure inputs** guide under the new `/docs/guides/tasks--caching/...` path. In **distribute task execution**, the DTE setup link moves from the retired `nx-cloud/set-up` URL to **`/docs/features/ci-features/distribute-task-execution`**. In **troubleshooting**, Jest references use **`jestjs.io`** (homepage and CLI docs for `--runInBand` and `--no-cache`) instead of the defunct `facebook.github.io/jest` URLs.
> 
> Doc-only; no behavior or tooling changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5dd62bba6de66b3fc00a594b1d6703bcdb23179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->