### PR TITLE
feat(core): Add support for authenticating with a security key when publishing

### DIFF
--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -237,7 +237,7 @@ lerna publish --otp 123456
 
 > Please keep in mind that one-time passwords expire within 30 seconds of their generation. If it expires during publish operations, a prompt will request a refreshed value before continuing.
 
-If your npm account uses a security key or passkey for two-factor authentication (rather than an authenticator app), there is no code to type and `--otp` is not applicable. Instead, when the registry requests two-factor authentication, `lerna` will print a URL and open it in your browser so that you can complete the challenge with your security key. Once complete, publishing continues automatically. Set the npm `browser` config to `false` (e.g. `npm_config_browser=false`) to only print the URL without opening a browser.
+If your npm account uses a security key or passkey for two-factor authentication (rather than an authenticator app), there is no code to type and `--otp` is not applicable. Instead, when the registry requests two-factor authentication, `lerna` will print a URL and open it in your browser so that you can complete the challenge with your security key. Once complete, publishing continues automatically. Set the npm `browser` config to `false` (e.g. `npm_config_browser=false`) to only print the URL without opening a browser. As with the npm CLI, providing `--otp` explicitly (or setting the npm `auth-type` config to `legacy`) opts out of the browser-based flow.
 
 ### `--preid`
 

--- a/libs/commands/publish/README.md
+++ b/libs/commands/publish/README.md
@@ -237,6 +237,8 @@ lerna publish --otp 123456
 
 > Please keep in mind that one-time passwords expire within 30 seconds of their generation. If it expires during publish operations, a prompt will request a refreshed value before continuing.
 
+If your npm account uses a security key or passkey for two-factor authentication (rather than an authenticator app), there is no code to type and `--otp` is not applicable. Instead, when the registry requests two-factor authentication, `lerna` will print a URL and open it in your browser so that you can complete the challenge with your security key. Once complete, publishing continues automatically. Set the npm `browser` config to `false` (e.g. `npm_config_browser=false`) to only print the URL without opening a browser.
+
 ### `--preid`
 
 Unlike the `lerna version` option of the same name, this option only applies to [`--canary`](#--canary) version calculation.

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -226,6 +226,13 @@ export class PublishCommand extends Command {
 
     this.conf["set"]("user-agent", this.userAgent, "cli");
 
+    // npm-registry-fetch sends the camelCased `authType` as the `npm-auth-type` request header, which is how the
+    // registry learns whether the client can complete a browser-based ("web") two-factor challenge - required for
+    // accounts secured with a security key / passkey. Mirroring npm, an explicitly configured OTP forces the
+    // legacy (typed one-time password) flow, and so does any `auth-type` other than `web`.
+    const authType = !this.otpCache.otp && this.conf["get"]("auth-type") === "web" ? "web" : "legacy";
+    this.conf["set"]("authType", authType, "cli");
+
     if (this.conf["get"]("registry") === "https://registry.yarnpkg.com") {
       this.logger.warn("", "Yarn's registry proxy is broken, replacing with public npm registry");
       this.logger.warn("", "If you don't have an npm token, you should exit and run `npm login`");

--- a/libs/commands/publish/src/index.ts
+++ b/libs/commands/publish/src/index.ts
@@ -206,7 +206,10 @@ export class PublishCommand extends Command {
       this.logger.info("require-scripts", "enabled");
     }
 
-    // npmSession and user-agent are consumed by npm-registry-fetch (via libnpmpublish)
+    // npmSession, npmCommand and userAgent are consumed by npm-registry-fetch (via libnpmpublish) and sent as the
+    // `npm-session`, `npm-command` and `user-agent` request headers. Note that npm-registry-fetch only reads the
+    // camelCased option names. The registry requires `npm-command` (alongside `npm-auth-type: web`, see below) in
+    // order to respond to a two-factor requirement with a browser-based challenge.
     this.logger.verbose("session", this.npmSession);
     this.logger.verbose("user-agent", this.userAgent);
 
@@ -214,7 +217,9 @@ export class PublishCommand extends Command {
       lernaCommand: "publish",
       _auth: this.options.legacyAuth,
       npmSession: this.npmSession,
+      npmCommand: "publish",
       npmVersion: this.userAgent,
+      userAgent: this.userAgent,
       otp: this.options.otp,
       registry: this.options.registry,
       "ignore-prepublish": this.options.ignorePrepublish,

--- a/libs/commands/publish/src/lib/publish-command.spec.ts
+++ b/libs/commands/publish/src/lib/publish-command.spec.ts
@@ -318,9 +318,39 @@ Map {
       expect(npmPublish).toHaveBeenCalledWith(
         expect.objectContaining({ name: "package-1" }),
         "/TEMP_DIR/package-1-MOCKED.tgz",
-        expect.objectContaining({ "auth-type": "legacy", _auth: auth }),
+        expect.objectContaining({ authType: "web", _auth: auth }),
         expect.objectContaining({ root: expect.any(Object) }),
         expect.objectContaining({ otp: undefined })
+      );
+    });
+  });
+
+  describe("auth-type", () => {
+    it("advertises the web auth type by default so the registry can issue a browser-based 2FA challenge", async () => {
+      const testDir = await initFixture("normal");
+
+      await lernaPublish(testDir)();
+
+      expect(npmPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "package-1" }),
+        "/TEMP_DIR/package-1-MOCKED.tgz",
+        expect.objectContaining({ authType: "web" }),
+        expect.objectContaining({ root: expect.any(Object) }),
+        expect.objectContaining({ otp: undefined })
+      );
+    });
+
+    it("falls back to the legacy auth type when an OTP is provided explicitly", async () => {
+      const testDir = await initFixture("normal");
+
+      await lernaPublish(testDir)("--otp", "123456");
+
+      expect(npmPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "package-1" }),
+        "/TEMP_DIR/package-1-MOCKED.tgz",
+        expect.objectContaining({ authType: "legacy" }),
+        expect.objectContaining({ root: expect.any(Object) }),
+        expect.objectContaining({ otp: "123456" })
       );
     });
   });

--- a/libs/commands/publish/src/lib/publish-command.spec.ts
+++ b/libs/commands/publish/src/lib/publish-command.spec.ts
@@ -326,7 +326,7 @@ Map {
   });
 
   describe("auth-type", () => {
-    it("advertises the web auth type by default so the registry can issue a browser-based 2FA challenge", async () => {
+    it("advertises the web auth type and command by default so the registry can issue a browser-based 2FA challenge", async () => {
       const testDir = await initFixture("normal");
 
       await lernaPublish(testDir)();
@@ -334,7 +334,11 @@ Map {
       expect(npmPublish).toHaveBeenCalledWith(
         expect.objectContaining({ name: "package-1" }),
         "/TEMP_DIR/package-1-MOCKED.tgz",
-        expect.objectContaining({ authType: "web" }),
+        expect.objectContaining({
+          authType: "web",
+          npmCommand: "publish",
+          userAgent: expect.stringMatching(/^lerna\//),
+        }),
         expect.objectContaining({ root: expect.any(Object) }),
         expect.objectContaining({ otp: undefined })
       );

--- a/libs/core/src/lib/npm-conf/defaults.ts
+++ b/libs/core/src/lib/npm-conf/defaults.ts
@@ -58,7 +58,7 @@ export const defaults = {
   also: null,
   audit: true,
   "audit-level": "low",
-  "auth-type": "legacy",
+  "auth-type": "web",
   "bin-links": true,
   browser: null,
   ca: null,

--- a/libs/core/src/lib/npm-conf/types.ts
+++ b/libs/core/src/lib/npm-conf/types.ts
@@ -16,7 +16,7 @@ export const types: Record<string, unknown> = {
   also: [null, "dev", "development"],
   audit: Boolean,
   "audit-level": ["low", "moderate", "high", "critical"],
-  "auth-type": ["legacy", "sso", "saml", "oauth"],
+  "auth-type": ["legacy", "web", "sso", "saml", "oauth"],
   "bin-links": Boolean,
   browser: [null, String],
   ca: [null, String, Array],

--- a/libs/core/src/lib/otplease.spec.ts
+++ b/libs/core/src/lib/otplease.spec.ts
@@ -3,9 +3,14 @@
 // @ts-nocheck
 
 vi.mock("./prompt");
+vi.mock("./web-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./web-auth")>()),
+  getWebAuthOneTimePassword: vi.fn(),
+}));
 
 // mocked modules
 import { promptTextInput } from "./prompt";
+import { getWebAuthOneTimePassword } from "./web-auth";
 
 // file under test
 import { otplease, getOneTimePassword } from "./otplease";
@@ -25,6 +30,7 @@ describe("otplease", () => {
   afterEach(() => {
     process.stdin.isTTY = stdinIsTTY;
     process.stdout.isTTY = stdoutIsTTY;
+    getWebAuthOneTimePassword.mockReset();
   });
 
   it("no error", async () => {
@@ -187,6 +193,83 @@ describe("otplease", () => {
     await expect(otplease(fn)).rejects.toThrow(`non-interactive ${pipe}`);
   });
 
+  describe("web auth (security key / passkey)", () => {
+    const challenge = {
+      authUrl: "https://www.npmjs.com/auth/cli/abc123",
+      doneUrl: "https://registry.npmjs.org/-/v1/done?sessionId=abc123",
+    };
+
+    it("completes the web-auth challenge instead of prompting for a typed OTP", async () => {
+      getWebAuthOneTimePassword.mockResolvedValue("web-otp-token");
+
+      const obj = {};
+      const fn = vi.fn(makeWebAuthTestCallback("web-otp-token", obj, challenge));
+      const result = await otplease(fn, { registry: "https://registry.npmjs.org/" });
+
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(promptTextInput).not.toHaveBeenCalled();
+      expect(getWebAuthOneTimePassword).toHaveBeenCalledWith(
+        challenge,
+        expect.objectContaining({ registry: "https://registry.npmjs.org/" })
+      );
+      expect(fn).toHaveBeenLastCalledWith(expect.objectContaining({ otp: "web-otp-token" }));
+      expect(result).toBe(obj);
+    });
+
+    it("caches the web-auth token so it is reused by subsequent requests", async () => {
+      getWebAuthOneTimePassword.mockResolvedValue("web-otp-token");
+
+      const otpCache = { otp: undefined };
+      const obj = {};
+      const fn = vi.fn(makeWebAuthTestCallback("web-otp-token", obj, challenge));
+
+      await otplease(fn, {}, otpCache);
+      expect(otpCache.otp).toBe("web-otp-token");
+
+      const obj2 = {};
+      const fn2 = vi.fn(makeWebAuthTestCallback("web-otp-token", obj2, challenge));
+      const result = await otplease(fn2, {}, otpCache);
+
+      expect(fn2).toHaveBeenCalledTimes(1);
+      expect(getWebAuthOneTimePassword).toHaveBeenCalledTimes(1);
+      expect(result).toBe(obj2);
+    });
+
+    it("semaphore prevents overlapping web-auth challenges", async () => {
+      getWebAuthOneTimePassword.mockResolvedValue("web-otp-token");
+
+      const otpCache = { otp: undefined };
+      const obj1 = {};
+      const fn1 = vi.fn(makeWebAuthTestCallback("web-otp-token", obj1, challenge));
+      const obj2 = {};
+      const fn2 = vi.fn(makeWebAuthTestCallback("web-otp-token", obj2, challenge));
+
+      const [res1, res2] = await Promise.all([otplease(fn1, {}, otpCache), otplease(fn2, {}, otpCache)]);
+
+      expect(getWebAuthOneTimePassword).toHaveBeenCalledTimes(1);
+      expect(res1).toBe(obj1);
+      expect(res2).toBe(obj2);
+    });
+
+    it("rejects web-auth errors", async () => {
+      getWebAuthOneTimePassword.mockRejectedValue(new Error("browser exploded"));
+
+      const fn = vi.fn(makeWebAuthTestCallback("web-otp-token", {}, challenge));
+
+      await expect(otplease(fn, {})).rejects.toThrow("browser exploded");
+      expect(promptTextInput).not.toHaveBeenCalled();
+    });
+
+    it.each([["stdin"], ["stdout"]])("re-throws web-auth EOTP error when %s is not a TTY", async (pipe) => {
+      const fn = vi.fn(makeWebAuthTestCallback("web-otp-token", {}, challenge));
+
+      process[pipe].isTTY = false;
+
+      await expect(otplease(fn, {})).rejects.toThrow("OTP required for authentication");
+      expect(getWebAuthOneTimePassword).not.toHaveBeenCalled();
+    });
+  });
+
   describe("getOneTimePassword()", () => {
     it("defaults message argument", async () => {
       await getOneTimePassword();
@@ -204,6 +287,23 @@ describe("otplease", () => {
     });
   });
 });
+
+function makeWebAuthTestCallback(
+  otp: string,
+  result: unknown,
+  challenge: { authUrl: string; doneUrl: string }
+) {
+  return (opts: { otp: string }) => {
+    if (opts.otp !== otp) {
+      // mirrors npm-registry-fetch's HttpErrorAuthOTP when the registry requires a security key
+      const err = new Error("OTP required for authentication");
+      err.code = "EOTP";
+      err.body = { ...challenge };
+      throw err;
+    }
+    return result;
+  };
+}
 
 function makeTestCallback(otp: string, result: any) {
   return (opts: { otp: string }) => {

--- a/libs/core/src/lib/otplease.ts
+++ b/libs/core/src/lib/otplease.ts
@@ -1,4 +1,5 @@
 import { promptTextInput } from "./prompt";
+import { getWebAuthChallenge, getWebAuthOneTimePassword } from "./web-auth";
 
 export interface OneTimePasswordCache {
   otp: string | null;
@@ -35,7 +36,12 @@ const semaphore = {
 };
 
 /**
- * Attempt to execute Promise callback, prompting for OTP if necessary.
+ * Attempt to execute Promise callback, obtaining an OTP if necessary.
+ *
+ * Accounts secured with an authenticator app are prompted to type a one-time password.
+ * Accounts secured with a security key / passkey receive a web-auth challenge from the registry
+ * instead, which is completed in the browser (see `./web-auth`).
+ *
  * @template {Record<string, unknown>} T
  * @param {(opts: T) => Promise<unknown>} fn
  * @param {T} _opts The options to be passed to `fn`
@@ -76,7 +82,7 @@ function attempt<T extends Record<string, unknown>>(
           semaphore.release();
           return attempt(fn, { ...opts, ...otpCache }, otpCache);
         }
-        return getOneTimePassword()
+        return requestOneTimePassword(err, opts)
           .then(
             (otp) => {
               // update the otp and release the lock so that waiting
@@ -99,6 +105,20 @@ function attempt<T extends Record<string, unknown>>(
       });
     }
   });
+}
+
+/**
+ * Obtain a one-time password appropriate to the EOTP error received:
+ * complete the web-auth challenge when the registry sent one, otherwise prompt the user to type one.
+ */
+function requestOneTimePassword(err: unknown, opts: Record<string, unknown>): Promise<string> {
+  const challenge = getWebAuthChallenge(err);
+
+  if (challenge) {
+    return getWebAuthOneTimePassword(challenge, opts);
+  }
+
+  return getOneTimePassword();
 }
 
 /**

--- a/libs/core/src/lib/otplease.ts
+++ b/libs/core/src/lib/otplease.ts
@@ -1,3 +1,4 @@
+import log from "./npmlog";
 import { promptTextInput } from "./prompt";
 import { getWebAuthChallenge, getWebAuthOneTimePassword } from "./web-auth";
 
@@ -118,6 +119,7 @@ function requestOneTimePassword(err: unknown, opts: Record<string, unknown>): Pr
     return getWebAuthOneTimePassword(challenge, opts);
   }
 
+  log.silly("otplease", "registry did not offer a web-auth challenge, prompting for a one-time password");
   return getOneTimePassword();
 }
 

--- a/libs/core/src/lib/web-auth.spec.ts
+++ b/libs/core/src/lib/web-auth.spec.ts
@@ -1,15 +1,26 @@
 vi.mock("npm-registry-fetch");
-vi.mock("@lerna/child-process");
 
+import childProcess from "node:child_process";
+import { EventEmitter } from "node:events";
 // mocked modules
-import * as childProcess from "@lerna/child-process";
 import fetch from "npm-registry-fetch";
+import log from "./npmlog";
 
 // file under test
 import { getWebAuthChallenge, getWebAuthOneTimePassword } from "./web-auth";
 
 const mockedFetch = vi.mocked(fetch);
-const mockedExec = vi.mocked(childProcess.exec);
+
+type FakeChild = EventEmitter & { unref: ReturnType<typeof vi.fn> };
+let spawnSpy: ReturnType<typeof vi.spyOn>;
+let spawnedChildren: FakeChild[];
+
+function fakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.unref = vi.fn();
+  spawnedChildren.push(child);
+  return child;
+}
 
 function response(status: number, body?: unknown, headers: Record<string, string> = {}) {
   return {
@@ -21,10 +32,12 @@ function response(status: number, body?: unknown, headers: Record<string, string
 
 describe("web-auth", () => {
   beforeEach(() => {
-    mockedExec.mockResolvedValue(undefined as never);
+    spawnedChildren = [];
+    spawnSpy = vi.spyOn(childProcess, "spawn").mockImplementation(() => fakeChild() as never);
   });
 
   afterEach(() => {
+    spawnSpy.mockRestore();
     vi.resetAllMocks();
   });
 
@@ -101,7 +114,8 @@ describe("web-auth", () => {
       const result = await getWebAuthOneTimePassword(challenge, opts);
 
       expect(result).toBe("web-otp-token");
-      expect(mockedExec).toHaveBeenCalledTimes(1);
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(spawnedChildren[0].unref).toHaveBeenCalled();
       expect(mockedFetch).toHaveBeenCalledTimes(3);
       expect(mockedFetch).toHaveBeenCalledWith(
         challenge.doneUrl,
@@ -132,16 +146,16 @@ describe("web-auth", () => {
     });
 
     it.each([
-      ["darwin", "open", [challenge.authUrl], undefined],
-      ["linux", "xdg-open", [challenge.authUrl], undefined],
-      ["win32", "start", ['""', `"${challenge.authUrl}"`], { shell: true }],
-    ])("opens the auth url with the platform default on %s", async (os, command, args, execOpts) => {
+      ["darwin", "open", [challenge.authUrl], { stdio: "ignore" }],
+      ["linux", "xdg-open", [challenge.authUrl], { stdio: "ignore" }],
+      ["win32", "start", ['""', `"${challenge.authUrl}"`], { shell: true, stdio: "ignore" }],
+    ])("opens the auth url with the platform default on %s", async (os, command, args, spawnOpts) => {
       Object.defineProperty(process, "platform", { value: os });
       mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
 
       await getWebAuthOneTimePassword(challenge, opts);
 
-      expect(mockedExec).toHaveBeenCalledWith(command, args, ...(execOpts ? [execOpts] : []));
+      expect(spawnSpy).toHaveBeenCalledWith(command, args, expect.objectContaining(spawnOpts));
     });
 
     it("does not open a browser when the npm 'browser' config is false", async () => {
@@ -150,7 +164,7 @@ describe("web-auth", () => {
       await expect(getWebAuthOneTimePassword(challenge, { ...opts, browser: false })).resolves.toBe(
         "web-otp-token"
       );
-      expect(mockedExec).not.toHaveBeenCalled();
+      expect(spawnSpy).not.toHaveBeenCalled();
     });
 
     it("uses the npm 'browser' config as the opener command when it is a string", async () => {
@@ -158,14 +172,67 @@ describe("web-auth", () => {
 
       await getWebAuthOneTimePassword(challenge, { ...opts, browser: "firefox" });
 
-      expect(mockedExec).toHaveBeenCalledWith("firefox", [challenge.authUrl]);
+      expect(spawnSpy).toHaveBeenCalledWith(
+        "firefox",
+        [challenge.authUrl],
+        expect.objectContaining({ stdio: "ignore" })
+      );
     });
 
-    it("still resolves when the browser cannot be opened", async () => {
-      mockedExec.mockRejectedValue(Object.assign(new Error("spawn failed"), { exitCode: 127 }));
+    it("does not wait for the opener to exit", async () => {
+      mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      // the fake child never emits "exit"
+      await expect(getWebAuthOneTimePassword(challenge, opts)).resolves.toBe("web-otp-token");
+    });
+
+    it("still resolves when the opener cannot be spawned", async () => {
+      const verbose = vi.spyOn(log, "verbose").mockImplementation(() => undefined);
+      mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      const pending = getWebAuthOneTimePassword(challenge, opts);
+      spawnedChildren[0].emit("error", Object.assign(new Error("spawn xdg-open ENOENT"), { code: "ENOENT" }));
+
+      await expect(pending).resolves.toBe("web-otp-token");
+      expect(verbose).toHaveBeenCalledWith("web-auth", expect.stringContaining("spawn xdg-open ENOENT"));
+    });
+
+    it("still resolves when the opener exits with a non-zero status", async () => {
+      const verbose = vi.spyOn(log, "verbose").mockImplementation(() => undefined);
+      mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      const pending = getWebAuthOneTimePassword(challenge, opts);
+      spawnedChildren[0].emit("exit", 127, null);
+
+      await expect(pending).resolves.toBe("web-otp-token");
+      expect(verbose).toHaveBeenCalledWith("web-auth", expect.stringContaining("exited with code 127"));
+    });
+
+    it("still resolves when spawn throws synchronously", async () => {
+      spawnSpy.mockImplementation(() => {
+        throw new Error("EACCES");
+      });
       mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
 
       await expect(getWebAuthOneTimePassword(challenge, opts)).resolves.toBe("web-otp-token");
+    });
+
+    it("does not touch process.exitCode when a real opener is missing", async () => {
+      // use the real child_process so that the ENOENT path is exercised end-to-end
+      spawnSpy.mockRestore();
+      const verbose = vi.spyOn(log, "verbose").mockImplementation(() => undefined);
+      const exitCode = process.exitCode;
+      mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      await expect(
+        getWebAuthOneTimePassword(challenge, { ...opts, browser: "lerna-web-auth-nonexistent-opener-xyz" })
+      ).resolves.toBe("web-otp-token");
+
+      // the spawn error is emitted asynchronously
+      await vi.waitFor(() => {
+        expect(verbose).toHaveBeenCalledWith("web-auth", expect.stringContaining("ENOENT"));
+      });
+      expect(process.exitCode).toBe(exitCode);
     });
 
     it("rejects when a 200 response does not contain a token", async () => {

--- a/libs/core/src/lib/web-auth.spec.ts
+++ b/libs/core/src/lib/web-auth.spec.ts
@@ -1,0 +1,189 @@
+vi.mock("npm-registry-fetch");
+vi.mock("@lerna/child-process");
+
+// mocked modules
+import * as childProcess from "@lerna/child-process";
+import fetch from "npm-registry-fetch";
+
+// file under test
+import { getWebAuthChallenge, getWebAuthOneTimePassword } from "./web-auth";
+
+const mockedFetch = vi.mocked(fetch);
+const mockedExec = vi.mocked(childProcess.exec);
+
+function response(status: number, body?: unknown, headers: Record<string, string> = {}) {
+  return {
+    status,
+    headers: new Headers(headers),
+    json: () => Promise.resolve(body),
+  } as unknown as Awaited<ReturnType<typeof fetch>>;
+}
+
+describe("web-auth", () => {
+  beforeEach(() => {
+    mockedExec.mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("getWebAuthChallenge()", () => {
+    const authUrl = "https://www.npmjs.com/auth/cli/abc123";
+    const doneUrl = "https://registry.npmjs.org/-/v1/done?sessionId=abc123";
+
+    it("returns the challenge from an EOTP error body", () => {
+      const err = Object.assign(new Error("OTP required for authentication"), {
+        code: "EOTP",
+        body: { authUrl, doneUrl },
+      });
+
+      expect(getWebAuthChallenge(err)).toEqual({ authUrl, doneUrl });
+    });
+
+    it("returns undefined for classic EOTP errors without a challenge", () => {
+      expect(getWebAuthChallenge(Object.assign(new Error("otp"), { code: "EOTP" }))).toBeUndefined();
+      expect(
+        getWebAuthChallenge(Object.assign(new Error("otp"), { code: "EOTP", body: {} }))
+      ).toBeUndefined();
+      expect(
+        getWebAuthChallenge(Object.assign(new Error("otp"), { code: "EOTP", body: { authUrl } }))
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when the body is not an object", () => {
+      const err = Object.assign(new Error("otp"), {
+        code: "EOTP",
+        body: "this operation requires a one-time pass",
+      });
+
+      expect(getWebAuthChallenge(err)).toBeUndefined();
+    });
+
+    it("returns undefined for non-EOTP errors", () => {
+      const err = Object.assign(new Error("not found"), { code: "E404", body: { authUrl, doneUrl } });
+
+      expect(getWebAuthChallenge(err)).toBeUndefined();
+    });
+
+    it("returns undefined for non-http(s) urls", () => {
+      expect(
+        getWebAuthChallenge({ code: "EOTP", body: { authUrl: "javascript:alert(1)", doneUrl } })
+      ).toBeUndefined();
+      expect(getWebAuthChallenge({ code: "EOTP", body: { authUrl, doneUrl: "not a url" } })).toBeUndefined();
+    });
+
+    it("tolerates nullish input", () => {
+      expect(getWebAuthChallenge(undefined)).toBeUndefined();
+      expect(getWebAuthChallenge(null)).toBeUndefined();
+    });
+  });
+
+  describe("getWebAuthOneTimePassword()", () => {
+    const platform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: platform });
+    });
+
+    const challenge = {
+      authUrl: "https://www.npmjs.com/auth/cli/abc123",
+      doneUrl: "https://registry.npmjs.org/-/v1/done?sessionId=abc123",
+    };
+    const opts = { registry: "https://registry.npmjs.org/", "//registry.npmjs.org/:_authToken": "token" };
+
+    it("opens the auth url and polls the done url until a token is returned", async () => {
+      mockedFetch
+        .mockResolvedValueOnce(response(202, undefined, { "retry-after": "0.001" }))
+        .mockResolvedValueOnce(response(202, undefined, { "retry-after": "0.001" }))
+        .mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      const result = await getWebAuthOneTimePassword(challenge, opts);
+
+      expect(result).toBe("web-otp-token");
+      expect(mockedExec).toHaveBeenCalledTimes(1);
+      expect(mockedFetch).toHaveBeenCalledTimes(3);
+      expect(mockedFetch).toHaveBeenCalledWith(
+        challenge.doneUrl,
+        expect.objectContaining({ ...opts, method: "GET", cache: false })
+      );
+    });
+
+    it("waits for the retry-after header between polls", async () => {
+      vi.useFakeTimers();
+      try {
+        mockedFetch
+          .mockResolvedValueOnce(response(202, undefined, { "retry-after": "5" }))
+          .mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+        const pending = getWebAuthOneTimePassword(challenge, opts);
+
+        // first poll happens immediately, second must wait 5s
+        await vi.advanceTimersByTimeAsync(4999);
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(mockedFetch).toHaveBeenCalledTimes(2);
+
+        await expect(pending).resolves.toBe("web-otp-token");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it.each([
+      ["darwin", "open", [challenge.authUrl], undefined],
+      ["linux", "xdg-open", [challenge.authUrl], undefined],
+      ["win32", "start", ['""', `"${challenge.authUrl}"`], { shell: true }],
+    ])("opens the auth url with the platform default on %s", async (os, command, args, execOpts) => {
+      Object.defineProperty(process, "platform", { value: os });
+      mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      await getWebAuthOneTimePassword(challenge, opts);
+
+      expect(mockedExec).toHaveBeenCalledWith(command, args, ...(execOpts ? [execOpts] : []));
+    });
+
+    it("does not open a browser when the npm 'browser' config is false", async () => {
+      mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      await expect(getWebAuthOneTimePassword(challenge, { ...opts, browser: false })).resolves.toBe(
+        "web-otp-token"
+      );
+      expect(mockedExec).not.toHaveBeenCalled();
+    });
+
+    it("uses the npm 'browser' config as the opener command when it is a string", async () => {
+      mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      await getWebAuthOneTimePassword(challenge, { ...opts, browser: "firefox" });
+
+      expect(mockedExec).toHaveBeenCalledWith("firefox", [challenge.authUrl]);
+    });
+
+    it("still resolves when the browser cannot be opened", async () => {
+      mockedExec.mockRejectedValue(Object.assign(new Error("spawn failed"), { exitCode: 127 }));
+      mockedFetch.mockResolvedValueOnce(response(200, { token: "web-otp-token" }));
+
+      await expect(getWebAuthOneTimePassword(challenge, opts)).resolves.toBe("web-otp-token");
+    });
+
+    it("rejects when a 200 response does not contain a token", async () => {
+      mockedFetch.mockResolvedValueOnce(response(200, { nope: true }));
+
+      await expect(getWebAuthOneTimePassword(challenge, opts)).rejects.toThrow("expected a token");
+    });
+
+    it("rejects on an unexpected status", async () => {
+      mockedFetch.mockResolvedValueOnce(response(204));
+
+      await expect(getWebAuthOneTimePassword(challenge, opts)).rejects.toThrow("unexpected status 204");
+    });
+
+    it("propagates fetch errors", async () => {
+      mockedFetch.mockRejectedValueOnce(Object.assign(new Error("boom"), { code: "E500" }));
+
+      await expect(getWebAuthOneTimePassword(challenge, opts)).rejects.toThrow("boom");
+    });
+  });
+});

--- a/libs/core/src/lib/web-auth.ts
+++ b/libs/core/src/lib/web-auth.ts
@@ -11,7 +11,7 @@
  * - https://github.com/npm/npm-profile/blob/main/lib/index.js (webAuthOpener / webAuthCheckLogin)
  */
 
-import * as childProcess from "@lerna/child-process";
+import childProcess from "node:child_process";
 import fetch, { FetchOptions } from "npm-registry-fetch";
 import log from "./npmlog";
 
@@ -77,9 +77,7 @@ export async function getWebAuthOneTimePassword(
 
   // Opening the browser is best-effort: the URL has already been printed, so a missing or
   // failing opener (e.g. an SSH session) must not prevent the user from completing the challenge.
-  openInBrowser(authUrl, opts["browser"]).catch((err: Error) => {
-    log.verbose("web-auth", `Unable to open browser automatically: ${err?.message || err}`);
-  });
+  openInBrowser(authUrl, opts["browser"]);
 
   return pollForToken(doneUrl, opts);
 }
@@ -88,27 +86,53 @@ export async function getWebAuthOneTimePassword(
  * Open a URL with the user's default browser, honouring the npm `browser` config:
  * `false` disables opening entirely, a string is used as the opener command,
  * anything else uses the platform default (`open`, `start`, or `xdg-open`).
+ *
+ * This is deliberately fire-and-forget:
+ * - the child is unref'd so that an opener which stays in the foreground (as `xdg-open` may when it has to
+ *   launch the browser itself) cannot keep lerna alive after publishing has finished
+ * - failures are only logged, and never affect `process.exitCode`. `@lerna/child-process` is intentionally not
+ *   used here because it propagates a child's non-zero exit status onto `process.exitCode`, which would turn an
+ *   otherwise successful publish into a failed lerna run whenever no opener is available (SSH, containers, CI).
  */
-function openInBrowser(url: string, browser: unknown): Promise<unknown> {
+function openInBrowser(url: string, browser: unknown): void {
   if (browser === false) {
-    return Promise.resolve();
+    return;
   }
+
+  const onError = (err: unknown) => {
+    log.verbose("web-auth", `Unable to open browser automatically: ${(err as Error)?.message || err}`);
+  };
 
   // URLs are only ever passed through as a single argument, so escape anything that could be
   // interpreted by a shell (`"` etc) - the registry URL is expected to already be well-formed.
   const target = encodeURI(url);
 
-  if (typeof browser === "string") {
-    return childProcess.exec(browser, [target]);
-  }
+  try {
+    const child =
+      typeof browser === "string"
+        ? childProcess.spawn(browser, [target], { stdio: "ignore", windowsHide: true })
+        : process.platform === "win32"
+          ? // `start` is a cmd.exe builtin, so a shell is required. The empty quoted first argument is the
+            // window title, without which `start` would treat the URL as the title.
+            childProcess.spawn("start", ['""', `"${target}"`], {
+              shell: true,
+              stdio: "ignore",
+              windowsHide: true,
+            })
+          : childProcess.spawn(process.platform === "darwin" ? "open" : "xdg-open", [target], {
+              stdio: "ignore",
+            });
 
-  if (process.platform === "win32") {
-    // `start` is a cmd.exe builtin, so a shell is required. The empty quoted first argument is the
-    // window title, without which `start` would treat the URL as the title.
-    return childProcess.exec("start", ['""', `"${target}"`], { shell: true });
+    child.on("error", onError);
+    child.on("exit", (code) => {
+      if (code) {
+        onError(new Error(`opener exited with code ${code}`));
+      }
+    });
+    child.unref();
+  } catch (err) {
+    onError(err);
   }
-
-  return childProcess.exec(process.platform === "darwin" ? "open" : "xdg-open", [target]);
 }
 
 async function pollForToken(doneUrl: string, opts: Record<string, unknown>): Promise<string> {

--- a/libs/core/src/lib/web-auth.ts
+++ b/libs/core/src/lib/web-auth.ts
@@ -1,0 +1,141 @@
+/**
+ * Web-based two-factor authentication ("web OTP") for registry requests.
+ *
+ * When an npm account uses a security key / passkey (WebAuthn) instead of an authenticator app,
+ * the registry cannot be satisfied with a typed one-time password. Instead, the EOTP error it
+ * returns carries an `authUrl` (to be opened in a browser, where the user completes the challenge)
+ * and a `doneUrl` (to be polled until it yields a token that can be sent as the `otp` on a retry).
+ *
+ * Adapted from:
+ * - https://github.com/npm/cli/blob/latest/lib/utils/auth.js (otplease)
+ * - https://github.com/npm/npm-profile/blob/main/lib/index.js (webAuthOpener / webAuthCheckLogin)
+ */
+
+import * as childProcess from "@lerna/child-process";
+import fetch, { FetchOptions } from "npm-registry-fetch";
+import log from "./npmlog";
+
+export interface WebAuthChallenge {
+  authUrl: string;
+  doneUrl: string;
+}
+
+/**
+ * Delay between polls of the `doneUrl` when the registry does not send a `retry-after` header.
+ */
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
+/**
+ * If the given error is an EOTP error whose body carries a web-auth challenge
+ * (as produced by npm-registry-fetch when the registry requires a security key),
+ * return that challenge. Otherwise return `undefined`.
+ */
+export function getWebAuthChallenge(err: unknown): WebAuthChallenge | undefined {
+  const { code, body } = (err ?? {}) as { code?: unknown; body?: unknown };
+
+  if (code !== "EOTP" || body == null || typeof body !== "object") {
+    return undefined;
+  }
+
+  const { authUrl, doneUrl } = body as { authUrl?: unknown; doneUrl?: unknown };
+
+  if (!isHttpUrl(authUrl) || !isHttpUrl(doneUrl)) {
+    return undefined;
+  }
+
+  return { authUrl, doneUrl };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isHttpUrl(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  try {
+    return /^https?:$/.test(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Complete a web-auth challenge: direct the user to `authUrl`, then poll `doneUrl`
+ * until the registry hands back a token. The token is used as the `otp` on the retried request.
+ *
+ * @param challenge The `authUrl` / `doneUrl` pair from the EOTP error body
+ * @param opts The registry fetch options of the request that failed (registry, auth, etc)
+ */
+export async function getWebAuthOneTimePassword(
+  { authUrl, doneUrl }: WebAuthChallenge,
+  opts: Record<string, unknown>
+): Promise<string> {
+  log.notice("", "This operation requires two-factor authentication. Authenticate your account at:");
+  log.notice("", authUrl);
+
+  // Opening the browser is best-effort: the URL has already been printed, so a missing or
+  // failing opener (e.g. an SSH session) must not prevent the user from completing the challenge.
+  openInBrowser(authUrl, opts["browser"]).catch((err: Error) => {
+    log.verbose("web-auth", `Unable to open browser automatically: ${err?.message || err}`);
+  });
+
+  return pollForToken(doneUrl, opts);
+}
+
+/**
+ * Open a URL with the user's default browser, honouring the npm `browser` config:
+ * `false` disables opening entirely, a string is used as the opener command,
+ * anything else uses the platform default (`open`, `start`, or `xdg-open`).
+ */
+function openInBrowser(url: string, browser: unknown): Promise<unknown> {
+  if (browser === false) {
+    return Promise.resolve();
+  }
+
+  // URLs are only ever passed through as a single argument, so escape anything that could be
+  // interpreted by a shell (`"` etc) - the registry URL is expected to already be well-formed.
+  const target = encodeURI(url);
+
+  if (typeof browser === "string") {
+    return childProcess.exec(browser, [target]);
+  }
+
+  if (process.platform === "win32") {
+    // `start` is a cmd.exe builtin, so a shell is required. The empty quoted first argument is the
+    // window title, without which `start` would treat the URL as the title.
+    return childProcess.exec("start", ['""', `"${target}"`], { shell: true });
+  }
+
+  return childProcess.exec(process.platform === "darwin" ? "open" : "xdg-open", [target]);
+}
+
+async function pollForToken(doneUrl: string, opts: Record<string, unknown>): Promise<string> {
+  while (true) {
+    // the done endpoint must never be served from the local http cache
+    const res = await fetch(doneUrl, { ...opts, method: "GET", cache: false } as unknown as FetchOptions);
+
+    if (res.status === 200) {
+      const content = (await res.json()) as { token?: unknown };
+
+      if (typeof content?.token !== "string" || !content.token) {
+        throw new Error(`Invalid response from ${doneUrl}: expected a token`);
+      }
+
+      return content.token;
+    }
+
+    if (res.status === 202) {
+      const retryAfter = Number(res.headers.get("retry-after"));
+      const delay =
+        Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : DEFAULT_RETRY_DELAY_MS;
+
+      log.silly("web-auth", `authentication pending, retrying in ${delay}ms`);
+      await sleep(delay);
+      continue;
+    }
+
+    throw new Error(`Invalid response from ${doneUrl}: unexpected status ${res.status}`);
+  }
+}


### PR DESCRIPTION
Hi! I ran into #3273 today, and this is a fix for it.

For full disclosure, Claude wrote most of the code in this PR, but I (a human) have personally read it, am happy with it, and have manually tested it. I'm happy to stand behind this change.

The change is based on what npm's CLI does, but adapted (I think) for Lerna's style. Please let me know if there's anything that needs changing, or if I've missed anything.

I have manually tested it against the repository that I couldn't publish on the current version of lerna, and it correctly spawns the browser, and after authenticating with a security key press, it then publishes successfully.

One note - this PR changes the auth that lerna requests from `legacy` to `web`. I was not able to test whether the old style of auth still works correctly, although I believe it should.

I also wasn't able to run the e2e tests on main before I made changes (and, uh, they still didn't run after, I did check). Hopefully these run in CI.

PR template below. With the exception of the first two paragraphs of the description I (a human) wrote it. For the two paragraphs in the description that Claude suggested, I copyedited so that they read better.


----


## Description

When an npm account uses a security key / passkey for 2FA rather than an authenticator app, the registry responds to publish (and dist-tag) requests with an EOTP error carrying `authUrl` and `doneUrl` instead of expecting a typed one-time password. Lerna's `otplease` helper treated every EOTP error as the classic flow and prompted "This operation requires a one-time password:", which users with security keys have no way to satisfy.

To fix this, I borrowed the behaviour from npm CLI: when the EOTP body carries a web-auth challenge, print and open `authUrl` in the browser (if configured), then poll `doneUrl` until the registry returns a token, and retry the request with that token as the `otp`. The existing OTP cache and semaphore ensure the challenge is completed once and the token reused for the remaining packages.

This also required changing the `authType` to `'web'`, which is the current default in npm. I've followed the behaviour of npm's cli as much as possible.

## Motivation and Context

Users with security keys and no authenticator set in their npm account are currently unable to publish with Lerna. It's possible to use an access token as a workaround. This was reported a couple of years ago in #3273, and now that npm is tightening up their requirements, this is going to become more of a problem.

## How Has This Been Tested?

Automated tests are provided, and I've manually tested it to successfully publish a repository I was previously unable to publish. I was unable to test the OTP flow manually (as you can't set an authenticator on your npm account once you've set up a security key), but I believe it should work.

I couldn't get the e2e tests to run on main with no changes, so I wasn't able to run them after the changes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (change that has absolutely no effect on users)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed

^ With the exception of e2e, which I couldn't get to pass even on main



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default registry auth negotiation from legacy to web and extend shared OTP handling used on publish and dist-tag; explicit `--otp` and legacy auth-type still opt out, but untested edge cases around classic 2FA are possible.
> 
> **Overview**
> Adds **browser-based two-factor authentication** for npm accounts that use a security key or passkey, fixing publishes that previously stalled on a typed OTP prompt.
> 
> When the registry returns an `EOTP` error with `authUrl` and `doneUrl`, **`otplease`** now completes that web challenge (print URL, optionally open a browser, poll `doneUrl` for a token) instead of always prompting for a numeric OTP. Tokens are **cached and deduplicated** with the existing OTP semaphore, so multi-package publishes still authenticate once. The same path applies to **publish and dist-tag** registry calls that use `otplease`.
> 
> **`lerna publish`** advertises **`npm-auth-type: web`** and **`npm-command: publish`** by default (matching current npm), and falls back to **legacy** when `--otp` is set or `auth-type` is not `web`. npm-conf defaults and allowed **`auth-type`** values now include **`web`**.
> 
> Publish docs under **`--otp`** explain the security-key flow and **`browser`** / legacy opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3dc73c7a55496f21cd5538947623ac17e2a9af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->