### PR TITLE
fix: missing peer dependency in lerna 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14867,9 +14867,9 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
-      "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
       "license": "MIT",
       "dependencies": {
         "@simple-libs/stream-utils": "^2.0.0",
@@ -32180,7 +32180,7 @@
         "conventional-changelog": "8.1.0",
         "conventional-changelog-angular": "9.2.1",
         "conventional-commits-filter": "6.0.1",
-        "conventional-commits-parser": "7.1.0",
+        "conventional-commits-parser": "7.1.2",
         "conventional-recommended-bump": "12.1.0",
         "cosmiconfig": "9.0.0",
         "dedent": "1.5.3",

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -50,7 +50,7 @@
     "conventional-changelog": "8.1.0",
     "conventional-changelog-angular": "9.2.1",
     "conventional-commits-filter": "6.0.1",
-    "conventional-commits-parser": "7.1.0",
+    "conventional-commits-parser": "7.1.2",
     "conventional-recommended-bump": "12.1.0",
     "cosmiconfig": "9.0.0",
     "dedent": "1.5.3",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The newly released lerna 10 has an unmet peer dependency version.

## Motivation and Context

```
❯ pnpm add lerna
 WARN  Issues with peer dependencies found
.
└─┬ lerna 10.0.0
  └─┬ conventional-changelog 8.1.0
    └─┬ @conventional-changelog/git-client 3.1.2
      └── ✕ unmet peer conventional-commits-parser@^7.1.2: found 7.1.0
```

## How Has This Been Tested?

- Ran unit and integration tests.
- Packed the local version and installed it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version alignment only; patch-level bump with no logic or API surface changes in Lerna itself.
> 
> **Overview**
> Resolves pnpm peer dependency warnings when installing Lerna 10: `@conventional-changelog/git-client` expects `conventional-commits-parser@^7.1.2`, but Lerna previously pinned **7.1.0**.
> 
> The PR updates the direct dependency in `packages/lerna/package.json` and the lockfile to **7.1.2**—a patch bump with no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa315ddfb3ffd37c90bdcbe241b4090d41359e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->