### PR TITLE
feat(publish)!: use .sha-{SHA} prerelease identifiers for --canary

### DIFF
--- a/e2e/publish/src/publish-private-packages.spec.ts
+++ b/e2e/publish/src/publish-private-packages.spec.ts
@@ -451,9 +451,11 @@ describe("lerna-publish-private", () => {
         const output = await fixture.lerna(
           "publish --canary major --include-private test-1 test-2 --registry=http://localhost:4873 -y"
         );
+        // the sha suffix is only known at runtime, so recover the exact published version from the output
+        const canaryVersion = output.combinedOutput.match(/1\.0\.0-alpha\.0\.sha-[0-9a-f]+/)?.[0];
         const unpublish = async (packageName: string) => {
           const unpublishOutput = await fixture.exec(
-            `npm unpublish ${packageName}@1.0.0-alpha.0 --force --registry=http://localhost:4873`
+            `npm unpublish ${packageName}@${canaryVersion} --force --registry=http://localhost:4873`
           );
           expect(replaceVersion(unpublishOutput.combinedOutput)).toContain(`${packageName}@XX.XX.XX`);
         };
@@ -467,9 +469,9 @@ describe("lerna-publish-private", () => {
           lerna info Assuming all packages changed
 
           Found 3 packages to publish:
-           - test-X => XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA} (private!)
-           - test-X => XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA} (private!)
-           - test-X => XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+           - test-X => XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA} (private!)
+           - test-X => XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA} (private!)
+           - test-X => XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
 
           lerna info auto-confirmed
           lerna info publish Publishing packages to npm...
@@ -478,51 +480,51 @@ describe("lerna-publish-private", () => {
           lerna WARN ENOLICENSE Packages test-X, test-X, and test-X are missing a license.
           lerna WARN ENOLICENSE One way to fix this is to add a LICENSE.md file to the root of this repository.
           lerna WARN ENOLICENSE See https://choosealicense.com for additional guidance.
-          lerna success published test-X XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna success published test-X XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
           lerna notice
-          lerna notice 📦  test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice 📦  test-X@XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
           lerna notice === Tarball Contents ===
           lerna notice 90B  lib/test-X.js
           lerna notice XXXB package.json
           lerna notice 110B README.md
           lerna notice === Tarball Details ===
           lerna notice name:          test-X
-          lerna notice version:       XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
-          lerna notice filename:      test-X-XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}.tgz
+          lerna notice version:       XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
+          lerna notice filename:      test-X-XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}.tgz
           lerna notice package size: XXXB
           lerna notice unpacked size: XXX.XXX kb
           lerna notice shasum:        {FULL_COMMIT_SHA}
           lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
           lerna notice total files:   3
           lerna notice
-          lerna success published test-X XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna success published test-X XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
           lerna notice
-          lerna notice 📦  test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice 📦  test-X@XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
           lerna notice === Tarball Contents ===
           lerna notice 90B  lib/test-X.js
           lerna notice XXXB package.json
           lerna notice 110B README.md
           lerna notice === Tarball Details ===
           lerna notice name:          test-X
-          lerna notice version:       XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
-          lerna notice filename:      test-X-XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}.tgz
+          lerna notice version:       XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
+          lerna notice filename:      test-X-XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}.tgz
           lerna notice package size: XXXB
           lerna notice unpacked size: XXX.XXX kb
           lerna notice shasum:        {FULL_COMMIT_SHA}
           lerna notice integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
           lerna notice total files:   3
           lerna notice
-          lerna success published test-X XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna success published test-X XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
           lerna notice
-          lerna notice 📦  test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+          lerna notice 📦  test-X@XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
           lerna notice === Tarball Contents ===
           lerna notice 90B  lib/test-X.js
           lerna notice XXXB package.json
           lerna notice 110B README.md
           lerna notice === Tarball Details ===
           lerna notice name:          test-X
-          lerna notice version:       XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
-          lerna notice filename:      test-X-XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}.tgz
+          lerna notice version:       XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
+          lerna notice filename:      test-X-XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}.tgz
           lerna notice package size: XXXB
           lerna notice unpacked size: XXX.XXX kb
           lerna notice shasum:        {FULL_COMMIT_SHA}
@@ -530,9 +532,9 @@ describe("lerna-publish-private", () => {
           lerna notice total files:   3
           lerna notice
           Successfully published:
-           - test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
-           - test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
-           - test-X@XX.XX.XX-alpha.0+{SHORT_COMMIT_SHA}
+           - test-X@XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
+           - test-X@XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
+           - test-X@XX.XX.XX-alpha.0.sha-{SHORT_COMMIT_SHA}
           lerna success published 3 packages
 
         `);

--- a/integration/__tests__/lerna-publish-canary.spec.ts
+++ b/integration/__tests__/lerna-publish-canary.spec.ts
@@ -31,14 +31,14 @@ test("lerna publish --canary uses default prerelease id", async () => {
   expect(stdout).toMatchInlineSnapshot(`
 
 Found 3 packages to publish:
- - package-1 => 1.0.1-alpha.0+SHA
- - package-2 => 1.0.1-alpha.0+SHA
- - package-3 => 1.0.1-alpha.0+SHA
+ - package-1 => 1.0.1-alpha.0.sha-SHA
+ - package-2 => 1.0.1-alpha.0.sha-SHA
+ - package-3 => 1.0.1-alpha.0.sha-SHA
 
 Successfully published:
- - package-1@1.0.1-alpha.0+SHA
- - package-2@1.0.1-alpha.0+SHA
- - package-3@1.0.1-alpha.0+SHA
+ - package-1@1.0.1-alpha.0.sha-SHA
+ - package-2@1.0.1-alpha.0.sha-SHA
+ - package-3@1.0.1-alpha.0.sha-SHA
 `);
 });
 
@@ -53,14 +53,14 @@ test("lerna publish --canary --no-git-reset leaves the working tree dirty", asyn
   expect(stdout).toMatchInlineSnapshot(`
 
 Found 3 packages to publish:
- - package-1 => 1.0.1-alpha.0+SHA
- - package-2 => 1.0.1-alpha.0+SHA
- - package-3 => 1.0.1-alpha.0+SHA
+ - package-1 => 1.0.1-alpha.0.sha-SHA
+ - package-2 => 1.0.1-alpha.0.sha-SHA
+ - package-3 => 1.0.1-alpha.0.sha-SHA
 
 Successfully published:
- - package-1@1.0.1-alpha.0+SHA
- - package-2@1.0.1-alpha.0+SHA
- - package-3@1.0.1-alpha.0+SHA
+ - package-1@1.0.1-alpha.0.sha-SHA
+ - package-2@1.0.1-alpha.0.sha-SHA
+ - package-3@1.0.1-alpha.0.sha-SHA
 `);
 
   const result = gitStatus();

--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -78,20 +78,20 @@ This is useful when a previous `lerna publish` failed to publish all packages to
 
 ```sh
 lerna publish --canary
-# 1.0.0 => 1.0.1-alpha.0+${SHA} of packages changed since the previous commit
-# a subsequent canary publish will yield 1.0.1-alpha.1+${SHA}, etc
+# 1.0.0 => 1.0.1-alpha.0.sha-${SHA} of packages changed since the previous commit
+# a subsequent canary publish will yield 1.0.1-alpha.1.sha-${SHA}, etc
 
 lerna publish --canary --preid beta
-# 1.0.0 => 1.0.1-beta.0+${SHA}
+# 1.0.0 => 1.0.1-beta.0.sha-${SHA}
 
 # The following are equivalent:
 lerna publish --canary minor
 lerna publish --canary preminor
-# 1.0.0 => 1.1.0-alpha.0+${SHA}
+# 1.0.0 => 1.1.0-alpha.0.sha-${SHA}
 ```
 
 When run with this flag, `lerna publish` publishes packages in a more granular way (per commit).
-Before publishing to npm, it creates the new `version` tag by taking the current `version`, bumping it to the next _minor_ version, adding the provided meta suffix (defaults to `alpha`) and appending the current git sha (ex: `1.0.0` becomes `1.1.0-alpha.0+81e3b443`).
+Before publishing to npm, it creates the new `version` tag by taking the current `version`, bumping it to the next _minor_ version, adding the provided meta suffix (defaults to `alpha`) and appending the current git sha as a final `sha-`-prefixed prerelease identifier (ex: `1.0.0` becomes `1.1.0-alpha.0.sha-81e3b443`).
 
 If you have publish canary releases from multiple active development branches in CI,
 it is recommended to customize the [`--preid`](#--preid) and [`--dist-tag <tag>`](#--dist-tag-tag) on a per-branch basis to avoid clashing versions.
@@ -244,11 +244,11 @@ Unlike the `lerna version` option of the same name, this option only applies to 
 ```sh
 lerna publish --canary
 # uses the next semantic prerelease version, e.g.
-# 1.0.0 => 1.0.1-alpha.0
+# 1.0.0 => 1.0.1-alpha.0.sha-${SHA}
 
 lerna publish --canary --preid next
 # uses the next semantic prerelease version with a specific prerelease identifier, e.g.
-# 1.0.0 => 1.0.1-next.0
+# 1.0.0 => 1.0.1-next.0.sha-${SHA}
 ```
 
 When run with this flag, `lerna publish --canary` will increment `premajor`, `preminor`, `prepatch`, or `prerelease` semver

--- a/libs/commands/publish/src/command.ts
+++ b/libs/commands/publish/src/command.ts
@@ -21,7 +21,8 @@ const command: CommandModule = {
   builder(yargs) {
     const opts = {
       c: {
-        describe: "Publish packages after every successful merge using the sha as part of the tag.",
+        describe:
+          "Publish packages after every successful merge, appending the sha as a prerelease identifier (e.g. 1.0.1-alpha.0.sha-81e3b44).",
         alias: "canary",
         type: "boolean",
       },

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -45,6 +45,7 @@ import { getProjectsWithUnpublishedPackages } from "./lib/get-projects-with-unpu
 import { getTwoFactorAuthRequired } from "./lib/get-two-factor-auth-required";
 import { gitCheckout } from "./lib/git-checkout";
 import { interpolate } from "./lib/interpolate";
+import { makeCanaryVersion } from "./lib/make-canary-version";
 import { removeTempLicenses } from "./lib/remove-temp-licenses";
 import { Queue, TailHeadQueue } from "./lib/throttle-queue";
 import { verifyNpmPackageAccess } from "./lib/verify-npm-package-access";
@@ -584,8 +585,7 @@ export class PublishCommand extends Command {
         );
 
         // semver.inc() starts a new prerelease at .0, git describe starts at .1
-        // and build metadata is always ignored when comparing dependency ranges
-        return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}+${sha}`;
+        return makeCanaryVersion(nextVersion as string, preid, refCount, sha);
       };
 
     let updatesVersions: [string, string][];

--- a/libs/commands/publish/src/lib/make-canary-version.spec.ts
+++ b/libs/commands/publish/src/lib/make-canary-version.spec.ts
@@ -1,0 +1,66 @@
+import semver from "semver";
+
+import { makeCanaryVersion } from "./make-canary-version";
+
+// short SHAs come in three flavors that semver treats very differently without the "sha." guard:
+// - all digits with a leading zero: invalid numeric identifier (see lerna/lerna#1118)
+// - all digits without a leading zero: valid, but a *numeric* identifier in a different
+//   precedence class than alphanumeric hex SHAs
+// - regular hex: alphanumeric identifier
+const ALL_DIGIT_LEADING_ZERO_SHA = "0812331";
+const ALL_DIGIT_SHA = "8123312";
+const HEX_SHA = "81e3b44";
+const SHAS = [ALL_DIGIT_LEADING_ZERO_SHA, ALL_DIGIT_SHA, HEX_SHA];
+
+describe("makeCanaryVersion", () => {
+  test("produces the documented shape", () => {
+    expect(makeCanaryVersion("1.0.1", "alpha", 1, HEX_SHA)).toBe("1.0.1-alpha.0.sha-81e3b44");
+    expect(makeCanaryVersion("1.0.1", "alpha", 1, HEX_SHA)).toMatch(
+      /^\d+\.\d+\.\d+-[a-zA-Z]+\.\d+\.sha-[0-9a-f]+$/
+    );
+  });
+
+  test.each(SHAS)("produces a strictly valid semver version for sha %s", (sha) => {
+    const version = makeCanaryVersion("1.0.1", "alpha", 1, sha);
+
+    expect(semver.valid(version)).toBeTruthy();
+  });
+
+  test.each(SHAS)("parses the sha as a string prerelease identifier for sha %s", (sha) => {
+    const version = makeCanaryVersion("1.0.1", "alpha", 1, sha);
+    const prerelease = semver.parse(version)!.prerelease;
+
+    // a single (string) comparison class regardless of the sha's characters,
+    // so precedence never flaps between numeric and alphanumeric ordering
+    expect(typeof prerelease[prerelease.length - 1]).toBe("string");
+  });
+
+  test.each(SHAS)("produces a version usable as an exact dependency range for sha %s", (sha) => {
+    const version = makeCanaryVersion("1.0.1", "alpha", 1, sha);
+
+    // an invalid comparator here would make sibling packages with pinned
+    // dependencies on this version uninstallable
+    expect(() => new semver.Range(version)).not.toThrow();
+    expect(semver.satisfies(version, `=${version}`)).toBe(true);
+  });
+
+  test.each(SHAS)("orders successive canary versions by counter for sha %s", (sha) => {
+    const first = makeCanaryVersion("1.0.1", "alpha", 1, sha);
+    const second = makeCanaryVersion("1.0.1", "alpha", 2, sha);
+
+    expect(semver.gt(second, first)).toBe(true);
+  });
+
+  test("orders canary versions by counter across sha classes", () => {
+    const first = makeCanaryVersion("1.0.1", "alpha", 1, HEX_SHA);
+    const second = makeCanaryVersion("1.0.1", "alpha", 2, ALL_DIGIT_LEADING_ZERO_SHA);
+    const third = makeCanaryVersion("1.0.1", "alpha", 3, ALL_DIGIT_SHA);
+
+    expect(semver.gt(second, first)).toBe(true);
+    expect(semver.gt(third, second)).toBe(true);
+  });
+
+  test("clamps a zero refCount to counter 0", () => {
+    expect(makeCanaryVersion("1.0.1", "alpha", 0, HEX_SHA)).toBe("1.0.1-alpha.0.sha-81e3b44");
+  });
+});

--- a/libs/commands/publish/src/lib/make-canary-version.ts
+++ b/libs/commands/publish/src/lib/make-canary-version.ts
@@ -1,0 +1,14 @@
+/**
+ * Composes a canary version, e.g. `1.1.0-alpha.0.sha-81e3b44`.
+ *
+ * The commit SHA is appended as a prerelease identifier (instead of build metadata, which
+ * registries strip on publish). The literal "sha-" prefix is fused with the hash into a
+ * single identifier so that it always parses as an alphanumeric (string) identifier, no
+ * matter which characters the short SHA happens to contain. A dot-separated hash would be
+ * parsed as its own identifier: all digits with a leading zero is an invalid semver
+ * numeric identifier (see lerna/lerna#1118), and all digits without a leading zero would
+ * sort in a different (numeric) precedence class than hex SHAs.
+ */
+export function makeCanaryVersion(nextVersion: string, preid: string, refCount: number, sha: string): string {
+  return `${nextVersion}-${preid}.${Math.max(0, refCount - 1)}.sha-${sha}`;
+}

--- a/libs/commands/publish/src/lib/publish-canary.spec.ts
+++ b/libs/commands/publish/src/lib/publish-canary.spec.ts
@@ -15,6 +15,7 @@ import {
 } from "@lerna/test-helpers";
 import fs from "fs-extra";
 import path from "path";
+import semver from "semver";
 
 import * as childProcess from "@lerna/child-process";
 
@@ -112,10 +113,10 @@ Map {
 `);
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
-  "package-4": 1.0.1-alpha.0+SHA,
+  "package-1": 1.0.1-alpha.0.sha-SHA,
+  "package-2": 1.0.1-alpha.0.sha-SHA,
+  "package-3": 1.0.1-alpha.0.sha-SHA,
+  "package-4": 1.0.1-alpha.0.sha-SHA,
 }
 `);
   });
@@ -128,9 +129,9 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-1": 1.0.1-beta.0+SHA,
-  "package-2": 1.0.1-beta.0+SHA,
-  "package-3": 1.0.1-beta.0+SHA,
+  "package-1": 1.0.1-beta.0.sha-SHA,
+  "package-2": 1.0.1-beta.0.sha-SHA,
+  "package-3": 1.0.1-beta.0.sha-SHA,
 }
 `);
   });
@@ -143,9 +144,9 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
+  "package-1": 1.0.1-alpha.0.sha-SHA,
+  "package-2": 1.0.1-alpha.0.sha-SHA,
+  "package-3": 1.0.1-alpha.0.sha-SHA,
 }
 `);
   });
@@ -159,9 +160,9 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
+  "package-1": 1.0.1-alpha.0.sha-SHA,
+  "package-2": 1.0.1-alpha.0.sha-SHA,
+  "package-3": 1.0.1-alpha.0.sha-SHA,
 }
 `);
   });
@@ -174,9 +175,9 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-1": 1.1.0-alpha.0+SHA,
-  "package-2": 2.1.0-alpha.0+SHA,
-  "package-3": 3.1.0-alpha.0+SHA,
+  "package-1": 1.1.0-alpha.0.sha-SHA,
+  "package-2": 2.1.0-alpha.0.sha-SHA,
+  "package-3": 3.1.0-alpha.0.sha-SHA,
 }
 `);
   });
@@ -202,7 +203,7 @@ Object {
     // there have been two commits since the beginning of the repo
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-6": 1.0.0-alpha.1+SHA,
+  "package-6": 1.0.0-alpha.1.sha-SHA,
 }
 `);
   });
@@ -216,11 +217,11 @@ Object {
 
       expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
-  "package-4": 1.0.1-alpha.0+SHA,
-  "package-5": 1.0.1-alpha.0+SHA,
+  "package-1": 1.0.1-alpha.0.sha-SHA,
+  "package-2": 1.0.1-alpha.0.sha-SHA,
+  "package-3": 1.0.1-alpha.0.sha-SHA,
+  "package-4": 1.0.1-alpha.0.sha-SHA,
+  "package-5": 1.0.1-alpha.0.sha-SHA,
 }
 `);
     });
@@ -233,9 +234,9 @@ Object {
 
       expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-3": 1.1.0-alpha.0+SHA,
-  "package-4": 1.1.0-alpha.0+SHA,
-  "package-5": 1.1.0-alpha.0+SHA,
+  "package-3": 1.1.0-alpha.0.sha-SHA,
+  "package-4": 1.1.0-alpha.0.sha-SHA,
+  "package-5": 1.1.0-alpha.0.sha-SHA,
 }
 `);
     });
@@ -248,7 +249,7 @@ Object {
 
       expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-5": 2.0.0-alpha.0+SHA,
+  "package-5": 2.0.0-alpha.0.sha-SHA,
 }
 `);
     });
@@ -267,7 +268,7 @@ Object {
 
       expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-5": 5.0.1-alpha.0+SHA,
+  "package-5": 5.0.1-alpha.0.sha-SHA,
 }
 `);
     });
@@ -278,9 +279,9 @@ Object {
 
       expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-3": 3.0.1-alpha.1+SHA,
-  "package-4": 4.0.1-alpha.1+SHA,
-  "package-5": 5.0.1-alpha.1+SHA,
+  "package-3": 3.0.1-alpha.1.sha-SHA,
+  "package-4": 4.0.1-alpha.1.sha-SHA,
+  "package-5": 5.0.1-alpha.1.sha-SHA,
 }
 `);
     });
@@ -291,11 +292,11 @@ Object {
 
       expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-1": 1.0.1-alpha.2+SHA,
-  "package-2": 2.0.1-alpha.2+SHA,
-  "package-3": 3.0.1-alpha.2+SHA,
-  "package-4": 4.0.1-alpha.2+SHA,
-  "package-5": 5.0.1-alpha.2+SHA,
+  "package-1": 1.0.1-alpha.2.sha-SHA,
+  "package-2": 2.0.1-alpha.2.sha-SHA,
+  "package-3": 3.0.1-alpha.2.sha-SHA,
+  "package-4": 4.0.1-alpha.2.sha-SHA,
+  "package-5": 5.0.1-alpha.2.sha-SHA,
 }
 `);
     });
@@ -306,9 +307,9 @@ Object {
 
       expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-3": 3.0.1-alpha.3+SHA,
-  "package-4": 4.0.1-alpha.3+SHA,
-  "package-5": 5.0.1-alpha.3+SHA,
+  "package-3": 3.0.1-alpha.3.sha-SHA,
+  "package-4": 4.0.1-alpha.3.sha-SHA,
+  "package-5": 5.0.1-alpha.3.sha-SHA,
 }
 `);
     });
@@ -319,9 +320,41 @@ Object {
 
       expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-5": 5.0.1-alpha.4+SHA,
+  "package-5": 5.0.1-alpha.4.sha-SHA,
 }
 `);
+    });
+  });
+
+  describe("publish --canary dependency ranges", () => {
+    test("writes parseable caret ranges pointing at canary versions", async () => {
+      const cwd = await initTaggedFixture("normal");
+
+      await setupChanges(cwd, ["packages/package-1/all-your-base.js", "belong to us"]);
+      await lernaPublish(cwd)("--canary");
+
+      const canaryVersion = writePackage.updatedManifest("package-1").version;
+      const spec = writePackage.updatedManifest("package-2").dependencies["package-1"];
+
+      expect(spec).toMatch(/^\^\d+\.\d+\.\d+-alpha\.\d+\.sha-[0-9a-f]+$/);
+      expect(() => new semver.Range(spec)).not.toThrow();
+      expect(semver.satisfies(canaryVersion, spec, { includePrerelease: true })).toBe(true);
+    });
+
+    test("writes parseable exact ranges pointing at canary versions with --exact", async () => {
+      const cwd = await initTaggedFixture("normal");
+
+      await setupChanges(cwd, ["packages/package-1/all-your-base.js", "belong to us"]);
+      await lernaPublish(cwd)("--canary", "--exact");
+
+      const canaryVersion = writePackage.updatedManifest("package-1").version;
+      const spec = writePackage.updatedManifest("package-2").dependencies["package-1"];
+
+      expect(spec).toMatch(/^\d+\.\d+\.\d+-alpha\.\d+\.sha-[0-9a-f]+$/);
+      // an exact pin on a canary version must remain a valid comparator,
+      // otherwise sibling packages are published uninstallable
+      expect(() => new semver.Range(spec)).not.toThrow();
+      expect(semver.satisfies(canaryVersion, spec, { includePrerelease: true })).toBe(true);
     });
   });
 
@@ -346,10 +379,10 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
-  "package-4": 1.0.1-alpha.0+SHA,
+  "package-1": 1.0.1-alpha.0.sha-SHA,
+  "package-2": 1.0.1-alpha.0.sha-SHA,
+  "package-3": 1.0.1-alpha.0.sha-SHA,
+  "package-4": 1.0.1-alpha.0.sha-SHA,
 }
 `);
   });
@@ -370,8 +403,8 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
 Object {
-  "package-2": 2.0.1-alpha.0+SHA,
-  "package-3": 3.0.1-alpha.0+SHA,
+  "package-2": 2.0.1-alpha.0.sha-SHA,
+  "package-3": 3.0.1-alpha.0.sha-SHA,
 }
 `);
   });
@@ -419,10 +452,10 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
     Object {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 1.0.1-alpha.0+SHA,
-      "package-3": 1.0.1-alpha.0+SHA,
-      "package-4": 1.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.sha-SHA,
+      "package-2": 1.0.1-alpha.0.sha-SHA,
+      "package-3": 1.0.1-alpha.0.sha-SHA,
+      "package-4": 1.0.1-alpha.0.sha-SHA,
     }
   `);
   });
@@ -433,11 +466,11 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
     Object {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 2.0.1-alpha.0+SHA,
-      "package-3": 3.0.1-alpha.0+SHA,
-      "package-4": 4.0.1-alpha.0+SHA,
-      "package-6": 0.1.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.sha-SHA,
+      "package-2": 2.0.1-alpha.0.sha-SHA,
+      "package-3": 3.0.1-alpha.0.sha-SHA,
+      "package-4": 4.0.1-alpha.0.sha-SHA,
+      "package-6": 0.1.1-alpha.0.sha-SHA,
     }
   `);
   });
@@ -463,8 +496,8 @@ Object {
 
     expect(writePackage.updatedVersions()).toMatchInlineSnapshot(`
     Object {
-      "package-1": 1.0.1-alpha.0+SHA,
-      "package-2": 2.0.1-alpha.0+SHA,
+      "package-1": 1.0.1-alpha.0.sha-SHA,
+      "package-2": 2.0.1-alpha.0.sha-SHA,
     }
   `);
   });

--- a/libs/e2e-utils/src/lib/snapshot-serializer-utils.ts
+++ b/libs/e2e-utils/src/lib/snapshot-serializer-utils.ts
@@ -12,9 +12,13 @@ function containsE2ERootWithNoLeadingSlash(str: string): boolean {
 }
 
 export function normalizeCommitSHAs(str: string): string {
-  return str
-    .replaceAll(/\b[0-9a-f]{7,8}\b/g, "{SHORT_COMMIT_SHA}")
-    .replaceAll(/\b[0-9a-f]{40}\b/g, "{FULL_COMMIT_SHA}");
+  return (
+    str
+      // canary versions embed the short SHA in a "sha-"-prefixed prerelease identifier
+      .replaceAll(/\.sha-[0-9a-f]+\b/g, ".sha-{SHORT_COMMIT_SHA}")
+      .replaceAll(/\b[0-9a-f]{7,8}\b/g, "{SHORT_COMMIT_SHA}")
+      .replaceAll(/\b[0-9a-f]{40}\b/g, "{FULL_COMMIT_SHA}")
+  );
 }
 
 /**

--- a/libs/test-helpers/src/lib/serializers/serialize-git-sha.ts
+++ b/libs/test-helpers/src/lib/serializers/serialize-git-sha.ts
@@ -4,6 +4,8 @@ export const gitSHASerializer = {
   serialize: (str: string) => {
     return (
       str
+        // canary versions embed the short SHA in a "sha-"-prefixed prerelease identifier
+        .replace(/\.sha-[0-9a-f]+\b/g, ".sha-SHA")
         // short SHA tends to be in the path diff comparisons
         .replace(/\b[0-9a-f]{7,8}\b/g, "SHA")
         // full SHA corresponds to gitHead property in package.json files


### PR DESCRIPTION
Canary versions now embed the commit SHA as a prerelease identifier (1.1.0-alpha.0.sha-81e3b44) instead of build metadata (1.1.0-alpha.0+81e3b44).

Build metadata is stripped by the npm registry on publish, so the SHA has been invisible on npm for years, and the "+" makes canary versions publishable but not installable on JFrog Artifactory (#2060, #1878).

The "sha-" prefix is fused with the hash into a single prerelease identifier so it always parses as an alphanumeric (string) identifier in one semver precedence class. A dot-separated hash would be its own identifier: an all-digit short SHA with a leading zero is an invalid semver numeric identifier (#1118), and an all-digit SHA without a leading zero would sort in a numeric precedence class, flapping ordering semantics between publishes.

BREAKING CHANGE: `lerna publish --canary` now produces versions like `1.1.0-alpha.0.sha-81e3b44` instead of `1.1.0-alpha.0+81e3b44`.

Effective published versions change as follows:

- On registries that strip build metadata (npm): consumers previously received `1.1.0-alpha.N`; they now receive `1.1.0-alpha.N.sha-<hash>`.
- On registries that preserved build metadata (some private registries): `1.1.0-alpha.N+<hash>` becomes `1.1.0-alpha.N.sha-<hash>`.

Canary versions are now globally unique per commit and installable on registries such as JFrog Artifactory. Any CI tooling that predicts or parses canary version strings (regexes anchored on "+", scripts constructing expected versions, registry cleanup jobs) must be updated. The commit SHA also remains available as `gitHead` in the packument for anyone previously extracting it from the version string. There is no opt-out flag; see #2060, #1878, #1118 and #4124 for the full rationale.

Closes #4124