### PR TITLE
fix: skip unnecessary package managers during release

### DIFF
--- a/.github/actions/install-node-and-dependencies/action.yml
+++ b/.github/actions/install-node-and-dependencies/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "The command to run to install dependencies"
     required: false
     default: "npm ci"
+  install-additional-package-managers:
+    description: "Whether to install package managers used by the integration and e2e test suites"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -26,12 +30,13 @@ runs:
     # https://github.com/actions/cache/blob/940f3d7cf195ba83374c77632d1e2cbb2f24ae68/examples.md#node---npm
 
     - name: Install Corepack for the primary Node version
-      if: ${{ inputs.node-version == '' }}
+      if: ${{ inputs.node-version == '' && inputs.install-additional-package-managers == 'true' }}
       # Windows runners already provide Yarn shims that Corepack needs to replace.
       run: npm install --global corepack@0.35.0 --min-release-age=0 --ignore-scripts --force
       shell: bash
 
     - name: Enable corepack
+      if: ${{ inputs.install-additional-package-managers == 'true' }}
       run: corepack enable
       shell: bash
       env:
@@ -44,6 +49,7 @@ runs:
       shell: bash
 
     - name: Install pnpm v8
+      if: ${{ inputs.install-additional-package-managers == 'true' }}
       run: corepack install -g pnpm@8
       shell: bash
       env:
@@ -51,6 +57,7 @@ runs:
         COREPACK_ENABLE_STRICT: "0"
 
     - name: Use Yarn classic
+      if: ${{ inputs.install-additional-package-managers == 'true' }}
       run: yarn set version classic
       shell: bash
       env:
@@ -58,16 +65,22 @@ runs:
         COREPACK_ENABLE_STRICT: "0"
 
     - name: Install Bun
+      if: ${{ inputs.install-additional-package-managers == 'true' }}
       uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad # v2 (Node.js 24 runtime)
       with:
         # Latest 1.x so e2e exercises the text-based bun.lock format that has been bun's
         # default since 1.2 (the legacy binary bun.lockb handling is covered by unit tests)
         bun-version: "1.x"
 
-    - name: Print installed node, npm, yarn, pnpm and bun versions
+    - name: Print installed Node and npm versions
       run: |
         node --version
         npm --version
+      shell: bash
+
+    - name: Print installed yarn, pnpm and bun versions
+      if: ${{ inputs.install-additional-package-managers == 'true' }}
+      run: |
         yarn --version
         pnpm --version
         bun --version

--- a/.github/actions/install-node-and-dependencies/action.yml
+++ b/.github/actions/install-node-and-dependencies/action.yml
@@ -56,9 +56,9 @@ runs:
         COREPACK_ENABLE_AUTO_PIN: "0"
         COREPACK_ENABLE_STRICT: "0"
 
-    - name: Use Yarn classic
+    - name: Install Yarn classic
       if: ${{ inputs.install-additional-package-managers == 'true' }}
-      run: yarn set version classic
+      run: corepack install -g yarn@1.22.22
       shell: bash
       env:
         COREPACK_ENABLE_AUTO_PIN: "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Start Nx Cloud CI Run - Windows
-        run: npx nx-cloud start-ci-run --stop-agents-after="test"
+        run: npx nx-cloud start-ci-run --stop-agents-after="test,integration"
 
       - name: Install primary node version (see volta config in package.json) and dependencies
         uses: ./.github/actions/install-node-and-dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Install node and dependencies
         uses: ./.github/actions/install-node-and-dependencies
+        with:
+          install-additional-package-managers: "false"
 
       - name: Version and publish
         if: inputs.mode == 'release'


### PR DESCRIPTION
The release workflow now installs only Node, the pinned npm version, and project dependencies. This avoids the failing `yarn set version classic` step and skips unrelated Corepack, pnpm, and Bun setup, while preserving the full package-manager setup for CI jobs by default.

Validated with `npm ci` using Node 26.5.0 and npm 12.0.1, plus Prettier and YAML input assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release workflow and composite-action behavior only; release path is intentionally narrower with no auth or publish logic changes.
> 
> **Overview**
> Adds **`install-additional-package-managers`** (default `true`) to the shared install composite action so callers can skip Corepack, pnpm, Yarn, and Bun setup. The **release** workflow sets it to **`false`**, leaving only Node, pinned npm, and `npm ci`—avoiding the failing **`yarn set version classic`** step during publish.
> 
> When extra managers are enabled, Yarn is installed via **`corepack install -g yarn@1.22.22`** instead of **`yarn set version classic`**. Version-print steps are split so release runs only log Node/npm.
> 
> **Windows CI** extends Nx Cloud **`--stop-agents-after`** to **`test,integration`** so agents stop after integration work on that job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740728767095bdfb853ada6319cd058207e3d512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->