### PR TITLE
fix(core): keep modern writer template when preset ships a legacy writer guard

### DIFF
--- a/libs/core/src/lib/conventional-commits/__fixtures__/fixed/scripts/legacy-guard-preset.js
+++ b/libs/core/src/lib/conventional-commits/__fixtures__/fixed/scripts/legacy-guard-preset.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const parserOpts = require("./parser-opts");
+const whatBump = require("./what-bump");
+
+// Simulates a new v8+ preset that also ships the legacy writer guard, i.e. a
+// string mainTemplate which throws when rendered by a pre-v9 writer
+module.exports = function createPreset() {
+  return {
+    parser: parserOpts,
+    writer: {
+      mainTemplate: "{{[this preset requires conventional-changelog-writer@9 or newer] true}}",
+      template: (context) =>
+        [
+          `<a name="${context.version}"></a>`,
+          `## <small>${context.version} (${context.date})</small>`,
+          ...context.commitGroups.flatMap((group) => group.commits.map((commit) => `* ${commit.header}`)),
+          "",
+        ].join("\n"),
+      groupBy: `type`,
+    },
+    commits: { merges: false },
+    whatBump,
+  };
+};

--- a/libs/core/src/lib/conventional-commits/__fixtures__/fixed/scripts/legacy-guard-preset.js
+++ b/libs/core/src/lib/conventional-commits/__fixtures__/fixed/scripts/legacy-guard-preset.js
@@ -3,20 +3,25 @@
 const parserOpts = require("./parser-opts");
 const whatBump = require("./what-bump");
 
-// Simulates a new v8+ preset that also ships the legacy writer guard, i.e. a
-// string mainTemplate which throws when rendered by a pre-v9 writer
+// Simulates a new v8+ preset that also ships the legacy writer guard:
+// a string mainTemplate which only renders on a pre-v9 writer
 module.exports = function createPreset() {
   return {
     parser: parserOpts,
     writer: {
       mainTemplate: "{{[this preset requires conventional-changelog-writer@9 or newer] true}}",
-      template: (context) =>
-        [
-          `<a name="${context.version}"></a>`,
-          `## <small>${context.version} (${context.date})</small>`,
-          ...context.commitGroups.flatMap((group) => group.commits.map((commit) => `* ${commit.header}`)),
+      template: (context) => {
+        const commits = context.commitGroups.flatMap((group) => group.commits);
+
+        return [
+          context.headerPartial(context),
+          ...commits.map((commit) => context.commitPartial(context, commit)),
           "",
-        ].join("\n"),
+        ].join("\n");
+      },
+      headerPartial: (context) =>
+        `<a name="${context.version}"></a>\n## <small>${context.version} (${context.date})</small>`,
+      commitPartial: (context, commit) => `* ${commit.header}`,
       groupBy: `type`,
     },
     commits: { merges: false },

--- a/libs/core/src/lib/conventional-commits/get-changelog-config.ts
+++ b/libs/core/src/lib/conventional-commits/get-changelog-config.ts
@@ -21,14 +21,12 @@ function normalizeLegacyWriterOptions(writer: any): any {
     return writer;
   }
 
-  // modern presets ship a string mainTemplate that only exists to fail loudly on pre-v9 writers
-  if (typeof writer.template === "function") {
-    return writer;
-  }
-
   const normalized = { ...writer };
+  // Modern presets pair a function template with a string mainTemplate that only guards pre-v9 writers
   const legacyMainTemplate =
-    typeof writer.mainTemplate === "string" ? Handlebars.compile(writer.mainTemplate) : undefined;
+    typeof writer.mainTemplate === "string" && typeof writer.template !== "function"
+      ? Handlebars.compile(writer.mainTemplate)
+      : undefined;
   const legacyHeaderPartial =
     typeof writer.headerPartial === "string" ? Handlebars.compile(writer.headerPartial) : undefined;
   const legacyCommitPartial =

--- a/libs/core/src/lib/conventional-commits/get-changelog-config.ts
+++ b/libs/core/src/lib/conventional-commits/get-changelog-config.ts
@@ -21,6 +21,11 @@ function normalizeLegacyWriterOptions(writer: any): any {
     return writer;
   }
 
+  // modern presets ship a string mainTemplate that only exists to fail loudly on pre-v9 writers
+  if (typeof writer.template === "function") {
+    return writer;
+  }
+
   const normalized = { ...writer };
   const legacyMainTemplate =
     typeof writer.mainTemplate === "string" ? Handlebars.compile(writer.mainTemplate) : undefined;

--- a/libs/core/src/lib/conventional-commits/index.spec.ts
+++ b/libs/core/src/lib/conventional-commits/index.spec.ts
@@ -732,6 +732,33 @@ describe("conventional-commits", () => {
       `);
     });
 
+    it("keeps the writer template of a new v8+ preset that ships a legacy writer guard", async () => {
+      const cwd = await initFixture("fixed");
+
+      await gitTag(cwd, "v1.0.0");
+
+      const [pkg1] = await getPackages(cwd);
+
+      // make a change in package-1
+      await pkg1.set("changed", 1).serialize();
+      await gitAdd(cwd, pkg1.manifestLocation);
+      await gitCommit(cwd, "fix(pkg1): A commit using a preset with a legacy writer guard");
+
+      // update version
+      await pkg1.set("version", "1.0.1").serialize();
+
+      const leafChangelog = await updateChangelog(pkg1, "fixed", {
+        changelogPreset: "./scripts/legacy-guard-preset.js",
+      });
+
+      expect(leafChangelog.newEntry).toMatchInlineSnapshot(`
+        <a name="1.0.1"></a>
+        ## <small>1.0.1 (YYYY-MM-DD)</small>
+        * fix(pkg1): A commit using a preset with a legacy writer guard
+
+      `);
+    });
+
     it("updates independent changelogs", async () => {
       const cwd = await initFixture("independent");
 

--- a/libs/core/src/lib/conventional-commits/index.spec.ts
+++ b/libs/core/src/lib/conventional-commits/index.spec.ts
@@ -732,7 +732,7 @@ describe("conventional-commits", () => {
       `);
     });
 
-    it("keeps the writer template of a new v8+ preset that ships a legacy writer guard", async () => {
+    it("keeps the writer template of a new v8+ preset with a legacy guard", async () => {
       const cwd = await initFixture("fixed");
 
       await gitTag(cwd, "v1.0.0");


### PR DESCRIPTION
## Description

`normalizeLegacyWriterOptions` compiles any string `writer.mainTemplate` it finds and assigns the result to `writer.template`. Presets built on `@conventional-changelog/template` ship such a string on purpose: it is a guard that renders to a "you need conventional-changelog-writer@9 or newer" error, and it sits next to the real function-based `template`. Since the guard is only meant to be read by an old writer, normalizing it throws away the working template and makes the bundled v9 writer render the error instead.

The normalization now leaves the writer options alone when `writer.template` is already a function.

## Motivation and Context

`lerna version --conventional-commits` with `conventional-changelog-conventionalcommits@10.4.0` fails with:

```
Missing helper: "conventional-changelog-conventionalcommits requires conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer). Your changelog tooling loaded an older writer which cannot render this preset. Update the tooling or use an older major version of the preset."
```

Fixes #4414

## How Has This Been Tested?

Added a unit test with a fixture preset that carries both a guard `mainTemplate` and a modern `template`. It reproduces the error on `main` and passes here. Also ran `nx test core`, `nx test commands-version`, `nx test commands-publish`, lint and `format:check`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bug fix in preset normalization for conventional commits; behavior for legacy-only string templates is unchanged.
> 
> **Overview**
> Fixes changelog generation for modern conventional-changelog presets (e.g. `conventional-changelog-conventionalcommits@10.x`) that expose both a string `writer.mainTemplate` (legacy writer guard) and a function `writer.template`.
> 
> **`normalizeLegacyWriterOptions`** no longer compiles `mainTemplate` into `template` when `template` is already a function, so Lerna’s v9 writer keeps the real template instead of rendering the guard error message.
> 
> Adds a **`legacy-guard-preset`** fixture and an **`updateChangelog`** test that assert the changelog entry is produced from the function template, not the guard string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392bcfc3610039d14b4a7c70dc04cc5cde6c800c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->